### PR TITLE
BASW-65: Fix Bug On Membership Creation

### DIFF
--- a/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
+++ b/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
@@ -66,15 +66,19 @@ class CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus {
    *   Membership details from the calling function
    */
   public function alterMembershipStatus(&$calculatedStatus, $arguments, $membership) {
+    // If membership hasn't been created, do not alter status.
+    if (!CRM_Utils_Array::value('id', $this->membership, false)) {
+      return;
+    }
+
+    $this->membership = $membership;
+    $this->calculationArguments = $arguments;
     $isPaymentPlanMembership = $this->checkMembershipPaymentPlan();
 
     // If membership was not last payed for with a payment plan, no need to process
     if (!$isPaymentPlanMembership) {
       return;
     }
-
-    $this->membership = $membership;
-    $this->calculationArguments = $arguments;
 
     foreach (self::$memberShipStatuses as $status) {
       $startEventIsArrearsRelated = stripos($status['start_event'], 'arrears') !== false;
@@ -351,6 +355,7 @@ class CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus {
     }
 
     $adjustedReferenceDate = $referenceDate->format('Y-m-d H:i:s');
+
     $query = "
       SELECT COUNT(civicrm_contribution.id) AS total
       FROM civicrm_membership_payment


### PR DESCRIPTION
## Overview
A bug was injected into membership creation by hook that altered membership status, as it assumed the hook would only be called once membership was created. This was not the case, as the hook was being called prior to creating the membership to calculate status.

## Before
Error was thrown when creating a membership.

```
#0 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/Error.php(381): CRM_Core_Error::backtrace("backTrace", TRUE)
#1 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Utils/Type.php(540): CRM_Core_Error::fatal("One of parameters  (value: ) is not of the type Integer")
#2 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/DAO.php(1454): CRM_Utils_Type::validate(NULL, "Integer")
#3 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/DAO.php(1331): CRM_Core_DAO::composeQuery("\r\n      SELECT civicrm_contribution_recur.id AS recurid\r\n      FROM civic...", (Array:1), TRUE)
#4 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/civicrm-extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php(133): CRM_Core_DAO::executeQuery("\r\n      SELECT civicrm_contribution_recur.id AS recurid\r\n      FROM civic...", (Array:1))
#5 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/civicrm-extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php(69): CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus->checkMembershipPaymentPlan()
#6 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/civicrm-extensions/uk.co.compucorp.membershipextras/membershipextras.php(192): CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus->alterMembershipStatus((Array:2), (Array:8), (Array:36))
#7 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Utils/Hook.php(278): membershipextras_civicrm_alterCalculatedMembershipStatus((Array:2), (Array:8), (Array:36))
#8 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Utils/Hook/DrupalBase.php(85): CRM_Utils_Hook->runHooks((Array:39), "civicrm_alterCalculatedMembershipStatus", 3, (Array:2), (Array:8), (Array:36), NULL, NULL, NULL)
#9 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/Civi/Core/CiviEventDispatcher.php(94): CRM_Utils_Hook_DrupalBase->invokeViaUF(3, (Array:2), (Array:8), (Array:36), NULL, NULL, NULL, "civicrm_alterCalculatedMembershipStatus")
#10 [internal function](): Civi\Core\CiviEventDispatcher::delegateToUF(Object(Civi\Core\Event\GenericHookEvent), "hook_civicrm_alterCalculatedMembershipStatus", Object(Civi\Core\CiviEventDispatcher))
#11 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/Symfony/Component/EventDispatcher/EventDispatcher.php(164): call_user_func((Array:2), Object(Civi\Core\Event\GenericHookEvent), "hook_civicrm_alterCalculatedMembershipStatus", Object(Civi\Core\CiviEventDispatcher))
#12 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/Symfony/Component/EventDispatcher/EventDispatcher.php(53): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch((Array:1), "hook_civicrm_alterCalculatedMembershipStatus", Object(Civi\Core\Event\GenericHookEvent))
#13 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/vendor/symfony/event-dispatcher/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php(167): Symfony\Component\EventDispatcher\EventDispatcher->dispatch("hook_civicrm_alterCalculatedMembershipStatus", Object(Civi\Core\Event\GenericHookEvent))
#14 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/Civi/Core/CiviEventDispatcher.php(47): Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch("hook_civicrm_alterCalculatedMembershipStatus", Object(Civi\Core\Event\GenericHookEvent))
#15 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Utils/Hook.php(164): Civi\Core\CiviEventDispatcher->dispatch("hook_civicrm_alterCalculatedMembershipStatus", Object(Civi\Core\Event\GenericHookEvent))
#16 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Utils/Hook.php(1105): CRM_Utils_Hook->invoke((Array:3), (Array:2), (Array:8), (Array:36), NULL, NULL, NULL, "civicrm_alterCalculatedMembershipStatus")
#17 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Member/BAO/MembershipStatus.php(378): CRM_Utils_Hook::alterCalculatedMembershipStatus((Array:2), (Array:8), (Array:36))
#18 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Member/Form/Membership.php(866): CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate("20180406", "20190405", "20180406000000", "today", TRUE, "1", (Array:36))
#19 [internal function](): CRM_Member_Form_Membership::formRule((Array:36), (Array:0), Object(CRM_Member_Form_Membership))
#20 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/packages/HTML/QuickForm.php(1594): call_user_func((Array:2), (Array:36), (Array:0), Object(CRM_Member_Form_Membership))
#21 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/Form.php(513): HTML_QuickForm->validate()
#22 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/QuickForm/Action/Upload.php(153): CRM_Core_Form->validate()
#23 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/QuickForm/Action/Upload.php(136): CRM_Core_QuickForm_Action_Upload->realPerform(Object(CRM_Member_Form_Membership), "upload")
#24 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/packages/HTML/QuickForm/Controller.php(203): CRM_Core_QuickForm_Action_Upload->perform(Object(CRM_Member_Form_Membership), "upload")
#25 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/packages/HTML/QuickForm/Page.php(103): HTML_QuickForm_Controller->handle(Object(CRM_Member_Form_Membership), "upload")
#26 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/Controller.php(351): HTML_QuickForm_Page->handle("upload")
#27 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Member/Page/Tab.php(305): CRM_Core_Controller->run()
#28 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Member/Page/Tab.php(378): CRM_Member_Page_Tab->edit()
#29 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/Invoke.php(309): CRM_Member_Page_Tab->run((Array:3), NULL)
#30 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/Invoke.php(84): CRM_Core_Invoke::runItem((Array:16))
#31 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/CRM/Core/Invoke.php(52): CRM_Core_Invoke::_invoke((Array:3))
#32 /var/www/payment.ccuptest.co.uk/httpdocs/sites/all/modules/civicrm/drupal/civicrm.module(445): CRM_Core_Invoke::invoke((Array:3))
#33 [internal function](): civicrm_invoke("member", "add")
#34 /var/www/payment.ccuptest.co.uk/httpdocs/includes/menu.inc(527): call_user_func_array("civicrm_invoke", (Array:2))
#35 /var/www/payment.ccuptest.co.uk/httpdocs/index.php(21): menu_execute_active_handler()
#36 {main}
```

## After
Fixed by checking if membership ID exists, prior to altering calculated status and only proceeding with alteration if ID is set.
