### PR TITLE
BASW-82: Adding Optout from using last membership price option

### DIFF
--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+<CustomData>
+    <CustomGroups>
+        <CustomGroup>
+            <name>offline_autorenew_option</name>
+            <title>Offline auto-renew option</title>
+            <extends>Membership</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_offline_autorenew_option</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+            <is_reserved>0</is_reserved>
+        </CustomGroup>
+    </CustomGroups>
+    <CustomFields>
+        <CustomField>
+            <name>optout_last_price_offline_autorenew</name>
+            <label>Opt-out auto price update for offline auto-renew</label>
+            <data_type>Boolean</data_type>
+            <html_type>Radio</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>0</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>optout_last_price_offline_autorenew</column_name>
+            <custom_group_name>offline_autorenew_option</custom_group_name>
+            <in_selector>1</in_selector>
+        </CustomField>
+    </CustomFields>
+</CustomData>


### PR DESCRIPTION
In the previous PR https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/11 we added the ability to configure the site to either to use the membership last price or its previous price for offline membership auto-renewal scheduled job.

In this PR, we add a new custom group called "**Offline auto-renew option**" that contain a single Boolean custom field "**Opt-out auto price update for offline auto-renew**" for membership entity.
If this Boolean field is enabled for a specific membership, then it will not be affected whither "**Use latest price when auto renew membership?**"  is enabled or not, which means that the membership when get auto-renewed  will always use the previous price if this field is enabled.

In other words, it is a way to override **Opt-out auto price update for offline auto-renew**" for specific memberships.

