### PR TITLE
BASW-90: Fixing line item amounts and membership end date when renewing memberships

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
@@ -1,0 +1,39 @@
+<?php
+
+class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
+
+  /**
+   * Calculates the membership new end date
+   * for renewal.
+   *
+   * @param int $membershipId
+   *
+   * @return string
+   */
+  public static function calculate($membershipId) {
+    $membershipDetails = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'return' => ['end_date', 'membership_type_id.duration_unit', 'membership_type_id.duration_interval'],
+      'id' => $membershipId,
+    ])['values'][0];
+
+    $currentEndDate = new DateTime($membershipDetails['end_date']);
+
+    switch ($membershipDetails['membership_type_id.duration_unit']) {
+      case 'month':
+        $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] . 'M';
+        break;
+      case 'day':
+        $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] .'D';
+        break;
+      case 'year':
+        $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] .'Y';
+        break;
+    }
+
+    $currentEndDate->add(new DateInterval($interval));
+    $newEndDate = $currentEndDate->format('Ymd');
+    return $newEndDate;
+  }
+
+}


### PR DESCRIPTION
## Before
When renewing a membership using "payment plan" option and selecting the payment status as "pending", the line item amounts will not be correct and the membership will not get extended.

The membership extending part is how civicrm core work, it does not extend the membership unless u complete the related membership payment but still for this extension we should extend it when paying via payment plan. The extending should be similar to how it work in offline renewal scheduled job.

![111111](https://user-images.githubusercontent.com/6275540/40110967-4b0544e8-58f9-11e8-9d5c-4f3e4bda5997.gif)


## After

Now the line items amounts are correct and the membership get extended as soon as u submit the renewal form.

![sssss](https://user-images.githubusercontent.com/6275540/40111006-6e791c56-58f9-11e8-9aa0-06ef1247f8bf.gif)


## Technical notes 

- The logic that calculates the end date for extending the membership is moved to a new class called : **CRM_MembershipExtras_Service_MembershipEndDateCalculator** , this class is now used in hooks when renewing the membership and for offline renewal scheduled job.

- The extending at renewal only work for payment plan payments and only when the payment status is "pending"

- The reason for line item amount problem, is that the financial item creation order is different from membership creation. For example at membership creation, the MembershipPayment record is created before LineItem record, but for renewal the MembershipPayment is created after the LineItem, So the logic implemented in pre hook is not valid anymore since it was depend on the membership creation order and I had to change it so it does not care about MembershipPayment  record anymore.

