### PR TITLE
BASW-65: Add In Arrears Events to Membership Status Rules

### DIFF
--- a/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
+++ b/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
@@ -35,9 +35,6 @@ class CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus {
    */
   private static $contributionStatusValueMap = [];
 
-  /**
-   * CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus constructor.
-   */
   public function __construct() {
     if (count(self::$memberShipStatuses) == 0) {
       $membershipStatuses = civicrm_api3('MembershipStatus', 'get', [

--- a/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
+++ b/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
@@ -1,0 +1,336 @@
+<?php
+
+/**
+ * Calculates membership status taking into account in_arrears and not_arrears
+ * start and end events.
+ */
+class CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus {
+
+  private $membership;
+  private $calculationArguments;
+  private static $memberShipStatuses = array();
+  private static $contributionStatusValueMap = array();
+
+  public function __construct() {
+    if (count(self::$memberShipStatuses) == 0) {
+      $membershipStatuses = civicrm_api3('MembershipStatus', 'get', [
+        'sequential' => 1,
+        'options' => ['sort' => 'weight ASC', 'limit' => 0],
+      ]);
+      self::$memberShipStatuses = $membershipStatuses['values'];
+    }
+
+    if (count(self::$contributionStatusValueMap) == 0) {
+      $contributionStatuses = civicrm_api3('OptionValue', 'get', array(
+        'option_group_id' => "contribution_status",
+      ));
+
+      foreach ($contributionStatuses['values'] as $currentStatus) {
+        self::$contributionStatusValueMap[$currentStatus['name']] = $currentStatus['value'];
+      }
+    }
+  }
+
+  /**
+   * This hook is called when membership status is being calculated.
+   *
+   * @param array $calculatedStatus
+   *   Membership status details as determined by CiviCRM core
+   * @param array $arguments
+   *   Arguments passed in to calculate date
+   * @param array $membership
+   *   Membership details from the calling function
+   */
+  public function alterMembershipStatus(&$calculatedStatus, $arguments, $membership) {
+    $this->membership = $membership;
+    $this->calculationArguments = $arguments;
+
+    foreach (self::$memberShipStatuses as $currentStatus) {
+      $startEventIsArrearsRelated = stripos($currentStatus['start_event'], 'arrears') !== false;
+      $endEventIsArrearsRelated = stripos($currentStatus['end_event'], 'arrears') !== false;
+
+      if (!$startEventIsArrearsRelated && !$endEventIsArrearsRelated) {
+        // If we reach calculated status, we don't need to consider other options by weight.
+        if ($calculatedStatus['id'] == $currentStatus['id']) {
+          break;
+        }
+
+        // No arrears, so we continue with next status.
+        continue;
+      }
+
+      $startEvent = $this->checkEvent(
+        CRM_Utils_Array::value('start_event', $currentStatus),
+        $arguments['status_date'],
+        CRM_Utils_Array::value('start_event_adjust_unit', $currentStatus),
+        CRM_Utils_Array::value('start_event_adjust_interval', $currentStatus)
+      );
+
+      $endEvent = $this->checkEvent(
+        CRM_Utils_Array::value('end_event', $currentStatus),
+        $arguments['status_date'],
+        CRM_Utils_Array::value('start_event_adjust_unit', $currentStatus),
+        CRM_Utils_Array::value('start_event_adjust_interval', $currentStatus)
+      );
+
+      if ($startEvent && !$endEvent) {
+        $calculatedStatus['id'] = $currentStatus['id'];
+        $calculatedStatus['name'] = $currentStatus['name'];
+        break;
+      }
+    }
+  }
+
+  /**
+   * Checks if the given event has presented itself on the given membership.
+   *
+   * @param $event
+   *   Event to be checked
+   * @param string $referenceDate
+   *   Date to use as reference to check start date
+   * @param string $adjustUnit
+   *   Unit of time interval to be added to start date
+   * @param int $adjustInterval
+   *   Amount of time to be added to start date
+   *
+   * @return boolean
+   *   True if the event has occurred, false otherwise
+   */
+  private function checkEvent($event, $referenceDate, $adjustUnit, $adjustInterval) {
+    switch($event) {
+      case 'start_date':
+        $result = $this->checkStartDateEvent($referenceDate, $adjustUnit, $adjustInterval);
+        break;
+
+      case 'end_date':
+        $result = $this->checkEndDateEvent($referenceDate, $adjustUnit, $adjustInterval);
+        break;
+
+      case 'join_date':
+        $result = $this->checkJoinDateEvent($referenceDate, $adjustUnit, $adjustInterval);
+        break;
+
+      case 'in_arrears':
+        $result = $this->checkInArrearsEvent($referenceDate, $adjustUnit, $adjustInterval);
+        break;
+
+      case 'not_arrears':
+        $result = $this->checkNotInArrearsEvent($referenceDate, $adjustUnit, $adjustInterval);
+        break;
+
+      default:
+        $result = FALSE;
+    }
+
+    return $result;
+  }
+
+  /**
+   * Checks if the membership has started, taking into account given time
+   * interval.
+   *
+   * @param string $referenceDateString
+   *   Date to use as reference to check start date
+   * @param string $adjustUnit
+   *   Unit of time interval to be added to start date
+   * @param int $adjustInterval
+   *   Amount of time to be added to start date
+   *
+   * @return boolean
+   *   True if membership start date + interval is less than reference date,
+   *   false otherwise
+   */
+  private function checkStartDateEvent($referenceDateString, $adjustUnit, $adjustInterval) {
+    return $this->hasAdjustedDatePassed(
+      $this->calculationArguments['start_date'],
+      $referenceDateString,
+      $adjustUnit,
+      $adjustInterval
+    );
+  }
+
+  /**
+   * Checks if the membership has ended, taking into account given time
+   * interval.
+   *
+   * @param string $referenceDateString
+   *   Date to use as reference to check end date
+   * @param string $adjustUnit
+   *   Unit of time interval to be added to end date
+   * @param int $adjustInterval
+   *   Amount of time to be added to end date
+   *
+   * @return boolean
+   *   True if membership end date + interval is less than reference date,
+   *   false otherwise
+   */
+  private function checkEndDateEvent($referenceDateString, $adjustUnit, $adjustInterval) {
+    return $this->hasAdjustedDatePassed(
+      $this->calculationArguments['end_date'],
+      $referenceDateString,
+      $adjustUnit,
+      $adjustInterval
+    );
+  }
+
+  /**
+   * Checks if the join date has passed, taking into account given time
+   * interval.
+   *
+   * @param string $referenceDateString
+   *   Date to use as reference to check end date
+   * @param string $adjustUnit
+   *   Unit of time interval to be added to end date
+   * @param int $adjustInterval
+   *   Amount of time to be added to end date
+   *
+   * @return boolean
+   *   True if membership join date + interval is less than reference date,
+   *   false otherwise
+   */
+  private function checkJoinDateEvent($referenceDateString, $adjustUnit, $adjustInterval) {
+    return $this->hasAdjustedDatePassed(
+      $this->calculationArguments['join_date'],
+      $referenceDateString,
+      $adjustUnit,
+      $adjustInterval
+    );
+  }
+
+  /**
+   * Checks if the given date has passed, taking into account given time
+   * interval, comparing it to the reference date.
+   *
+   * @param string $evaluatedDateString
+   *   Date to be evaluated
+   * @param string $referenceDateString
+   *   Date to use as reference to check date to be evaluated
+   * @param string $adjustUnit
+   *   Unit of time interval to be added to evaluated date
+   * @param int $adjustInterval
+   *   Amount of time to be added to evaluated date
+   *
+   * @return boolean
+   *   True if evaluated date + interval is less than reference date, false
+   *   otherwise
+   */
+  private function hasAdjustedDatePassed($evaluatedDateString, $referenceDateString, $adjustUnit, $adjustInterval) {
+    $referenceDate = new DateTime($referenceDateString);
+    $evaluatedDate = new DateTime($evaluatedDateString);
+
+    if ($adjustInterval && $adjustUnit) {
+      $intervalAbsoluteValue = abs($adjustInterval);
+
+      switch ($adjustUnit) {
+        case 'month':
+          $interval = "P{$intervalAbsoluteValue}M";
+          break;
+        case 'day':
+          $interval = "P{$intervalAbsoluteValue}D";
+          break;
+        case 'year':
+          $interval = "P{$intervalAbsoluteValue}Y";
+          break;
+      }
+
+      if ($adjustInterval >= 0) {
+        $referenceDate->add(new DateInterval($interval));
+      } else {
+        $referenceDate->sub(new DateInterval($interval));
+      }
+    }
+
+    if ($evaluatedDate >= $referenceDate) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Checks if membership is in arrears, by checking if any pending payments
+   * associated to a payment plan land before the adjusted reference date.
+   *
+   * @param string $referenceDateString
+   *   Date to use as reference to check if membership is in arrears
+   * @param string $adjustUnit
+   *   Unit of time interval to be added to evaluated date
+   * @param int $adjustInterval
+   *   Amount of time to be added to evaluated date
+   *
+   * @return boolean
+   *   True if membership is in arrears, false otherwise
+   */
+  private function checkInArrearsEvent($referenceDateString, $adjustUnit, $adjustInterval) {
+    $referenceDate = new DateTime($referenceDateString);
+
+    if ($adjustInterval && $adjustUnit) {
+      $intervalAbsoluteValue = abs($adjustInterval);
+
+      switch ($adjustUnit) {
+        case 'month':
+          $interval = "P{$intervalAbsoluteValue}M";
+          break;
+        case 'day':
+          $interval = "P{$intervalAbsoluteValue}D";
+          break;
+        case 'year':
+          $interval = "P{$intervalAbsoluteValue}Y";
+          break;
+      }
+
+      /**
+       * Since we're applying interval delta to reference date instead of
+       * evaluated date, we need to reverse sign of interval, ie. subtract
+       * if > 0, add if < 0.
+       */
+      if ($adjustInterval >= 0) {
+        $referenceDate->sub(new DateInterval($interval));
+      } else {
+        $referenceDate->add(new DateInterval($interval));
+      }
+    }
+
+    $adjustedReferenceDate = $referenceDate->format('Y-m-d H:i:s');
+    $query = "
+      SELECT COUNT(civicrm_contribution.id) AS total
+      FROM civicrm_membership_payment
+      INNER JOIN civicrm_contribution ON civicrm_membership_payment.contribution_id = civicrm_contribution.id
+      INNER JOIN civicrm_contribution_recur ON civicrm_contribution.contribution_recur_id = civicrm_contribution_recur.id
+      WHERE civicrm_membership_payment.membership_id = %1
+      AND civicrm_contribution.contribution_status_id = %2
+      AND civicrm_contribution.receive_date <= %3
+      AND civicrm_contribution_recur.installments > 0
+    ";
+    $pendingContributionsResult = CRM_Core_DAO::executeQuery($query, array(
+      1 => array($this->membership['id'], 'Integer'),
+      2 => array(self::$contributionStatusValueMap['Pending'], 'String'),
+      3 => array($adjustedReferenceDate, 'String'),
+    ));
+    $pendingContributionsResult->fetch();
+
+    if ($pendingContributionsResult->total > 0) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Checks if membership is NOT in arrears.
+   *
+   * @param string $referenceDateString
+   *   Date to use as reference to check if membership is in arrears
+   * @param string $adjustUnit
+   *   Unit of time interval to be added to evaluated date
+   * @param int $adjustInterval
+   *   Amount of time to be added to evaluated date
+   *
+   * @return boolean
+   *   True if membership is not in arrears, false otherwise
+   */
+  private function checkNotInArrearsEvent($referenceDateString, $adjustUnit, $adjustInterval) {
+    return !$this->checkInArrearsEvent($referenceDateString, $adjustUnit, $adjustInterval);
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipStatus.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipStatus.php
@@ -10,13 +10,13 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipStatus {
    * @var array
    *   Events that can be used to evaluate the start of a membership status
    */
-  private $startEvents = array();
+  private $startEvents = [];
 
   /**
    * @var array
    *   Events that can be used to evaluate the end of a membership status
    */
-  private $endEvents = array();
+  private $endEvents = [];
 
   /**
    * Initializes available start and end events.
@@ -24,14 +24,14 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipStatus {
   public function __construct() {
     $this->startEvents = array_merge(
       CRM_Core_SelectValues::eventDate(),
-      array(
+      [
         'in_arrears' => ts('Membership is in arrears (Payment Plan)'),
         'not_arrears' => ts('Membership is no longer in arrears (Payment Plan)'),
-      )
+      ]
     );
 
     $this->endEvents = array_merge(
-      array('' => ts('- select -')),
+      ['' => ts('- select -')],
       $this->startEvents
     );
   }

--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipStatus.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipStatus.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Alters MembershipStatus Form by adding in_arrears and not_arrears events as
+ * options.
+ */
+class CRM_MembershipExtras_Hook_BuildForm_MembershipStatus {
+
+  /**
+   * @var array
+   *   Events that can be used to evaluate the start of a membership status
+   */
+  private $startEvents = array();
+
+  /**
+   * @var array
+   *   Events that can be used to evaluate the end of a membership status
+   */
+  private $endEvents = array();
+
+  /**
+   * Initializes available start and end events.
+   */
+  public function __construct() {
+    $this->startEvents = array_merge(
+      CRM_Core_SelectValues::eventDate(),
+      array(
+        'in_arrears' => ts('Membership is in arrears (Payment Plan)'),
+        'not_arrears' => ts('Membership is no longer in arrears (Payment Plan)'),
+      )
+    );
+
+    $this->endEvents = array_merge(
+      array('' => ts('- select -')),
+      $this->startEvents
+    );
+  }
+
+  /**
+   * Alters given form by adding in_arrears and not_arrears events as options
+   * for start_event and end_event fields.
+   *
+   * @param \CRM_Member_Form_MembershipStatus $form
+   */
+  public function buildForm(CRM_Member_Form_MembershipStatus &$form) {
+    $form->removeAttribute('start_event');
+    $form->removeAttribute('end_event');
+    $form->add('select', 'start_event', ts('Start Event'), $this->startEvents, TRUE);
+    $form->add('select', 'end_event', ts('End Event'), $this->endEvents);
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -159,8 +159,13 @@ function membershipextras_civicrm_buildForm($formName, &$form) {
   }
 
   if ($formName === 'CRM_Member_Form_MembershipRenewal') {
-    $membershipHook = new CRM_MembershipExtras_Hook_BuildForm_MembershipRenewal($form);
-    $membershipHook->buildForm();
+    $membershipRenewal = new CRM_MembershipExtras_Hook_BuildForm_MembershipRenewal($form);
+    $membershipRenewal->buildForm();
+  }
+
+  if ($formName === 'CRM_Member_Form_MembershipStatus') {
+    $membershipStatusHook = new CRM_MembershipExtras_Hook_BuildForm_MembershipStatus();
+    $membershipStatusHook->buildForm($form);
   }
 }
 
@@ -177,4 +182,12 @@ function membershipextras_civicrm_postProcess($formName, &$form) {
     $membershipHook = new CRM_MembershipExtras_Hook_PostProcess_MembershipRenewal($form);
     $membershipHook->postProcess();
   }
+}
+
+/**
+ * Implements hook_civicrm_alterCalculatedMembershipStatus()
+ */
+function membershipextras_civicrm_alterCalculatedMembershipStatus(&$calculatedStatus, $arguments, $membership) {
+  $alterMembershipStatusHook = new CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus();
+  $alterMembershipStatusHook->alterMembershipStatus($calculatedStatus, $arguments, $membership);
 }


### PR DESCRIPTION
## Overview
To manage membership status for those payed with a payment plan in several instalments, we need two events that will allow to check for when programmed payments are overdue:

- In arrears: triggered when a membership is paid by recurring contribution with instalments and at least one pending instalment contribution's receive date falls to the past.
- Not in arrears: no pending instalment contribution in the past.

## Before
There was no way to manage the status of a membership payed with instalments in regard to the status of those payments.

## After
The two new events (In Arrears, Not In Arrears) were added as options to membership status form edit view, on **Start Event** and **End Event** fields.

Hook alterCalculatedMembershipStatus was implemented to go through the list of status rules sorted by weight, check if any of them use arrears related events as start or end, and validating for those that do if start and end conditions are met to set the status.
