### PR TITLE
BASW-122: Change payment plan recurring contribution status when paying installments

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/Contribution.php
+++ b/CRM/MembershipExtras/Hook/Pre/Contribution.php
@@ -1,0 +1,108 @@
+<?php
+
+class CRM_MembershipExtras_Hook_Pre_Contribution {
+
+
+  private $id;
+
+  /**
+   * The contribution to-be-created parameters passed from the hook.
+   *
+   * @var array
+   */
+  private $params;
+
+  /**
+   * The payment plan recurring contribution data if exist
+   *
+   * @var array|null
+   */
+  private $recurContribution = NULL;
+
+  /**
+   * Is this an offline payment plan payment ?
+   *
+   * @var bool
+   */
+  private $isOfflinePaymentPlanPayment = FALSE;
+
+  public function __construct($id, &$params) {
+    $this->id = $id;
+    $this->params = $params;
+    $this->setRecurContribution();
+    $this->setIsOfflinePaymentPlanPayment();
+  }
+
+  /**
+   * Sets $recurContribution
+   */
+  private function setRecurContribution() {
+    if (empty($this->params['prevContribution']->contribution_recur_id)) {
+      return;
+    }
+
+    $this->recurContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $this->params['prevContribution']->contribution_recur_id,
+    ])['values'][0];
+  }
+
+  /**
+   * Sets $isOfflinePaymentPlanPayment
+   */
+  private function setIsOfflinePaymentPlanPayment() {
+    $contributionStatuses = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    $previousStatus = $contributionStatuses[$this->params['prevContribution']->contribution_status_id];
+    $currentStatus = $contributionStatuses[$this->params['contribution_status_id']];
+
+    if ($previousStatus === 'Pending' && in_array($currentStatus, ['Partially paid', 'Completed']) && !empty($this->recurContribution)) {
+      $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
+      $isOfflineContribution = empty($this->recurContribution['payment_processor_id']) ||
+        in_array($this->recurContribution['payment_processor_id'], $manualPaymentProcessors);
+
+      if (!empty($this->recurContribution['installments']) || !$isOfflineContribution) {
+        $this->isOfflinePaymentPlanPayment = TRUE;
+      }
+    }
+  }
+
+  /**
+   * Updates the payment plan recurring contribution
+   * status based on the number of completed/partially paid
+   * installments.
+   */
+  public function updatePaymentPlanStatus() {
+    if (!$this->isOfflinePaymentPlanPayment) {
+      return;
+    }
+
+    $paidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurContribution['id'],
+      'contribution_status_id' => 'Completed',
+    ]);
+
+    $partiallyPaidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurContribution['id'],
+      'contribution_status_id' => 'Partially paid',
+    ]);
+
+    $newStatus = NULL;
+    if (($partiallyPaidInstallmentsCount == 1 && $paidInstallmentsCount == 0) ||
+      ($partiallyPaidInstallmentsCount == 0 && $paidInstallmentsCount == 1) ||
+      ($partiallyPaidInstallmentsCount == 0 && $paidInstallmentsCount == 0)
+    ) {
+      $newStatus = 'In Progress';
+    }
+
+    if ($paidInstallmentsCount >= $this->recurContribution['installments']) {
+      $newStatus = 'Completed';
+    }
+
+    if ($newStatus !== NULL) {
+      civicrm_api3('ContributionRecur', 'create', [
+        'id' => $this->recurContribution['id'],
+        'contribution_status_id' => $newStatus,
+      ]);
+    }
+  }
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -163,7 +163,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
 
   if ($op === 'edit' && $objectName === 'Membership' && $contributionID) {
     $preEditMembershipHook = new CRM_MembershipExtras_Hook_PreEdit_Membership($id, $contributionID, $params);
-    $preEditMembershipHook->preventExtendingOfflinePendingRecurringMembership();
+    $preEditMembershipHook->preventExtendingPaymentPlanMembership();
   }
 
   $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithMoreThanOneInstallment();

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -157,13 +157,19 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
    * options for now.
    */
   static $contributionID = NULL;
+  static $preEditContributionHook = NULL;
   if ($op === 'edit' && $objectName === 'Contribution') {
     $contributionID = $id;
+
+    $preEditContributionHook = new CRM_MembershipExtras_Hook_Pre_Contribution($id, $params);
+    $preEditContributionHook->updatePaymentPlanStatus();
   }
 
   if ($op === 'edit' && $objectName === 'Membership' && $contributionID) {
     $preEditMembershipHook = new CRM_MembershipExtras_Hook_PreEdit_Membership($id, $contributionID, $params);
     $preEditMembershipHook->preventExtendingPaymentPlanMembership();
+
+    $preEditContributionHook->updatePaymentPlanStatus();
   }
 
   $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithMoreThanOneInstallment();


### PR DESCRIPTION
## Before

When paying the first payment plan installment (completely or partially) or when the all the payment plan installments are completed, the recurring contribution status will stay on "pending" status.

![ddsadas](https://user-images.githubusercontent.com/6275540/40720003-3a6907fe-640d-11e8-8f23-9e81a7a3b644.gif)


## After

- When paying the first payment plan installment (completely or partially) , the recurring contribution status will change to "in progress".

- When paying completing all the payment plan installments, the recurring contribution will change to "Completed".

![before](https://user-images.githubusercontent.com/6275540/40720191-d8c2136e-640d-11e8-8d00-a6f38b0a7859.gif)


## Other Notes

There was a problem where the membership get extended when you finish the last payment, I fixed it in this commit : 

https://github.com/compucorp/uk.co.compucorp.membershipextras/commit/3fff6ec4d9d2441d2c15ae9acf9e8617a87ba254



## Limitations


Currently there is a problem with handling "partial payments" that emerge from CiviCRM side and hard to be solved currently (without probably some fixes to CiviCRM core) , the problem consist of two parts : 

1- If you paid the **last** installment partially then you completed it, then the recurring contribution status will stay "in progress" instead of "completed".

2- If for partially paid any installment (other than the first installment) then completed it, then the membership will get extended when you complete the partially paid installment.

Here is a gif that demonstrate the two issues : 

![aaaa](https://user-images.githubusercontent.com/6275540/40720457-b63b2f8c-640e-11e8-9762-9b139e0b7eaf.gif)
