### PR TITLE
BASW-90: Fixing pricesets payments and other fixes

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
@@ -97,6 +97,11 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
       'id' => $this->params['financial_type_id'],
     ]);
 
+    $paymentProcessorId = 'null';
+    if (!empty($this->params['payment_processor_id'])) {
+      $paymentProcessorId = $this->params['payment_processor_id'];
+    }
+
     $contributionRecurParams = [
       'sequential' => 1,
       'contact_id' => $this->params['contact_id'],
@@ -109,7 +114,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
       'contribution_status_id' => 'Pending',
       'is_test' => $this->params['is_test'],
       'cycle_day' => $this->calculateCycleDay(),
-      'payment_processor_id' => $this->params['payment_processor_id'],
+      'payment_processor_id' => $paymentProcessorId,
       'financial_type_id' =>  $financialType,
       'payment_instrument_id' => $PaymentInstrument,
       'campaign_id' => $this->params['campaign_id'],

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
@@ -156,7 +156,10 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
   public function updateLineItemData() {
     $this->params['line_total'] = $this->calculateSingleInstallmentAmount($this->params['line_total']);
     $this->params['unit_price'] = $this->calculateSingleInstallmentAmount($this->params['unit_price']);
-    $this->params['tax_amount'] = $this->calculateSingleInstallmentAmount($this->params['tax_amount']);
+
+    if (!empty($this->params['tax_amount'])) {
+      $this->params['tax_amount'] = $this->calculateSingleInstallmentAmount($this->params['tax_amount']);
+    }
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
@@ -3,7 +3,7 @@
 class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
 
   /**
-   * The contribution to be created parameters passed from the hook.
+   * The contribution or line item to-be-created parameters passed from the hook.
    *
    * @var array
    */
@@ -47,11 +47,11 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
   }
 
   /**
-   * Processes the membership in case it is paid
-   * using payment plan option.
+   * Creates the payment plan for the membership
+   * if its paid using payment plan option.
    *
    * For now, it creates the recurring contribution
-   * and update the first contribution & line itme amounts
+   * and update the first contribution amount
    * depending on the installments count.
    */
   public function createPaymentPlan() {

--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -61,7 +61,6 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
 
   /**
    * Sets $lastContribution
-   *
    */
   private function setLastContribution() {
     $contribution = civicrm_api3('Contribution', 'get', [
@@ -183,7 +182,6 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       'is_test' => $this->lastContribution['is_test'],
       'contribution_status_id' => $this->contributionPendingStatusValue,
       'is_pay_later' => TRUE,
-      'membership_id' => $this->lastContribution['membership_id'],
       'tax_amount' => $this->lastContribution['tax_amount'],
       'skipLineItem' => 1,
       'contribution_recur_id' => $this->currentRecurContribution['id'],
@@ -198,7 +196,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
 
 
   /**
-   * Creates the contribution line item.
+   * Creates the contribution line items.
    *
    * @param CRM_Contribute_BAO_Contribution $contribution
    *   The contribution that we need to build the line items for.

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -166,16 +166,9 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
     $preEditMembershipHook->preventExtendingOfflinePendingRecurringMembership();
   }
 
-  $action = CRM_Utils_Request::retrieve('action', 'String');
-  $context = CRM_Utils_Request::retrieve('context', 'String');
-
-  $membershipContributionCreation = $objectName === 'Contribution' && $op === 'create'
-    && $context === 'membership';
-  $newMembershipContribution = $membershipContributionCreation && ($action & CRM_Core_Action::ADD);
-  $renewMembershipContribution = $membershipContributionCreation && ($action & CRM_Core_Action::RENEW);
-
+  $membershipContributionCreation = ($objectName === 'Contribution' && $op === 'create' && !empty($params['membership_id']));
   static $isUpfrontContribution = FALSE;
-  if (($newMembershipContribution || $renewMembershipContribution) && !$isUpfrontContribution) {
+  if ($membershipContributionCreation && !$isUpfrontContribution) {
     $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
     $paymentPlanProcessor->process();
     $isUpfrontContribution = TRUE;

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -182,7 +182,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
     $upfrontContributionId = $params['contribution_id'];
   }
 
-  $upfrontContributionLineItemCreation = ($objectName === 'LineItem' && $op === 'create' && $upfrontContributionId == $params['contribution_id'] );
+  $upfrontContributionLineItemCreation = ($objectName === 'LineItem' && $op === 'create' && !empty($upfrontContributionId) && $upfrontContributionId == $params['contribution_id']);
   if ($upfrontContributionLineItemCreation) {
     $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
     $paymentPlanProcessor->updateLineItemData();

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -189,6 +189,13 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   }
 }
 
+/**
+ * Determines if the membership is paid
+ * using payment plan option using more than
+ * one installment or not.
+ *
+ * @return bool
+ */
 function _membershipextras_isPaymentPlanPayment() {
   $installmentsCount = CRM_Utils_Request::retrieve('installments', 'Int');
   $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');


### PR DESCRIPTION
When paying for membership using pricesets, the line items for the contributions were not getting calculated correctly, this is fixes in this PR by using the previous contribution line items as a base for creating the new one.

Also another issue is fixed that prevent you from paying for the a membership using payment plan if you don't open the form from membership contact tab. 