### PR TITLE
BASW-92: Adding (Days to renew in advance) setting

### DIFF
--- a/CRM/MembershipExtras/PaymentProcessor/OfflineRecurringContribution.php
+++ b/CRM/MembershipExtras/PaymentProcessor/OfflineRecurringContribution.php
@@ -42,11 +42,9 @@ class CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution {
 
     $paymentProcessor = civicrm_api3('PaymentProcessor', 'create', $params);
 
-    civicrm_api3(
-      'setting',
-      'create',
-      ['membershipextras_paymentplan_default_processor' => $paymentProcessor['values'][0]]['id']
-    );
+    civicrm_api3('setting', 'create',[
+      'membershipextras_paymentplan_default_processor' => $paymentProcessor['values'][0]['id'],
+    ]);
 
     return $paymentProcessor['values'][0];
   }

--- a/CRM/MembershipExtras/SettingsManager.php
+++ b/CRM/MembershipExtras/SettingsManager.php
@@ -9,15 +9,32 @@ class CRM_MembershipExtras_SettingsManager {
    * Returns the details of the default payment processor as per payment plan
    * settings, or NULL if it does not exist.
    *
-   * @return array
+   * @return int
    */
   public static function getDefaultProcessorID() {
-    $defaultPaymentProcessorID = civicrm_api3('Setting', 'get', array(
-      'sequential' => 1,
-      'return' => array('membershipextras_paymentplan_default_processor'),
-    ))['values'][0]['membershipextras_paymentplan_default_processor'];
+    return self::getSettingValue('membershipextras_paymentplan_default_processor');
+  }
 
-    return $defaultPaymentProcessorID;
+  /**
+   * Returns the 'days to renew in advance'
+   * setting.
+   *
+   * @return int
+   */
+  public static function getDaysToRenewInAdvance() {
+    $daysToRenewInAdvance = self::getSettingValue('membershipextras_paymentplan_days_to_renew_in_advance');
+    if (empty($daysToRenewInAdvance)) {
+      $daysToRenewInAdvance = 0;
+    }
+
+    return $daysToRenewInAdvance;
+  }
+
+  private static function getSettingValue($settingName) {
+    return civicrm_api3('Setting', 'get', [
+      'sequential' => 1,
+      'return' => [$settingName],
+    ])['values'][0][$settingName];
   }
 
 }

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -31,4 +31,17 @@ return [
     'description' => 'Select the payment processor that should be used when creating payment plans via CiviCRM admin interface such as new/ renew membership.',
     'help_text' => 'Select the payment processor that should be used when creating payment plans via CiviCRM admin interface such as new/ renew membership.',
   ],
+  'membershipextras_paymentplan_days_to_renew_in_advance' => [
+    'name' => 'membershipextras_paymentplan_days_to_renew_in_advance',
+    'group_name' => 'MembershipExtras: Payment Plan',
+    'group' => 'membershipextras_paymentplan',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'add' => '4.7',
+    'title' => 'Days to renew in advance',
+    'html_type' => 'text',
+    'is_required' => FALSE,
+    'description' => 'Number of days in advance of membership end date should an offline auto-renew membership get renewed.',
+    'help_text' => 'Number of days in advance of membership end date should an offline auto-renew membership get renewed.',
+  ],
 ];

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
@@ -15,3 +15,9 @@
     with the same price as the last membership.{/ts}
 {/htxt}
 
+{htxt id="membershipextras_paymentplan_days_to_renew_in_advance-title"}
+{ts}Days to renew in advance{/ts}
+{/htxt}
+{htxt id="membershipextras_paymentplan_days_to_renew_in_advance"}
+{ts}Number of days in advance of membership end date should an offline auto-renew membership get renewed.{/ts}
+{/htxt}


### PR DESCRIPTION
## Requirements 

A new option called "Days to renew in advance" with help text "Number of days in advance of membership end date should an offline auto-renew membership get renewed." should be added to  "payment plan settings" Form.

 If this field is not 0 or NULL, the "renew offline membership" scheduled job should renew memberships for a number of days specified in this setting in advance of its end date.


## Solution 

Here is the new setting in settings page : 

![111111](https://user-images.githubusercontent.com/6275540/40192691-05a271d2-59fd-11e8-86f0-fccc8fd8a6e5.gif)


And here is an example of it : 

![2nddd](https://user-images.githubusercontent.com/6275540/40192748-31c22348-59fd-11e8-9ae2-0818962161e2.gif)


In the example above, (Today Date = 17-5-2018) where (Membership End Date = 20-5-2018), and ("Days to renew in advance" = 2) so running the auto-renewal scheduled job does not auto-renew the membership since (20-5-2018 minus two days = 18-5-2018). But when I changed the ("Days to renew in advance" ) to 3, (20-5-2018 minus three days = 17-5-2018). which is equal or less than today date so it get autorenewed as u can see in the gif.


## Techincal notes

Nothing special done here, the new setting field is added to the list of the settings and a method to retrieve its value is added to the SettingsManager class. The scheduled job query is changed to use this : 

`civicrm_membership.end_date <= DATE_ADD(CURDATE(), INTERVAL ' . $daysToRenewInAdvance . ' DAY`

instead of just  : 

`civicrm_membership.end_date <= CURDATE()`