### PR TITLE
BASW-65: Fix Bug on Membership Status Alter Hook

### DIFF
--- a/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
+++ b/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
@@ -66,13 +66,14 @@ class CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus {
    *   Membership details from the calling function
    */
   public function alterMembershipStatus(&$calculatedStatus, $arguments, $membership) {
+    $this->membership = $membership;
+    $this->calculationArguments = $arguments;
+
     $isMembershipExist = CRM_Utils_Array::value('id', $this->membership, false);
     if (!$isMembershipExist) {
       return;
     }
 
-    $this->membership = $membership;
-    $this->calculationArguments = $arguments;
     $isPaymentPlanMembership = $this->checkMembershipPaymentPlan();
 
     // If membership was not last payed for with a payment plan, no need to process


### PR DESCRIPTION
## Overview
Calculation of arrears related statuses was failing.

## Before
We were checking for the membership's ID using CaculatedMembershipStatus class $membership attribute, but since that attribute wasn't set by the time the check was made, no memberships were being processed.

## After
Fixed by doing the check after the class' attribute is set.