### PR TITLE
DD-26: Create External ID for Direct Debit Related Entities

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -13,6 +13,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   {
     $this->createOfflineAutoRenewalScheduledJob();
     $this->createLineItemExternalIDCustomField();
+    $this->executeSqlFile('sql/set_unique_external_ids.sql');
   }
 
   /**
@@ -92,7 +93,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       ]);
     }
   }
-
+  
     public function enable() {
     $paymentProcessor = new OfflineRecurringPaymentProcessor();
     $paymentProcessor->toggle(TRUE);

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -134,7 +134,9 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     $paymentProcessorType->remove();
 
     $this->removeOfflineAutoRenewalScheduledJob();
-  }
+    $this->removeCustomExternalIDs();
+
+    }
 
   /**
    * Removes 'Renew offline auto-renewal memberships'
@@ -147,4 +149,19 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     ]);
   }
 
+  private function removeCustomExternalIDs(){
+    $customGroupsToDelete = [
+      'recurring_contribution_external_id',
+      'contribution_external_id',
+      'membership_external_id',
+      'line_item_external_id',
+    ];
+
+    foreach ($customGroupsToDelete as $customGroup) {
+      civicrm_api3('CustomGroup', 'get', [
+        'name' => $customGroup,
+        'api.CustomGroup.delete' => ['id' => '$value.id'],
+      ]);
+    }
+  }
 }

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -9,8 +9,7 @@ use CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution as Offlin
  */
 class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
-  public function Install()
-  {
+  public function Install(){
     $this->createOfflineAutoRenewalScheduledJob();
     $this->createLineItemExternalIDCustomField();
     $this->executeSqlFile('sql/set_unique_external_ids.sql');
@@ -37,9 +36,9 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     $paymentProcessor->create();
   }
 
-    /**
-     * Creates 'External ID' Custom Field for LineItem
-     */
+  /**
+  	* Creates 'External ID' Custom Field for LineItem
+  	*/
   private function createLineItemExternalIDCustomField()
   {
     $optionValues = civicrm_api3('OptionValue', 'get', [
@@ -70,12 +69,12 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
         'is_active' => 0,
         'style' => 'Inline',
         'is_multiple' => 0,
-
       ]);
     }
 
     $customFields = civicrm_api3('CustomField', 'get', [
       'custom_group_id' => $customGroups['id'],
+      'name' => 'external_id',
     ]);
     if (!$customFields['count']) {
       $customField = civicrm_api3('CustomField', 'create', [
@@ -89,12 +88,11 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
         'is_searchable' => 1,
         'column_name' => 'external_id',
         'is_view' => 1
-
       ]);
     }
   }
   
-    public function enable() {
+  public function enable() {
     $paymentProcessor = new OfflineRecurringPaymentProcessor();
     $paymentProcessor->toggle(TRUE);
 
@@ -137,7 +135,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     $this->removeOfflineAutoRenewalScheduledJob();
     $this->removeCustomExternalIDs();
 
-    }
+  }
 
   /**
    * Removes 'Renew offline auto-renewal memberships'

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -37,8 +37,8 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   }
 
   /**
-  	* Creates 'External ID' Custom Field for LineItem
-  	*/
+  * Creates 'External ID' Custom Field for LineItem
+  */
   private function createLineItemExternalIDCustomField()
   {
     $optionValues = civicrm_api3('OptionValue', 'get', [

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -67,7 +67,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
         'name' => 'line_item_external_id',
         'title' => E::ts('Line Item External ID'),
         'table_name' => 'civicrm_value_line_item_ext_id',
-        'is_active' => 1,
+        'is_active' => 0,
         'style' => 'Inline',
         'is_multiple' => 0,
 
@@ -85,7 +85,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
         'data_type' => 'String',
         'html_type' => 'Text',
         'required' => 0,
-        'is_active' => 1,
+        'is_active' => 0,
         'is_searchable' => 1,
         'column_name' => 'external_id',
         'is_view' => 1

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -37,10 +37,9 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   }
 
   /**
-  * Creates 'External ID' Custom Field for LineItem
-  */
-  private function createLineItemExternalIDCustomField()
-  {
+   * Creates 'External ID' Custom Field for LineItem
+   */
+  private function createLineItemExternalIDCustomField(){
     $optionValues = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => 'cg_extend_objects',
       'name' => 'civicrm_line_item'

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -9,7 +9,7 @@ use CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution as Offlin
  */
 class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
-  public function Install(){
+  public function Install() {
     $this->createOfflineAutoRenewalScheduledJob();
     $this->createLineItemExternalIDCustomField();
     $this->executeSqlFile('sql/set_unique_external_ids.sql');
@@ -28,7 +28,6 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       'api_action' => 'run',
     ]);
 
-
     $paymentProcessorType = new ManualRecurringPaymentProcessorType();
     $paymentProcessorType->create();
 
@@ -39,7 +38,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   /**
    * Creates 'External ID' Custom Field for LineItem
    */
-  private function createLineItemExternalIDCustomField(){
+  private function createLineItemExternalIDCustomField() {
     $optionValues = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => 'cg_extend_objects',
       'name' => 'civicrm_line_item'
@@ -90,7 +89,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       ]);
     }
   }
-  
+
   public function enable() {
     $paymentProcessor = new OfflineRecurringPaymentProcessor();
     $paymentProcessor->toggle(TRUE);
@@ -133,7 +132,6 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
     $this->removeOfflineAutoRenewalScheduledJob();
     $this->removeCustomExternalIDs();
-
   }
 
   /**
@@ -147,7 +145,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     ]);
   }
 
-  private function removeCustomExternalIDs(){
+  private function removeCustomExternalIDs() {
     $customGroupsToDelete = [
       'recurring_contribution_external_id',
       'contribution_external_id',

--- a/sql/auto_uninstall.sql
+++ b/sql/auto_uninstall.sql
@@ -1,1 +1,9 @@
 DELETE FROM civicrm_setting WHERE `name` LIKE 'membershipextras_paymentplan_%';
+
+-- /*******************************************************
+-- * Delete External IDs value tables
+-- *******************************************************/
+DROP TABLE IF EXISTS `civicrm_value_contribution_ext_id`;
+DROP TABLE IF EXISTS `civicrm_value_contribution_recur_ext_id`;
+DROP TABLE IF EXISTS `civicrm_value_membership_ext_id`;
+DROP TABLE IF EXISTS `civicrm_value_line_item_ext_id`;

--- a/sql/set_unique_external_ids.sql
+++ b/sql/set_unique_external_ids.sql
@@ -1,0 +1,10 @@
+-- /*******************************************************
+-- *Set External IDs as unique fields
+-- *******************************************************/
+ALTER TABLE civicrm_value_contribution_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+ALTER TABLE civicrm_value_contribution_recur_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+ALTER TABLE civicrm_value_membership_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+ALTER TABLE civicrm_value_line_item_ext_id ADD CONSTRAINT unique_external_id UNIQUE(external_id);
+
+
+

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -19,7 +19,7 @@
             <extends>ContributionRecur</extends>
             <style>Inline</style>
             <collapse_display>0</collapse_display>
-            <is_active>1</is_active>
+            <is_active>0</is_active>
             <table_name>civicrm_value_contribution_recur_ext_id</table_name>
             <is_multiple>0</is_multiple>
             <collapse_adv_display>0</collapse_adv_display>
@@ -30,7 +30,7 @@
             <extends>Contribution</extends>
             <style>Inline</style>
             <collapse_display>0</collapse_display>
-            <is_active>1</is_active>
+            <is_active>0</is_active>
             <table_name>civicrm_value_contribution_ext_id</table_name>
             <is_multiple>0</is_multiple>
             <collapse_adv_display>0</collapse_adv_display>
@@ -41,7 +41,7 @@
             <extends>Membership</extends>
             <style>Inline</style>
             <collapse_display>0</collapse_display>
-            <is_active>1</is_active>
+            <is_active>0</is_active>
             <table_name>civicrm_value_membership_ext_id</table_name>
             <is_multiple>0</is_multiple>
             <collapse_adv_display>0</collapse_adv_display>
@@ -73,7 +73,7 @@
             <is_required>0</is_required>
             <is_searchable>1</is_searchable>
             <is_search_range>0</is_search_range>
-            <is_active>1</is_active>
+            <is_active>0</is_active>
             <is_view>1</is_view>
             <text_length>64</text_length>
             <note_columns>60</note_columns>
@@ -89,7 +89,7 @@
             <is_required>0</is_required>
             <is_searchable>1</is_searchable>
             <is_search_range>0</is_search_range>
-            <is_active>1</is_active>
+            <is_active>0</is_active>
             <is_view>1</is_view>
             <text_length>64</text_length>
             <note_columns>60</note_columns>
@@ -105,7 +105,7 @@
             <is_required>0</is_required>
             <is_searchable>1</is_searchable>
             <is_search_range>0</is_search_range>
-            <is_active>1</is_active>
+            <is_active>0</is_active>
             <is_view>1</is_view>
             <text_length>64</text_length>
             <note_columns>60</note_columns>

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -13,6 +13,39 @@
             <collapse_adv_display>0</collapse_adv_display>
             <is_reserved>0</is_reserved>
         </CustomGroup>
+        <CustomGroup>
+            <name>recurring_contribution_external_id</name>
+            <title>Recurring Contribution External ID</title>
+            <extends>ContributionRecur</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_contribution_recur_ext_id</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+        </CustomGroup>
+        <CustomGroup>
+            <name>contribution_external_id</name>
+            <title>Contribution External ID</title>
+            <extends>Contribution</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_contribution_ext_id</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+        </CustomGroup>
+        <CustomGroup>
+            <name>membership_external_id</name>
+            <title>Membership External ID</title>
+            <extends>Membership</extends>
+            <style>Inline</style>
+            <collapse_display>0</collapse_display>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_membership_ext_id</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+        </CustomGroup>
     </CustomGroups>
     <CustomFields>
         <CustomField>
@@ -31,6 +64,54 @@
             <column_name>optout_last_price_offline_autorenew</column_name>
             <custom_group_name>offline_autorenew_option</custom_group_name>
             <in_selector>1</in_selector>
+        </CustomField>
+        <CustomField>
+            <name>external_id</name>
+            <label>External ID</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>external_id</column_name>
+            <custom_group_name>recurring_contribution_external_id</custom_group_name>
+        </CustomField>
+        <CustomField>
+            <name>external_id</name>
+            <label>External ID</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>external_id</column_name>
+            <custom_group_name>contribution_external_id</custom_group_name>
+        </CustomField>
+        <CustomField>
+            <name>external_id</name>
+            <label>External ID</label>
+            <data_type>String</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>1</is_searchable>
+            <is_search_range>0</is_search_range>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>64</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>external_id</column_name>
+            <custom_group_name>membership_external_id</custom_group_name>
         </CustomField>
     </CustomFields>
 </CustomData>


### PR DESCRIPTION
This implements both parts of the ticket:
 1) creating custom fields to support External ID for all 4 entities. Custom fields definitions for Contribution, Recurring Contribution, Memberships are added to customField xml file ,  but for Line Item is done via API
 2) Additional requirements - adding unique constraint for  external ids  on install() and removing fields when extensions is uninstalled 
---
some notes:
- External ID custom fields were supposed to be inactive so both custom group and custom field have property is_active=0. Please advise if it is correct
- Line Item is added as option value to cg_extends_object, but not removed when extension is uninstalled. 