### PR TITLE
BASW-118: Update Installments on Recurring Contribution Update

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipOfflineAutoRenew.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipOfflineAutoRenew.php
@@ -9,13 +9,13 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipOfflineAutoRenew {
    * @var string
    *   Path where the template for the auto renew section is soted.
    */
-  protected $templatePath;
+  private $templatePath;
 
   /**
    * @var \CRM_Member_Form
    *   Form object that is being altered.
    */
-  protected $form;
+  private $form;
 
   /**
    * CRM_MembershipExtras_Hook_BuildForm_Membership constructor.

--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipOfflineAutoRenew.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipOfflineAutoRenew.php
@@ -9,13 +9,13 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipOfflineAutoRenew {
    * @var string
    *   Path where the template for the auto renew section is soted.
    */
-  private $templatePath;
+  protected $templatePath;
 
   /**
    * @var \CRM_Member_Form
    *   Form object that is being altered.
    */
-  private $form;
+  protected $form;
 
   /**
    * CRM_MembershipExtras_Hook_BuildForm_Membership constructor.

--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Alters UpdateSubscription form.
+ */
+class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
+
+  private $form;
+  private $templatePath;
+  private $recurringContribution;
+
+  public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
+    $this->form = $form;
+    $this->templatePath = CRM_MembershipExtras_ExtensionUtil::path() . '/templates';
+    $this->loadRecurringContributionData();
+  }
+
+  /**
+   * Loads data for the current recurring contribution.
+   */
+  private function loadRecurringContributionData() {
+    $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, FALSE);
+
+    $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $recurringContributionID,
+    ])['values'][0];
+  }
+
+  /**
+   * Implements modifications to UpdateSubscription form.
+   */
+  public function buildForm() {
+    if ($this->isManualPaymentPlan()) {
+      $amount = $this->form->getElement('amount');
+      $amount->setAttribute('readonly', true);
+
+      $installments = $this->form->getElement('installments');
+      $installments->setAttribute('readonly', true);
+
+      $this->form->add('checkbox', 'auto_renew', ts('Auto-renew?'));
+      $this->form->setDefaults(['auto_renew' => $this->recurringContribution['auto_renew']]);
+
+      $this->form->add('select', 'payment_instrument_id',
+        ts('Payment Method'),
+        ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::paymentInstrument(),
+        TRUE
+      );
+      $this->form->setDefaults(['payment_instrument_id' => $this->recurringContribution['payment_instrument_id']]);
+      $this->form->assign('isBackOffice', 1);
+
+      $this->form->add('text', 'cycle_day', ts('Cycle Day'), TRUE);
+      $this->form->setDefaults(['cycle_day' => $this->recurringContribution['cycle_day']]);
+
+      CRM_Core_Region::instance('page-body')->add([
+        'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl"
+      ]);
+
+      $this->form->addButtons([
+        [
+          'type' => 'upload',
+          'name' => ts('Confirm'),
+          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+          'isDefault' => TRUE,
+          'js' => ['onclick' => "return processUpdate(this,'" . $this->form->getName() . "','" . ts('Processing') . "');"],
+        ],
+        [
+          'type' => 'cancel',
+          'name' => ts('Cancel'),
+        ],
+      ]);
+    }
+  }
+
+  /**
+   * Checks if recurring contribution is using manual pyment processor.
+   */
+  private function isManualPaymentPlan() {
+    // TODO!!!!
+
+    return true;
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -12,15 +12,8 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
   public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
     $this->form = $form;
     $this->templatePath = CRM_MembershipExtras_ExtensionUtil::path() . '/templates';
-    $this->loadRecurringContributionData();
-  }
 
-  /**
-   * Loads data for the current recurring contribution.
-   */
-  private function loadRecurringContributionData() {
     $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, FALSE);
-
     $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,
       'id' => $recurringContributionID,
@@ -31,54 +24,62 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
    * Implements modifications to UpdateSubscription form.
    */
   public function buildForm() {
-    if ($this->isManualPaymentPlan()) {
-      $amount = $this->form->getElement('amount');
-      $amount->setAttribute('readonly', true);
-
-      $installments = $this->form->getElement('installments');
-      $installments->setAttribute('readonly', true);
-
-      $this->form->add('checkbox', 'auto_renew', ts('Auto-renew?'));
-      $this->form->setDefaults(['auto_renew' => $this->recurringContribution['auto_renew']]);
-
-      $this->form->add('select', 'payment_instrument_id',
-        ts('Payment Method'),
-        ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::paymentInstrument(),
-        TRUE
-      );
-      $this->form->setDefaults(['payment_instrument_id' => $this->recurringContribution['payment_instrument_id']]);
-      $this->form->assign('isBackOffice', 1);
-
-      $this->form->add('text', 'cycle_day', ts('Cycle Day'), TRUE);
-      $this->form->setDefaults(['cycle_day' => $this->recurringContribution['cycle_day']]);
-
-      CRM_Core_Region::instance('page-body')->add([
-        'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl"
-      ]);
-
-      $this->form->addButtons([
-        [
-          'type' => 'upload',
-          'name' => ts('Confirm'),
-          'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-          'isDefault' => TRUE,
-          'js' => ['onclick' => "return processUpdate(this,'" . $this->form->getName() . "','" . ts('Processing') . "');"],
-        ],
-        [
-          'type' => 'cancel',
-          'name' => ts('Cancel'),
-        ],
-      ]);
+    if (!$this->isManualPaymentPlan()) {
+      return;
     }
+
+    $amount = $this->form->getElement('amount');
+    $amount->setAttribute('readonly', true);
+
+    $installments = $this->form->getElement('installments');
+    $installments->setAttribute('readonly', true);
+
+    $this->form->add('checkbox', 'auto_renew', ts('Auto-renew?'));
+    $this->form->setDefaults(['auto_renew' => $this->recurringContribution['auto_renew']]);
+
+    $this->form->add('select', 'payment_instrument_id',
+      ts('Payment Method'),
+      ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::paymentInstrument(),
+      TRUE
+    );
+    $this->form->setDefaults(['payment_instrument_id' => $this->recurringContribution['payment_instrument_id']]);
+    $this->form->assign('isBackOffice', 1);
+
+    $this->form->add('text', 'cycle_day', ts('Cycle Day'), TRUE);
+    $this->form->setDefaults(['cycle_day' => $this->recurringContribution['cycle_day']]);
+
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl"
+    ]);
+
+    $this->form->addButtons([
+      [
+        'type' => 'upload',
+        'name' => ts('Confirm'),
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,
+        'js' => ['onclick' => "return processUpdate(this,'" . $this->form->getName() . "','" . ts('Processing') . "');"],
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
   }
 
   /**
-   * Checks if recurring contribution is using manual pyment processor.
+   * Checks if recurring contribution is using manual payment processor.
    */
   private function isManualPaymentPlan() {
-    // TODO!!!!
+    $paymentProcessorID = $this->recurringContribution['payment_processor_id'];
+    $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
+    $isOfflineContribution = in_array($paymentProcessorID, $manualPaymentProcessors);
 
-    return true;
+    if ($isOfflineContribution || empty($paymentProcessorID)) {
+      return true;
+    }
+
+    return false;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -5,15 +5,39 @@
  */
 class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
 
+  /**
+   * Form that needs to be altered.
+   *
+   * @var \CRM_Contribute_Form_UpdateSubscription
+   */
   private $form;
+
+  /**
+   * Path to where extension templates are physically stored.
+   *
+   * @var string
+   */
   private $templatePath;
+
+  /**
+   * Array with the data of the recurring contribution that is being updated.
+   *
+   * @var array
+   */
   private $recurringContribution;
 
   public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
     $this->form = $form;
     $this->templatePath = CRM_MembershipExtras_ExtensionUtil::path() . '/templates';
+    $this->loadRecurringContribution();
+  }
 
-    $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, FALSE);
+  /**
+   * Loads data for recurring contribution identified by 'crid' parameter in
+   * http request.
+   */
+  private function loadRecurringContribution() {
+    $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
     $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,
       'id' => $recurringContributionID,

--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -29,14 +29,14 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
   public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
     $this->form = $form;
     $this->templatePath = CRM_MembershipExtras_ExtensionUtil::path() . '/templates';
-    $this->loadRecurringContribution();
+    $this->setRecurringContribution();
   }
 
   /**
    * Loads data for recurring contribution identified by 'crid' parameter in
    * http request.
    */
-  private function loadRecurringContribution() {
+  private function setRecurringContribution() {
     $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
     $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -30,14 +30,14 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
 
   public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
     $this->form = $form;
-    $this->loadRecurringContribution();
+    $this->setRecurringContribution();
   }
 
   /**
    * Loads data for recurring contribution identified by 'crid' parameter in
    * http request.
    */
-  private function loadRecurringContribution() {
+  private function setRecurringContribution() {
     $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
     $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -14,52 +14,92 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
    */
   private $form;
 
+  /**
+   * Array with the data of the recurring contribution that is being updated.
+   *
+   * @var array
+   */
+  private $recurringContribution;
+
+  /**
+   * Object that calcuates installment receive date.
+   *
+   * @var CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
+   */
+  private $receiveDateCalculator;
+
   public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
     $this->form = $form;
-    $this->recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
-    $this->recurringContribution = civicrm_api3('ContributionRecur', 'getsingle', [
-      'id' => $this->recurringContributionID
-    ]);
-    $this->receiveDateCalculator = new InstallmentReceiveDateCalculator($this->recurringContribution);
+    $this->loadRecurringContribution();
   }
 
   /**
-   * Postprocesses CRM_Contribute_Form_UpdateSubscription to deal with added
+   * Loads data for recurring contribution identified by 'crid' parameter in
+   * http request.
+   */
+  private function loadRecurringContribution() {
+    $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
+    $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $recurringContributionID,
+    ])['values'][0];
+  }
+
+  /**
+   * Post-processes CRM_Contribute_Form_UpdateSubscription to deal with added
    * fields.
    */
   public function postProcess() {
     $updateInstallments = CRM_Utils_Request::retrieve('update_installments', 'Integer', $this->form, FALSE);
+    $contributions = $this->getContributions();
 
-    if ($updateInstallments == '1') {
-      $params = $this->form->exportValues();
-      $contributions = civicrm_api3('Contribution', 'get', [
-        'sequential' => 1,
-        'contribution_recur_id' => $this->recurringContributionID,
-        'options' => ['limit' => 0, 'sort' => 'receive_date ASC'],
-      ]);
-      $newFirstInstallmentReceiveDate = $this->calculateFirstReceiveDate(
-        $contributions['values'][0]['receive_date'],
-        $params['cycle_day']
-      );
-
-      $this->receiveDateCalculator->setStartDate($newFirstInstallmentReceiveDate);
-      $installmentCount = 0;
-
-      foreach ($contributions['values'] as $payment) {
-        $installmentCount++;
-
-        if ($payment['contribution_status'] != 'Pending') {
-          continue;
-        }
-
-        $receiveDate = $this->receiveDateCalculator->calculate($installmentCount);
-        civicrm_api3('Contribution', 'create', [
-          'id' => $payment['id'],
-          'payment_instrument_id' => $params['payment_instrument_id'],
-          'receive_date' => $receiveDate,
-        ]);
-      }
+    if (!$updateInstallments || count($contributions) < 1) {
+      return;
     }
+
+    $formValues = $this->form->exportValues();
+    $newFirstInstallmentReceiveDate = $this->calculateFirstReceiveDate(
+      $contributions[0]['receive_date'],
+      $formValues['cycle_day']
+    );
+
+    $installmentCount = 0;
+    $this->receiveDateCalculator = new InstallmentReceiveDateCalculator($this->recurringContribution);
+    $this->receiveDateCalculator->setStartDate($newFirstInstallmentReceiveDate);
+
+    foreach ($contributions as $payment) {
+      $installmentCount++;
+
+      if ($payment['contribution_status'] != 'Pending') {
+        continue;
+      }
+
+      $this->updateContribution(
+        $payment['id'],
+        $formValues['payment_instrument_id'],
+        $installmentCount
+      );
+    }
+  }
+
+  /**
+   * Returns list of contributions associated to current recurring contribution.
+   *
+   * @return array
+   */
+  private function getContributions() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'options' => ['limit' => 0, 'sort' => 'receive_date ASC'],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+    return array();
   }
 
   /**
@@ -87,6 +127,57 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
     }
 
     return $date->format('Y-m-d H:i:s');
+  }
+
+  /**
+   * Respectively updates receive date and/or payment instrument if either of
+   * those were modified for the current recurring contribution.
+   *
+   * @param int $contributionID
+   * @param int $instrumentID
+   * @param int $installmentNumber
+   */
+  private function updateContribution($contributionID, $instrumentID, $installmentNumber) {
+    $params = [];
+
+    if ($this->isUpdatedCycleDate()) {
+      $params['receive_date'] = $this->receiveDateCalculator->calculate($installmentNumber);
+    }
+
+    if ($this->isUpdatedPaymentInstrument()) {
+      $params['payment_instrument_id'] = $instrumentID;
+    }
+
+    if (!empty($params)) {
+      $params['id'] = $contributionID;
+      civicrm_api3('Contribution', 'create', $params);
+    }
+  }
+
+  /**
+   * Checks if cycle date was updated by user.
+   *
+   * @return bool
+   *   True if the value was changed by user, false otherwise.
+   */
+  private function isUpdatedCycleDate() {
+    $formValues = $this->form->exportValues();
+    $oldCycleDay = CRM_Utils_Request::retrieve('old_cycle_day', 'Integer', $this->form, TRUE);
+
+    return $formValues['cycle_day'] != $oldCycleDay;
+  }
+
+  /**
+   * Checks if payment instrument was updated by user.
+   *
+   * @return bool
+   *   True if the value was changed by user, false otherwise.
+   */
+  private function isUpdatedPaymentInstrument() {
+    $formValues = $this->form->exportValues();
+    $oldPaymentInstrument = CRM_Utils_Request::retrieve('old_payment_instrument_id', 'Integer', $this->form, TRUE);
+
+    return $formValues['cycle_day'] != $oldPaymentInstrument;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -1,0 +1,92 @@
+<?php
+
+use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as InstallmentReceiveDateCalculator;
+
+/**
+ * Post-processes Recurring Conribution Update form.
+ */
+class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
+
+  /**
+   * Form to be processed.
+   *
+   * @var \CRM_Contribute_Form_UpdateSubscription
+   */
+  private $form;
+
+  public function __construct(CRM_Contribute_Form_UpdateSubscription $form) {
+    $this->form = $form;
+    $this->recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
+    $this->recurringContribution = civicrm_api3('ContributionRecur', 'getsingle', [
+      'id' => $this->recurringContributionID
+    ]);
+    $this->receiveDateCalculator = new InstallmentReceiveDateCalculator($this->recurringContribution);
+  }
+
+  /**
+   * Postprocesses CRM_Contribute_Form_UpdateSubscription to deal with added
+   * fields.
+   */
+  public function postProcess() {
+    $updateInstallments = CRM_Utils_Request::retrieve('update_installments', 'Integer', $this->form, FALSE);
+
+    if ($updateInstallments == '1') {
+      $params = $this->form->exportValues();
+      $contributions = civicrm_api3('Contribution', 'get', [
+        'sequential' => 1,
+        'contribution_recur_id' => $this->recurringContributionID,
+        'options' => ['limit' => 0, 'sort' => 'receive_date ASC'],
+      ]);
+      $newFirstInstallmentReceiveDate = $this->calculateFirstReceiveDate(
+        $contributions['values'][0]['receive_date'],
+        $params['cycle_day']
+      );
+
+      $this->receiveDateCalculator->setStartDate($newFirstInstallmentReceiveDate);
+      $installmentCount = 0;
+
+      foreach ($contributions['values'] as $payment) {
+        $installmentCount++;
+
+        if ($payment['contribution_status'] != 'Pending') {
+          continue;
+        }
+
+        $receiveDate = $this->receiveDateCalculator->calculate($installmentCount);
+        civicrm_api3('Contribution', 'create', [
+          'id' => $payment['id'],
+          'payment_instrument_id' => $params['payment_instrument_id'],
+          'receive_date' => $receiveDate,
+        ]);
+      }
+    }
+  }
+
+  /**
+   * Calculates first receive date for new cycle day.
+   *
+   * @param string $currentDate
+   * @param int $newCycleDay
+   *
+   * @return string
+   */
+  private function calculateFirstReceiveDate($currentDate, $newCycleDay) {
+    $frequency = $this->recurringContribution['frequency_unit'];
+    $currentCycleDay = CRM_MembershipExtras_Service_CycleDayCalculator::calculate($currentDate, $frequency);
+
+    $difference = $newCycleDay - $currentCycleDay;
+    $absoluteDifference = abs($difference);
+    $interval = "P{$absoluteDifference}D";
+
+    $date = new DateTime($currentDate);
+
+    if ($difference > 0) {
+      $date->add(new DateInterval($interval));
+    } elseif ($difference < 0) {
+      $date->sub(new DateInterval($interval));
+    }
+
+    return $date->format('Y-m-d H:i:s');
+  }
+
+}

--- a/CRM/MembershipExtras/Service/InstallmentReceiveDateCalculator.php
+++ b/CRM/MembershipExtras/Service/InstallmentReceiveDateCalculator.php
@@ -11,8 +11,25 @@ class CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator {
    */
   private $recurContribution;
 
+  /**
+   * Initial date from which other dates are calculated.
+   *
+   * @var string
+   */
+  private $startDate;
+
   public function __construct($recurContribution) {
     $this->recurContribution = $recurContribution;
+    $this->startDate = $this->recurContribution['start_date'];
+  }
+
+  /**
+   * Sets initial date from which subsequent dates are calculated.
+   *
+   * @param $date
+   */
+  public function setStartDate($date) {
+    $this->startDate = $date;
   }
 
   /**
@@ -29,7 +46,7 @@ class CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator {
    * @return string
    */
   public function calculate($contributionNumber = 1) {
-    $firstDate = $this->recurContribution['start_date'];
+    $firstDate = $this->startDate;
     $intervalFrequency = $this->recurContribution['frequency_interval'];
     $frequencyUnit = $this->recurContribution['frequency_unit'];
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -226,6 +226,11 @@ function membershipextras_civicrm_postProcess($formName, &$form) {
     $offlineAutoRenewProcessor = new CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor($form);
     $offlineAutoRenewProcessor->process();
   }
+
+  if ($formName === 'CRM_Contribute_Form_UpdateSubscription') {
+    $postProcessFormHook = new CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription($form);
+    $postProcessFormHook->postProcess();
+  }
 }
 
 /**
@@ -246,6 +251,11 @@ function membershipextras_civicrm_buildForm($formName, &$form) {
   if ($formName === 'CRM_Member_Form_MembershipStatus') {
     $membershipStatusHook = new CRM_MembershipExtras_Hook_BuildForm_MembershipStatus();
     $membershipStatusHook->buildForm($form);
+  }
+
+  if ($formName === 'CRM_Contribute_Form_UpdateSubscription') {
+    $updateFormHook = new CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription($form);
+    $updateFormHook->buildForm();
   }
 }
 

--- a/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
+++ b/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
@@ -1,0 +1,93 @@
+{include file="CRM/common/paymentBlock.tpl"}
+<script type="text/javascript">
+  {literal}
+  CRM.$(function($) {
+    var formLayoutTable = $('#UpdateSubscription table.form-layout');
+
+    $('#additional_fields tr').each(function () {
+      formLayoutTable.append($(this));
+    });
+
+    $('#payment_instrument_id').trigger('change');
+  });
+
+  function processUpdate(buttonObj, formName, onClickLabel) {
+    var showConfirmationDialog = false;
+
+    if (CRM.$('#old_payment_instrument_id').val() != CRM.$('#payment_instrument_id').val()) {
+      showConfirmationDialog = true;
+    }
+
+    if (CRM.$('#old_cycle_day').val() != CRM.$('#cycle_day').val()) {
+      showConfirmationDialog = true;
+    }
+
+    if (showConfirmationDialog) {
+      CRM.$('#confirmInstallmentsUpdate').dialog({
+        modal: true, title: 'Update Recurring Contribution', zIndex: 10000, autoOpen: true,
+        width: 'auto', resizable: false,
+        buttons: {
+          Yes: function () {
+            CRM.$('#update_installments').val(1);
+            submitOnce(buttonObj, formName, onClickLabel);
+            CRM.$(this).dialog("close");
+          },
+          No: function () {
+            submitOnce(buttonObj, formName, onClickLabel);
+            CRM.$(this).dialog("close");
+          }
+        },
+        close: function (event, ui) {
+          CRM.$(this).dialog("close");
+        }
+      });
+    } else {
+      return submitOnce(buttonObj, formName, onClickLabel);
+    }
+
+    return false;
+  }
+  {/literal}
+</script>
+
+<table id="additional_fields">
+  <tr id="payment_instrument_id_field">
+    <td class="label">
+      {$form.payment_instrument_id.label}
+    </td>
+    <td>
+      {$form.payment_instrument_id.html}
+      <input type="hidden" name="old_payment_instrument_id" id="old_payment_instrument_id" value="{$form.payment_instrument_id.value.0}" />
+      <input type="hidden" name="update_installments" id="update_installments" value="0" />
+    </td>
+  </tr>
+  <tr id="cycle_day_field">
+    <td class="label">
+      {$form.cycle_day.label}
+    </td>
+    <td>
+      {$form.cycle_day.html}
+      <input type="hidden" name="old_cycle_day" id="old_cycle_day" value="{$form.cycle_day.value}" />
+    </td>
+  </tr>
+  <tr id="autorenew_field">
+    <td class="label">
+      {$form.auto_renew.label}
+    </td>
+    <td>
+      {$form.auto_renew.html}
+    </td>
+  </tr>
+  <tr id="billing_optional_fields" class="crm-membership-form-block-billing">
+    <td colspan="2">
+      <div id="billing-payment-block" class="crm-ajax-container"></div>
+    </td>
+  </tr>
+</table>
+<div id="confirmInstallmentsUpdate" style="display: none;">
+  <table>
+    <tr>
+      <td>{ts}Do you want to update any outstanding instalment contribution with the new Payment Method/ Cycle Day?{/ts}</td>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
## Overview
We need to alter Update Recurring contribution form to expose some new fields and allow users to update related pending installments if they choose to do so. For this, we need to:

- Make "Number of instalment" field readonly if the recurring contribution is using a payment processor with "Payment_Manual" class.
- Expose the "Auto Renew?" field on "Update Recurring Contribution" form.
- Expose "Payment Method" field, "Cycle Day" field on "Update Recurring Contribution" form.
- When admin click on save on "Update Recurring Contribution" form, if "Payment Mehod" or "Cycle Day" is changed, a popup should appear asking "Do you want to update any outstanding instalment contribution with the new Payment Method/ Cycle Day?".
- If admin chose "No" in the previous popup. No existing contribution will get affected.
- If admin chose "Yes" in the previous popup. Any existing Pending contribution under the recurring contribution will reflect the new "Payment Method" and "Cycle Day".

## Before
![image](https://user-images.githubusercontent.com/21999940/40625868-8f8762a6-627a-11e8-8cf2-bcc0ed41b469.png)

## After
Added cycle_day and payment_instrument_id fields to Update Recurring Contribution Form, and added a confirmation dialog so that if user chooses to, pending installments' receive date and payment instrument are also updated.

![basw-118-after](https://user-images.githubusercontent.com/21999940/40625952-2805d940-627b-11e8-8437-c6473cb461ae.gif)
