### PR TITLE
BASW-81: Add option for using last membership price when renewing offline memberships

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentPlanSettings.php
+++ b/CRM/MembershipExtras/Form/PaymentPlanSettings.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Payment Plan Settings form controller
+ *
+ * @see http://wiki.civicrm.org/confluence/display/CRMDOC43/QuickForm+Reference
+ */
+class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
+
+  /**
+   * Contains the setting field names for payment plan.
+   * Used for caching the list since it require an API
+   * call to get it.
+   *
+   * @var string[]
+   */
+  private $settingFields = [];
+
+  /**
+   * @inheritdoc
+   */
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Payment Plan Settings'));
+
+    $settingFields  = $this->getSettingFields();
+    $settingFieldNames = [];
+    foreach ($settingFields  as $name => $field) {
+      $this->add(
+        $field['html_type'],
+        $name,
+        ts($field['title']),
+        '',
+        $field['is_required'],
+        ''
+      );
+
+      $settingFieldNames[] = $name;
+    }
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => ts('Submit'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
+
+    $this->assign('settingFields', $settingFieldNames);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function setDefaultValues() {
+    $currentValues = civicrm_api3('setting', 'get',
+      ['return' => array_keys($this->getSettingFields())]);
+
+    $defaults = [];
+    $domainID = CRM_Core_Config::domainID();
+    foreach ($currentValues['values'][$domainID] as $name => $value) {
+      $defaults[$name] = $value;
+    }
+
+    return $defaults;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function postProcess() {
+    $settingFields = $this->getSettingFields();
+    $submittedValues = $this->exportValues();
+
+    $valuesToSave = [];
+    foreach ($settingFields as $fieldName => $fieldData) {
+      if (array_key_exists($fieldName, $submittedValues)) {
+        $valuesToSave[$fieldName] = $submittedValues[$fieldName];
+      }
+      else if($fieldData['html_type'] === 'checkbox') {
+        $valuesToSave[$fieldName] = FALSE;
+      }
+    }
+
+    civicrm_api3('setting', 'create', $valuesToSave);
+  }
+
+  /**
+   * Gets the setting field names to be set on this form.
+   *
+   * @return array
+   */
+  private function getSettingFields() {
+    if (!empty($this->settingFields )) {
+      return $this->settingFields;
+    }
+
+    $this->settingFields =  civicrm_api3('setting', 'getfields',[
+      'filters' =>['group' => 'membershipextras_paymentplan'],
+    ])['values'];
+
+    return $this->settingFields;
+  }
+
+}

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -19,6 +19,22 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
   private $currentMembershipID;
 
   /**
+   * The "minimum fee"/"price" of the membership that currently
+   * being renewed/processed.
+   *
+   * @var int
+   */
+  private $currentMembershipMinimumFee;
+
+  /**
+   * The membership type name of the membership that currently
+   * being renewed/processed.
+   *
+   * @var int
+   */
+  private $currentMembershipTypeName;
+
+  /**
    * The ID of the recurring Contribution linked
    * with the membership that currently
    * being renewed/processed.
@@ -26,6 +42,76 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * @var int
    */
   private $currentRecurContributionID;
+
+  /**
+   * The number of installments of the membership that currently
+   * being renewed/processed.
+   *
+   * @var int
+   */
+  private $currentInstallmentsNumber;
+
+  /**
+   * The amount of the recurring Contribution linked
+   * with the membership that currently
+   * being renewed/processed.
+   *
+   * @var int
+   */
+  private $currentContributionRecurAmount;
+
+  /**
+   * The frequency unit of the recurring Contribution linked
+   * with the membership that currently
+   * being renewed/processed.
+   *
+   * @var int
+   */
+  private $currentFrequencyUnit;
+
+  /**
+   * The frequency Interval of the recurring Contribution linked
+   * with the membership that currently
+   * being renewed/processed.
+   *
+   * @var int
+   */
+  private $currentFrequencyInterval;
+
+
+  /**
+   * The total amount of all the contributions
+   * to be created for the membership renewal.
+   *
+   * @var int
+   */
+  private $totalAmount;
+
+  /**
+   * The amount of the contribution/recurring contribution
+   * to be created.
+   *
+   * @var int
+   */
+  private $singleInstallmentAmount;
+
+  /**
+   * The percentage of the contributing/recurring contribution
+   * to be created against the total number of contributions.
+   *
+   * @var int
+   */
+  private $singleInstallmentPercentage;
+
+
+  /**
+   * Should the membership latest price
+   * be used for renewal or the old one.
+   *
+   * @var bool
+   */
+  private $useMembershipLatestPrice = FALSE;
+
 
   /**
    * The data of the last Contribution related to
@@ -38,18 +124,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    *
    * @var int
    */
-  private $lastContribution = [];
+  private $currentContribution = [];
 
-  /**
-   * The ID of contact who his
-   * membership is to be auto-renewed.
-   *
-   * @var int
-   */
-  private $contactID;
 
   public function __construct() {
     $this->setFinancialTypesIDMap();
+    $this->setUseMembershipLatestPrice();
   }
 
   /**
@@ -68,6 +148,17 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
   }
 
   /**
+   * Sets $useMembershipLatestPrice
+   */
+  private function setUseMembershipLatestPrice() {
+    $settingFieldName = 'membershipextras_paymentplan_use_membership_latest_price';
+    $this->useMembershipLatestPrice = civicrm_api3('Setting', 'get', array(
+      'sequential' => 1,
+      'return' => [$settingFieldName],
+    ))['values'][0][$settingFieldName];
+  }
+
+  /**
    * Starts the scheduled job for renewing offline
    * auto-renewal memberships.
    *
@@ -77,11 +168,32 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    $membershipsToRenew = $this->getOfflineAutoRenewalMemberships();
    foreach ($membershipsToRenew as $membership) {
      $this->currentMembershipID = $membership['membership_id'];
+     $this->currentMembershipMinimumFee = $membership['membership_minimum_fee'];
+     $this->currentMembershipTypeName = $membership['membership_type_name'];
      $this->currentRecurContributionID = $membership['contribution_recur_id'];
-     $this->setLastContribution();
+     $this->currentInstallmentsNumber = $membership['installments'];
+     $this->currentContributionRecurAmount = $membership['contribution_recur_amount'];
+     $this->currentFrequencyUnit = $membership['frequency_unit'];
+     $this->currentFrequencyInterval = $membership['frequency_interval'];
 
-     if ($membership['installments']) {
-       $this->renewWithInstallmentsMembership($membership['installments']);
+     $this->totalAmount = $membership['total_amount'];
+     if ($this->useMembershipLatestPrice) {
+       $this->totalAmount = $this->currentMembershipMinimumFee;
+     }
+
+     $this->singleInstallmentAmount = $this->calculateSingleInstallmentAmount(
+       $this->totalAmount, $this->currentInstallmentsNumber
+     );
+
+     $this->singleInstallmentPercentage = $this->calculateSingleInstallmentPercentage(
+       $this->singleInstallmentAmount, $this->totalAmount
+     );
+
+
+     $this->setCurrentContribution();
+
+     if ($this->currentInstallmentsNumber > 1) {
+       $this->renewWithInstallmentsMembership();
      }
      else {
        $this->renewNoInstallmentsMembership();
@@ -95,18 +207,23 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * Gets the list of offline auto-renewal memberships
    * to be renewed, the membership should satisfy the following
    * conditions for it to be auto-renewed :
-   * 1- the membership is set to auto renew (has a linked recurring contribution)
-   *   along with the linked recurring contribution.
+   * 1- the membership is set to auto renew (has a linked recurring contribution).
    * 2- the payment processor used is pay later (aka : no payment processor used)
-   *   or an equivalent payment processor that behaves as pay later.
+   *   or an equivalent payment processor.
    * 3- The linked recurring contribution is not cancelled or refunded.
    * 4- The membership end date is less or equal than today.
    *
    * @return array
    *   Each membership row Contains :
-   *   1- The membership ID (membership_id)
-   *   2- The linked  recurring contribution (contribution_recur_id)
-   *   3- The number of recurring contribution installments (installments)
+   *   - The membership ID (membership_id)
+   *   - The membership current "minimum fee"/"price" (membership_minimum_fee)
+   *   - The membership type name (membership_type_name)
+   *   - The linked  recurring contribution (contribution_recur_id)
+   *   - The number of the linked recurring contribution installments (installments)
+   *   - The amount of the linked  recurring contribution (contribution_recur_amount)
+   *   - The linked recurring contribution frequency unit (frequency_unit)
+   *   - The linked recurring contribution frequency interval (frequency_interval)
+   *   - The previous membership total paid amount (total_amount)
    */
   private function getOfflineAutoRenewalMemberships() {
     $membershipsList = [];
@@ -115,20 +232,34 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
     $cancelledStatusID = $getContributionStatusesNameMap['Cancelled'];
     $refundedStatusID = $getContributionStatusesNameMap['Refunded'];
 
-    $query = 'SELECT cm.id as membership_id, ccr.id as contribution_recur_id, ccr.installments
-                FROM civicrm_membership cm
+    $payLaterPaymentProcessors = new CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution();
+    $payLaterPaymentProcessorsIDs = implode(',', [0, $payLaterPaymentProcessors->get()['id']]);
+
+    $query = 'SELECT cm.id as membership_id, cmt.minimum_fee as membership_minimum_fee,
+                cmt.name as membership_type_name, 
+                ccr.id as contribution_recur_id, ccr.installments , ccr.amount as contribution_recur_amount,
+                ccr.frequency_unit, ccr.frequency_interval 
+              FROM civicrm_membership cm
               INNER JOIN civicrm_contribution_recur ccr
                 ON cm.contribution_recur_id = ccr.id
+              LEFT JOIN civicrm_membership_type cmt 
+                ON cm.membership_type_id = cmt.id 
               WHERE ccr.auto_renew = 1 
-                AND (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id = 0)
+                AND (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN (' . $payLaterPaymentProcessorsIDs . '))
                 AND (ccr.contribution_status_id != ' . $cancelledStatusID . ' OR  ccr.contribution_status_id != ' . $refundedStatusID . ')
                 AND cm.end_date <= CURDATE()';
     $memberships = CRM_Core_DAO::executeQuery($query);
 
     while ($memberships->fetch()) {
       $membershipsList['membership_id'] = $memberships['membership_id'];
+      $membershipsList['membership_minimum_fee'] = $memberships['membership_minimum_fee'];
+      $membershipsList['membership_type_name'] = $memberships['membership_type_name'];
       $membershipsList['contribution_recur_id'] = $memberships['contribution_recur_id'];
       $membershipsList['installments'] = $memberships['installments'];
+      $membershipsList['contribution_recur_amount'] = $memberships['contribution_recur_amount'];
+      $membershipsList['frequency_unit'] = $memberships['frequency_unit'];
+      $membershipsList['frequency_interval'] = $memberships['frequency_interval'];
+      $membershipsList['total_amount'] = $memberships['installments'] * $memberships['contribution_recur_amount'];
     }
 
     return $membershipsList;
@@ -156,6 +287,39 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
   }
 
   /**
+   * Calculates a single installment amount (price) if there is more than one
+   * installment.
+   *
+   * If there is only one installment then its amount will be the total amount.
+   *
+   * @param float $totalAmount
+   * @param int $installmentsCount
+   *
+   * @return float
+   */
+  private function calculateSingleInstallmentAmount($totalAmount, $installmentsCount) {
+    $amount =  $totalAmount;
+    if ($installmentsCount > 1) {
+      $amount = floor(($totalAmount / $installmentsCount) * 100) / 100;
+    }
+
+    return $amount;
+  }
+
+  /**
+   * Calculates and returns the percentage value of the single installment
+   * compared to the total amount.
+   *
+   * @param float $installmentAmount
+   * @param float $totalAmount
+   *
+   * @return float
+   */
+  private function calculateSingleInstallmentPercentage($installmentAmount, $totalAmount) {
+    return round(($installmentAmount / $totalAmount) * 100, 2, PHP_ROUND_HALF_DOWN);
+  }
+
+  /**
    * Sets $lastContribution to contain last
    * contribution data related to the membership
    * to be renewed. It will contain the following data :
@@ -165,21 +329,16 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * - total_amount
    * - contact_id
    * - currency
-   * - fee_amount
-   * - net_amount
-   * - non_deductible_amount
-   * - tax_amount
    * - campaign_id
    * - source
    * - is_test
    */
-  private function setLastContribution() {
-    $this->lastContribution = civicrm_api3('Contribution', 'get', [
+  private function setCurrentContribution() {
+    $this->currentContribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
       'return' => ['id', 'financial_type_id',
-        'total_amount', 'contact_id', 'currency', 'fee_amount',
-        'net_amount', 'non_deductible_amount', 'tax_amount', 'campaign_id',
-        'source', 'is_test'],
+        'total_amount', 'contact_id', 'currency',
+        'campaign_id', 'source', 'is_test'],
       'contribution_recur_id' => $this->currentRecurContributionID,
       'options' => ['limit' => 1, 'sort' => 'id DESC'],
     ])['values'][0];
@@ -194,21 +353,14 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * creating a number of contributions equals the number
    * of installments and where all these contributions
    * are linked to the new recurring contribution.
-   *
-   * @param int $installmentsNumber
-   *   The number of installments
    */
-  private function renewWithInstallmentsMembership($installmentsNumber) {
-    $this->renewCurrentRecurringContribution();
-
-    for($i=1; $i <= $installmentsNumber; $i++) {
-      $newContributionID = $this->createContribution();
-
-      $this->createMembershipPayment($newContributionID);
-
-      $this->createLineItem($newContributionID);
+  private function renewWithInstallmentsMembership() {
+    $this->createRecurringContribution();
+    for($i=1; $i <= $this->currentInstallmentsNumber; $i++) {
+      $this->createContribution($i);
+      $this->createMembershipPayment();
+      $this->createLineItem();
     }
-
 
     $this->renewMembership();
   }
@@ -220,17 +372,18 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * Then new recurring contribution will then
    * be set to be the current recurring contribution.
    */
-  private function renewCurrentRecurringContribution() {
+  private function createRecurringContribution() {
     $currentRecurContribution = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,
       'id' => $this->currentRecurContributionID,
     ])['values'][0];
 
+
     $paymentProcessorID = !empty($currentRecurContribution['payment_processor_id']) ? $currentRecurContribution['payment_processor_id'] : NULL;
     $newRecurringContribution = civicrm_api3('ContributionRecur', 'create', [
       'contact_id' => $currentRecurContribution['contact_id'],
       'frequency_interval' => $currentRecurContribution['frequency_interval'],
-      'amount' => $currentRecurContribution['amount'],
+      'amount' => $this->singleInstallmentAmount,
       'currency' => $currentRecurContribution['currency'],
       'frequency_unit' => $currentRecurContribution['frequency_unit'],
       'installments' => $currentRecurContribution['installments'],
@@ -243,6 +396,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
       'payment_processor_id' => $paymentProcessorID,
     ])['values'][0];
 
+    // The new recurring contribution is now the current one.
     $this->currentRecurContributionID = $newRecurringContribution['id'];
   }
 
@@ -257,11 +411,9 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    *
    */
   private function renewNoInstallmentsMembership() {
-    $newContributionID = $this->createContribution();
-
-    $this->createMembershipPayment($newContributionID);
-
-    $this->createLineItem($newContributionID);
+    $this->createContribution();
+    $this->createMembershipPayment();
+    $this->createLineItem();
 
     $this->renewMembership();
   }
@@ -271,91 +423,113 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * contribution record based on the last contribution
    * data, the contribution is created in 'pending' status'.
    *
-   * @return int
-   *   The created Contribution ID
+   * @param int $contributionNumber
+   *   The number of the contribution to be created, used if there are more than
+   *   one contribution (installment) to be created to calculate the receive date.
    */
-  private function createContribution() {
+  private function createContribution($contributionNumber = 1) {
     $newContributionParams = [
-      'financial_type_id'=> $this->financialTypesIDMap[$this->lastContribution['financial_type_id']],
-      'total_amount'=> $this->lastContribution['total_amount'],
-      'contact_id' => $this->lastContribution['contact_id'],
-      'currency' => $this->lastContribution['currency'],
+      'financial_type_id'=> $this->financialTypesIDMap[$this->currentContribution['financial_type_id']],
+      'total_amount'=> $this->singleInstallmentAmount,
+      'contact_id' => $this->currentContribution['contact_id'],
+      'currency' => $this->currentContribution['currency'],
       'payment_instrument_id'=> 'EFT',
       'contribution_status_id' => 'Pending',
-      'non_deductible_amount' => $this->lastContribution['non_deductible_amount'],
-      'fee_amount' => $this->lastContribution['fee_amount'],
-      'net_amount' => $this->lastContribution['net_amount'],
       'contribution_recur_id'=> $this->currentRecurContributionID,
-      'is_test'=> $this->lastContribution['is_test'],
+      'is_test'=> $this->currentContribution['is_test'],
       'is_pay_later' => 1,
-      'tax_amount'=> $this->lastContribution['tax_amount'],
-      'source' => $this->lastContribution['source'],
-      'campaign_id' => $this->lastContribution['campaign_id'],
+      'source' => $this->currentContribution['source'],
+      'campaign_id' => $this->currentContribution['campaign_id'],
       'skipRecentView' => 1,
-      'skipLineItem' => 0, // TODO : Not sure of this flag, need to be tested
-      'membership_id'=> $this->currentMembershipID, // TODO : Not sure of this flag, need to be tested
-      'invoice_id' => md5(uniqid(rand(), TRUE))
+      'skipLineItem' => 0,
+      'membership_id'=> $this->currentMembershipID,
+      'invoice_id' => md5(uniqid(rand(), TRUE)),
+      'receive_date' => $this->calculateInstallmentReceiveDate($contributionNumber),
     ];
 
-    return civicrm_api3('Contribution', 'create', $newContributionParams)['id'];
+    // The new contribution is now the current one.
+    $this->currentContribution = civicrm_api3('Contribution', 'create', $newContributionParams)['values'];
   }
+
+  /**
+   * Calculate and returns the receive date for a single installment
+   * based on its order (number)
+   *
+   * @param int $installmentNumber
+   *
+   * @return string
+   */
+  private function calculateInstallmentReceiveDate($installmentNumber) {
+    $date = new DateTime();
+    $numberOfIntervals = ($installmentNumber - 1) * $this->currentFrequencyInterval;
+    switch ($this->currentFrequencyUnit) {
+      case 'day':
+        $interval = "P{$numberOfIntervals}D";
+        break;
+      case 'week':
+        $interval = "P{$numberOfIntervals}W";
+        break;
+      case 'month':
+        $interval = "P{$numberOfIntervals}M";
+        break;
+      case 'year':
+        $interval = "P{$numberOfIntervals}Y";
+        break;
+      default:
+        $interval = '';
+    }
+
+    if (!empty($interval)) {
+      $date->add(new DateInterval($interval));
+    }
+
+    return $date->format('Y-m-d');
+  }
+
 
   /**
    * Creates the membership offline auto-renew
    * payment record.
-   *
-   * @param $contributionID
    */
-  private function createMembershipPayment($contributionID) {
+  private function createMembershipPayment() {
     civicrm_api3('MembershipPayment', 'create', [
       'membership_id' => $this->currentMembershipID,
-      'contribution_id' => $contributionID,
+      'contribution_id' => $this->currentContribution['id'],
     ]);
   }
 
   /**
    * Creates line items for the membership
    * contribution to be auto-renewed.
-   *
-   * @param $contributionID
    */
-  private function createLineItem($contributionID) {
-    $lastContributionLineItem = civicrm_api3('LineItem', 'get', [
-      'sequential' => 1,
-      'return' => ['id', 'qty', 'unit_price', 'line_total', 'non_deductible_amount', 'tax_amount'],
-      'contribution_id' => $this->lastContribution['id'],
-      'options' => ['limit' => 1, 'sort' => 'id DESC'],
-    ])['values'][0];
+  private function createLineItem() {
+    $label = $this->currentMembershipTypeName;
+    if ($this->currentInstallmentsNumber > 1) {
+      $label .= " ({$this->singleInstallmentPercentage}%), " .
+        CRM_Utils_Date::customFormat($this->currentContribution['receive_date']);
+    }
+
+    $financialTypeName = $this->financialTypesIDMap[$this->currentContribution['financial_type_id']];
 
     $lineItemID = civicrm_api3('LineItem', 'create', [
       'sequential' => 1,
       'entity_table' => 'civicrm_membership',
       'entity_id' => $this->currentMembershipID,
-      'contribution_id' => $contributionID,
-      //'label' => '' TODO : Student (33.33%)March 19th, 2018,
-      'qty' => $lastContributionLineItem['qty'],
-      'unit_price' => $lastContributionLineItem['unit_price'],
-      'line_total' => $lastContributionLineItem['line_total'],
-      'financial_type_id' => $this->financialTypesIDMap[$lastContributionLineItem['financial_type_id']],
-      'non_deductible_amount' => $lastContributionLineItem['non_deductible_amount'],
-      'tax_amount' => $lastContributionLineItem['tax_amount'],
+      'contribution_id' => $this->currentContribution['id'],
+      'label' => $label,
+      'qty' => 1,
+      'unit_price' => $this->singleInstallmentAmount,
+      'line_total' => $this->singleInstallmentAmount,
+      'financial_type_id' => $financialTypeName,
     ])['id'];
 
 
-    $lastContributionFinancialItem = civicrm_api3('FinancialItem', 'get', [
-      'sequential' => 1,
-      'return' => ['id', 'amount', 'currency'],
-      'entity_id' => $lastContributionLineItem['id'],
-      'entity_table' => 'civicrm_line_item',
-      'options' => ['limit' => 1, 'sort' => 'id DESC'],
-    ])['values'][0];
-
     civicrm_api3('FinancialItem', 'create', [
-      'contact_id' => $this->contactID,
-      //'description' => '' TODO : Student (33.33%)March 19th, 2018,
-      'amount' => $lastContributionFinancialItem['amount'],
-      'currency' => $lastContributionFinancialItem['currency'],
-      'financial_type_id' => $this->financialTypesIDMap[$lastContributionLineItem['financial_type_id']],
+      'contact_id' => $this->currentContribution['contact_id'],
+      'description' => $label,
+      'amount' => $this->singleInstallmentAmount,
+      'currency' => $this->currentContribution['currency'],
+      'financial_type_id' => $financialTypeName,
       'status_id' => 'Unpaid',
       'entity_table' => 'civicrm_line_item',
       'entity_id' => $lineItemID,
@@ -370,12 +544,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
   private function renewMembership() {
     $membershipDetails = civicrm_api3('Membership', 'get', [
       'sequential' => 1,
-      'return' => ['membership_type_id', 'is_test', 'campaign_id'],
+      'return' => ['contact_id', 'membership_type_id', 'is_test', 'campaign_id'],
       'id' => $this->currentMembershipID,
     ])['values'][0];
 
     CRM_Member_BAO_Membership::processMembership(
-      $this->contactID, $membershipDetails['membership_type_id'], $membershipDetails['is_test'],
+      $membershipDetails['contact_id'], $membershipDetails['membership_type_id'], $membershipDetails['is_test'],
       NULL, NULL, NULL, 1, $this->currentMembershipID,
       FALSE,
       $this->currentRecurContributionID, NULL, TRUE, $membershipDetails['campaign_id']

--- a/CRM/MembershipExtras/PaymentProcessor/OfflineRecurringContribution.php
+++ b/CRM/MembershipExtras/PaymentProcessor/OfflineRecurringContribution.php
@@ -50,7 +50,7 @@ class CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution {
    *
    * @return array
    */
-  private function get() {
+  public function get() {
     $processor = civicrm_api3('PaymentProcessor', 'get', [
       'name' => self::NAME,
       'sequential' => 1,

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -127,6 +127,24 @@ function membershipextras_civicrm_alterSettingsFolders(&$metaDataFolders = NULL)
 /**
  * Implements hook_civicrm_pre().
  *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
+ */
+function membershipextras_civicrm_navigationMenu(&$menu) {
+  $paymentPlanSettingsMenuItem = [
+    'name' => ts('payment_plan_settings'),
+    'label' => ts('Payment Plan Settings'),
+    'url' => 'civicrm/admin/payment_plan_settings',
+    'permission' => 'administer CiviCRM',
+    'operator' => NULL,
+    'separator' => NULL,
+  ];
+
+  _membershipextras_civix_insert_navigation_menu($menu, 'Administer/', $paymentPlanSettingsMenuItem);
+}
+
+/**
+ * Implements hook_civicrm_pre().
+ *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_pre
  */
 function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * Metadata for Payment Plan Settings
+ */
+return [
+  'membershipextras_paymentplan_use_membership_latest_price' => [
+    'group_name' => 'MembershipExtras: Payment Plan',
+    'group' => 'membershipextras_paymentplan',
+    'name' => 'membershipextras_paymentplan_use_membership_latest_price',
+    'title' => 'Use latest price when auto renew membership?',
+    'type' => 'Integer',
+    'html_type' => 'checkbox',
+    'quick_form_type' => 'Element',
+    'default' => FALSE,
+    'is_required' => FALSE,
+  ],
+];

--- a/sql/auto_uninstall.sql
+++ b/sql/auto_uninstall.sql
@@ -1,0 +1,1 @@
+DELETE FROM civicrm_setting WHERE `name` LIKE 'membershipextras_paymentplan_%';

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.tpl
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.tpl
@@ -1,0 +1,11 @@
+{foreach from=$settingFields item=elementName}
+    <div class="crm-section">
+        <div class="label">{$form.$elementName.label}</div>
+        <div class="content">{$form.$elementName.html}</div>
+        <div class="clear"></div>
+    </div>
+{/foreach}
+
+<div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/admin/payment_plan_settings</path>
+    <page_callback>CRM_MembershipExtras_Form_PaymentPlanSettings</page_callback>
+    <title>Payment Plan Settings</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
When the "**offline memberships auto-renewal scheduled job**" runs, it will use the same price used in the last  payment, but sometimes and for some organizations, the membership price change and using the old price is no longer applicable.

In this PR we add a new configuration page called "**Payment Plan Configuration**" which can be accessed from the administer menu (or **civicrm/admin/payment_plan_settings**) that allow the user to toggle a checkbox called "**Use latest price when auto renew membership?**".


If the checkbox mentioned above is enabled, then the scheduled job will use the membership latest price when doing an auto-renew, if it is disabled then it will use the old price.


![aaatest](https://user-images.githubusercontent.com/6275540/38554279-eb1a6604-3cb9-11e8-9b27-c0d1ac78d676.gif)
