### PR TITLE
BASW-90: Fix Membership Creation and Renewal Forms Validation

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
@@ -39,6 +39,11 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
    * fields when renewing or creating memberships.
    */
   public function validate() {
+    $installmentsCount = CRM_Utils_Array::value('installments', $this->fields);
+    if (empty($installmentsCount)) {
+      $this->errors['installments'] = ts('"Installments" is a required field');
+    }
+
     $installmentsFrequency = CRM_Utils_Array::value('installments_frequency', $this->fields);
     if (empty($installmentsFrequency)) {
       $this->errors['installments_frequency'] = ts('"Installments Frequency" is a required field');
@@ -49,4 +54,5 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
       $this->errors['installments_frequency_unit'] = ts('"Installments Frequency Unit" is a required field');
     }
   }
+
 }

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -104,12 +104,14 @@
     </td>
   </tr>
   <tr id="installments_row">
-    <td nowrap>{$form.installments.label}</td>
+    <td nowrap>
+      {$form.installments.label} <span class="marker">*</span>
+    </td>
     <td nowrap>
       {$form.installments.html}
-      {$form.installments_frequency.label}
+      {$form.installments_frequency.label} <span class="marker">*</span>
       {$form.installments_frequency.html}
-      {$form.installments_frequency_unit.html}
+      {$form.installments_frequency_unit.html} <span class="marker">*</span>
     </td>
   </tr>
   <tr id="first_installment">


### PR DESCRIPTION
## Overview
By default, payment plan fields are set as Number of Instalments = 12, Interval=1 , Unit = month now. But if someone removes the Number of Instalments and Interval fields and save there is no validation. Also, there should be a red asterisk next to both fields, so it is clear both are required.

## Before
Validation was not being executed for for empty installments and frequencies. There was no visual marker that obviously stated the payment plan fields were required.

## After
Validation was only run if number of installments was > 1. Renamed method that checked if a payment plan is being used so it is clear it also validates if more than one contribution is being used to pay. Added validation of number of installments. Added red *'s to show fields 'installments', 'installments_frequency', and 'installments_frequency_unit' are required.