### PR TITLE
BASW-113: Cancel Existing Payment Plan

### DIFF
--- a/CRM/MembershipExtras/Form/CancelRecurringContribution.php
+++ b/CRM/MembershipExtras/Form/CancelRecurringContribution.php
@@ -108,7 +108,9 @@ class CRM_MembershipExtras_Form_CancelRecurringContribution extends CRM_Core_For
       'options' => ['limit' => 0],
       'api.Contribution.create' => array(
         'id' => '$value.id',
-        'contribution_status_id' => 'Cancelled'
+        'contribution_status_id' => 'Cancelled',
+        'cancel_date' => date('Y-m-d H:i:s'),
+        'cancel_reason' => 'Cancelled because related recurring contribution was cancelled.',
       ),
     ]);
   }

--- a/CRM/MembershipExtras/Form/CancelRecurringContribution.php
+++ b/CRM/MembershipExtras/Form/CancelRecurringContribution.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * QuickForm used to cancel memberships.
+ */
+class CRM_MembershipExtras_Form_CancelRecurringContribution extends CRM_Core_Form {
+
+  /**
+   * ID of recurring contribution to be cancelled.
+   *
+   * @var int
+   */
+  private $id;
+
+  /**
+   * ID of contact from where contributions is being cancellsd.
+   *
+   * @var int
+   */
+  private $contactID;
+
+  /**
+   * @inheritdoc
+   */
+  public function preProcess() {
+    $this->id = CRM_Utils_Request::retrieve('crid', 'Positive', $this);
+    $this->contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Payment Plan Settings'));
+
+    $this->add(
+      'checkbox',
+      'cancel_pending_installments',
+      ts('Do you wish to cancel any pending instalment contribution?'),
+      '',
+      FALSE
+    );
+
+    $this->add(
+      'checkbox',
+      'cancel_memberships',
+      ts('Do you wish to cancel any linked membership?'),
+      '',
+      FALSE
+    );
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => ts('Yes'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('No'),
+      ],
+    ]);
+  }
+
+  /**
+   * @@inheritdoc
+   */
+  public function postProcess() {
+    $submittedValues = $this->controller->exportValues($this->_name);
+
+    if ($submittedValues['cancel_memberships']) {
+      $this->cancelMemberships();
+    }
+
+    if ($submittedValues['cancel_pending_installments']) {
+      $this->cancelPendingInstallments();
+    }
+
+    $this->cancelRecurringContribution();
+  }
+
+  /**
+   * Cancels memberships being payed for with the current recurring
+   * contribution.
+   */
+  private function cancelMemberships() {
+    civicrm_api3('MembershipPayment', 'get', [
+      'sequential' => 1,
+      'contribution_id.contribution_recur_id.id' => $this->id,
+      'options' => ['limit' => 0],
+      'api.Membership.create' => [
+        'id' => '$value.membership_id',
+        'is_override' => 1,
+        'status_id' => 'Cancelled',
+      ],
+    ]);
+  }
+
+  /**
+   * Cancels pending contributions associated to current recurring contribution.
+   */
+  private function cancelPendingInstallments() {
+    civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->id,
+      'contact_id' => $this->contactId,
+      'contribution_status_id' => 'Pending',
+      'options' => ['limit' => 0],
+      'api.Contribution.create' => array(
+        'id' => '$value.id',
+        'contribution_status_id' => 'Cancelled'
+      ),
+    ]);
+  }
+
+  /**
+   * Cancels current recurring contribution.
+   */
+  private function cancelRecurringContribution() {
+    civicrm_api3('ContributionRecur', 'cancel', array(
+      'id' => $this->id,
+    ));
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Alters action links for recurring contributions.
+ */
+class CRM_MembershipExtras_Hook_Links_RecurringContribution {
+
+  /**
+   * Alters 'Cancel' action link to use a custom form, instead of CiviCRM's
+   * default enable/disable weird control.
+   *
+   * @param array $links
+   */
+  public function alterLinks(&$links) {
+    foreach ($links as &$actionLink) {
+      if ($actionLink['name'] == 'Cancel') {
+        unset($actionLink['ref']);
+        $actionLink['url'] = 'civicrm/recurring-contribution/cancel';
+        $actionLink['qs'] = 'reset=1&crid=%%crid%%&cid=%%cid%%&context=contribution';
+      }
+    }
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -5,14 +5,24 @@
  */
 class CRM_MembershipExtras_Hook_Links_RecurringContribution {
 
+  private $links;
+
+  /**
+   * CRM_MembershipExtras_Hook_Links_RecurringContribution constructor.
+   *
+   * @param array $links
+   *   Array with the action links for the recurring contribution
+   */
+  public function __construct(&$links) {
+    $this->links = &$links;
+  }
+
   /**
    * Alters 'Cancel' action link to use a custom form, instead of CiviCRM's
    * default enable/disable weird control.
-   *
-   * @param array $links
    */
-  public function alterLinks(&$links) {
-    foreach ($links as &$actionLink) {
+  public function alterLinks() {
+    foreach ($this->links as &$actionLink) {
       if ($actionLink['name'] == 'Cancel') {
         unset($actionLink['ref']);
         $actionLink['url'] = 'civicrm/recurring-contribution/cancel';

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -262,7 +262,7 @@ function membershipextras_civicrm_alterCalculatedMembershipStatus(&$calculatedSt
  */
 function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
   if ($op == 'contribution.selector.recurring' && $objectName == 'Contribution') {
-    $recurContribuLinksHook = new CRM_MembershipExtras_Hook_Links_RecurringContribution();
-    $recurContribuLinksHook->alterLinks($links);
+    $recurContribuLinksHook = new CRM_MembershipExtras_Hook_Links_RecurringContribution($links);
+    $recurContribuLinksHook->alterLinks();
   }
 }

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -256,3 +256,13 @@ function membershipextras_civicrm_alterCalculatedMembershipStatus(&$calculatedSt
   $alterMembershipStatusHook = new CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus();
   $alterMembershipStatusHook->alterMembershipStatus($calculatedStatus, $arguments, $membership);
 }
+
+/**
+ * Implements hook_civicrm_links()
+ */
+function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
+  if ($op == 'contribution.selector.recurring' && $objectName == 'Contribution') {
+    $recurContribuLinksHook = new CRM_MembershipExtras_Hook_Links_RecurringContribution();
+    //$recurContribuLinksHook->alterLinks($links);
+  }
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -263,6 +263,6 @@ function membershipextras_civicrm_alterCalculatedMembershipStatus(&$calculatedSt
 function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
   if ($op == 'contribution.selector.recurring' && $objectName == 'Contribution') {
     $recurContribuLinksHook = new CRM_MembershipExtras_Hook_Links_RecurringContribution();
-    //$recurContribuLinksHook->alterLinks($links);
+    $recurContribuLinksHook->alterLinks($links);
   }
 }

--- a/templates/CRM/MembershipExtras/Form/CancelRecurringContribution.tpl
+++ b/templates/CRM/MembershipExtras/Form/CancelRecurringContribution.tpl
@@ -1,0 +1,22 @@
+Are you sure you want to mark this recurring contribution as cancelled?
+<br><br>
+<strong>
+  WARNING - This action sets the CiviCRM recurring contribution status to
+  Cancelled, but does NOT send a cancellation request to the payment
+  processor. You will need to ensure that this recurring payment
+  (subscription) is cancelled by the payment processor.
+</strong>
+<br><br>
+<div class="crm-section">
+  <div class="label">{$form.cancel_pending_installments.label}</div>
+  <div class="content">{$form.cancel_pending_installments.html}</div>
+  <div class="clear"></div>
+</div>
+<div class="crm-section">
+  <div class="label">{$form.cancel_memberships.label}</div>
+  <div class="content">{$form.cancel_memberships.html}</div>
+  <div class="clear"></div>
+</div>
+<div class="crm-submit-buttons">
+  {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -6,4 +6,10 @@
     <title>Payment Plan Settings</title>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/recurring-contribution/cancel</path>
+    <page_callback>CRM_MembershipExtras_Form_CancelRecurringContribution</page_callback>
+    <title>Cancel Recurring Contribution</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
When cancelling a recurring contribution, a popup will show up and ask for confirmation. A new dialog box containing two checkbox options should be used to replace the popup.

The first checkbox is "Do you wish to cancel any pending instalment contribution?" which if checked and confirmed, as a result, all "Pending" contributions that are linked to the recurring contribution will also be cancelled.

The second checkbox is "Do you wish to cancel any linked membership?" which if checked and confirmed, as a result, all memberships that are linked to the recurring contribution will also be cancelled.

## Before
Enable/Disable CiviCRM Page was being used to handle recurring contribution cancellation.

![image](https://user-images.githubusercontent.com/21999940/40118305-3033e60c-58df-11e8-879f-68584af2dba5.png)

## After
Altered the cancellation link on recurring contributions list so it uses a new form, with the required checkboxes. If they are clicked, pending contributions and/or related memberships are cancelled too.

![image](https://user-images.githubusercontent.com/21999940/40118376-6233be3e-58df-11e8-8556-2f8fc1694cbd.png)
