### PR TITLE
BASW-68: Ensure that Payment_Manual payment processors are used instaed of offline recurring contribution processor

### DIFF
--- a/CRM/MembershipExtras/Hook/PreEdit/Membership.php
+++ b/CRM/MembershipExtras/Hook/PreEdit/Membership.php
@@ -1,7 +1,5 @@
 <?php
 
-use CRM_MembershipExtras_PaymentProcessorType_ManualRecurringPayment as ManualRecurringPaymenProcessorType;
-
 /**
  * Called by membershipextras_civicrm_pre hook
  * before editing/renewing a membership
@@ -123,9 +121,9 @@ class CRM_MembershipExtras_Hook_PreEdit_Membership {
     $isFirstPaidInstallment = $completedInstallmentsCount === 1;
     $isTherePendingInstallments = $completedInstallmentsCount !== $installmentsCount;
 
-    $offlineRecurringProcessors = $this->getOfflineRecurringPaymentProcessors();
+    $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
     $isOfflineContribution = empty($recurringContribution['payment_processor_id']) ||
-      in_array($recurringContribution['payment_processor_id'], $offlineRecurringProcessors);
+      in_array($recurringContribution['payment_processor_id'], $manualPaymentProcessors);
 
     if ($isFirstPaidInstallment && $isOfflineContribution) {
       return FALSE;
@@ -145,27 +143,6 @@ class CRM_MembershipExtras_Hook_PreEdit_Membership {
     ]);
 
     return $pendingContributions['count'];
-  }
-
-  /**
-   * Gets the list of offline Recurring Payment Processors
-   *
-   * @return array
-   */
-  private function getOfflineRecurringPaymentProcessors() {
-    $offlineRecPaymentProcessors = civicrm_api3('PaymentProcessor', 'get', [
-      'sequential' => 1,
-      'payment_processor_type_id' => ManualRecurringPaymenProcessorType::NAME,
-    ]);
-
-    $recPaymentProcessors = [];
-    if (!empty($offlineRecPaymentProcessors['values'])) {
-      foreach ($offlineRecPaymentProcessors['values'] as $paymentProcessor) {
-        $recPaymentProcessors[] = $paymentProcessor['id'];
-      }
-    }
-
-    return $recPaymentProcessors;
   }
 
 }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -187,15 +187,16 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
     $cancelledStatusID = $getContributionStatusesNameMap['Cancelled'];
     $refundedStatusID = $getContributionStatusesNameMap['Refunded'];
 
-    $payLaterPaymentProcessors = new CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution();
-    $payLaterPaymentProcessorsIDs = implode(',', [0, $payLaterPaymentProcessors->get()['id']]);
+    $payLaterProcessorID = 0;
+    $manualPaymentProcessors = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
+    $manualPaymentProcessorsIDs = implode(',', $manualPaymentProcessors);
 
     $query = 'SELECT ccr.id as contribution_recur_id, ccr.installments  
               FROM civicrm_contribution_recur ccr 
               LEFT JOIN  civicrm_membership cm 
                 ON ccr.id = cm.contribution_recur_id 
               WHERE ccr.auto_renew = 1 
-                AND (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN (' . $payLaterPaymentProcessorsIDs . '))
+                AND (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN (' . $manualPaymentProcessorsIDs . '))
                 AND (ccr.contribution_status_id != ' . $cancelledStatusID . ' OR  ccr.contribution_status_id != ' . $refundedStatusID . ')
                 AND cm.end_date <= CURDATE() 
               GROUP BY ccr.id';

--- a/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
+++ b/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
@@ -1,0 +1,27 @@
+<?php
+
+class CRM_MembershipExtras_Service_ManualPaymentProcessors {
+
+
+  /**
+   * Gets the list of Payment Processors
+   * that use 'Payment_Manual' class.
+   *
+   * @return array
+   */
+  public static function getIDs() {
+    $manualPaymentProcessors = civicrm_api3('PaymentProcessor', 'get', [
+      'sequential' => 1,
+      'class_name' => 'Payment_Manual',
+      'options' => ['limit' => 0],
+    ])['values'];
+
+    $manualPaymentProcessorsList = [];
+    foreach ($manualPaymentProcessors as $paymentProcessor) {
+      $manualPaymentProcessorsList[] = $paymentProcessor['id'];
+    }
+
+    return $manualPaymentProcessorsList;
+  }
+
+}


### PR DESCRIPTION
We where using 'Offline Recurring Contribution' payment processor for the scheduled job code to identify offline payment plan payments as well as in some other places, but we should use any payment processor with class name = 'Payment_Manual' instead which I fixed in this PR.