### PR TITLE
BASW-21: Fixing several issues in the extension

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
@@ -112,7 +112,10 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
     $this->params['contribution_recur_id'] =  $this->recurringContribution['id'];
     $this->params['total_amount'] =  $this->recurringContribution['amount'];
     $this->params['net_amount'] =  $this->recurringContribution['amount'];
-    $this->params['tax_amount'] = $this->calculateSingleInstallmentAmount($this->params['tax_amount']);
+
+    if (!empty($this->params['tax_amount'])) {
+      $this->params['tax_amount'] = $this->calculateSingleInstallmentAmount($this->params['tax_amount']);
+    }
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -284,7 +284,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
         $entityID = 'null';
       }
 
-      $lineItemsList[] = [
+      $lineItemParams = [
         'entity_table' => $lineItem['entity_table'],
         'entity_id' => $entityID,
         'contribution_id' => 'null',
@@ -296,8 +296,13 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
         'price_field_value_id' => $lineItem['price_field_value_id'],
         'financial_type_id' => $lineItem['financial_type_id'],
         'non_deductible_amount' => $lineItem['non_deductible_amount'],
-        'tax_amount' => $taxAmount,
       ];
+
+      if (!empty($taxAmount)) {
+        $lineItemParams['tax_amount'] = $taxAmount;
+      }
+
+      $lineItemsList[] = $lineItemParams;
     }
 
     $this->lineItems = $lineItemsList;
@@ -508,10 +513,13 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
       'is_test' => $this->lastContribution['is_test'],
       'contribution_status_id' => $this->contributionPendingStatusValue,
       'is_pay_later' => TRUE,
-      'tax_amount' => $this->totalTaxAmount,
       'skipLineItem' => 1,
       'contribution_recur_id' => $this->currentRecurContributionID,
     ];
+
+    if (!empty($this->totalTaxAmount)) {
+      $params['tax_amount'] = $this->totalTaxAmount;
+    }
 
     if (!empty($this->lastContribution['soft_credit'])) {
       $params['soft_credit'] = $this->lastContribution['soft_credit'];

--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -182,10 +182,13 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       'is_test' => $this->lastContribution['is_test'],
       'contribution_status_id' => $this->contributionPendingStatusValue,
       'is_pay_later' => TRUE,
-      'tax_amount' => $this->lastContribution['tax_amount'],
       'skipLineItem' => 1,
       'contribution_recur_id' => $this->currentRecurContribution['id'],
     ];
+
+    if (!empty($this->lastContribution['tax_amount'])) {
+      $params['tax_amount'] = $this->lastContribution['tax_amount'];
+    }
 
     if (!empty($this->lastContribution['soft_credit'])) {
       $params['soft_credit'] = $this->lastContribution['soft_credit'];
@@ -225,8 +228,10 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
         'price_field_value_id' => CRM_Utils_Array::value('price_field_value_id', $lineItem),
         'financial_type_id' => $lineItem['financial_type_id'],
         'non_deductible_amount' => $lineItem['non_deductible_amount'],
-        'tax_amount' => CRM_Utils_Array::value('tax_amount', $lineItem, 0),
       ];
+      if (!empty($lineItem['tax_amount'])) {
+        $lineItemParms['tax_amount'] = $lineItem['tax_amount'];
+      }
       $newLineItem = CRM_Price_BAO_LineItem::create($lineItemParms);
 
       CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution);


### PR DESCRIPTION
This PR fixes several small issues in the extension : 

1- IF there is no tax amount, a tax amount = 0 will appear in the contribution line item screen, but it is wrong and nothing should appear : 

### Before

![2222](https://user-images.githubusercontent.com/6275540/40115550-c4df2b08-5908-11e8-81c9-01e9bb3440ac.gif)


### After

![3333333](https://user-images.githubusercontent.com/6275540/40115571-d825a098-5908-11e8-8c42-e880b4fc9813.gif)


2- 