### PR TITLE
DD-29: Adding post hook for membership offline auto-renewal job

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -584,6 +584,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
       $membership->id = $membershipPayment['membership_id'];
       $membership->end_date = MembershipEndDateCalculator::calculate($membershipPayment['membership_id']);
       $membership->save();
+
+      $nullObject = CRM_Utils_Hook::$_nullObject;
+      CRM_Utils_Hook::singleton()->invoke(
+        ['membershipId', 'recurContributionId'], $membershipPayment['membership_id'],
+        $this->currentRecurContributionID, $nullObject, $nullObject, $nullObject, $nullObject,
+        'membershipextras_postOfflineAutoRenewal');
     }
   }
 


### PR DESCRIPTION
## Problem

In DD-29, direct deb extension need to create some CiviCRM Activities after the auto-renewal job renew a membership.

## Solution

A new hook is created inside this extension which is called directly after the offline auto-renewal job extend a membership for renewal.

The new Hook name and signature is  : 

**hook_membershipextras_postOfflineAutoRenewal($membershipId, $recurContributionId)**

which means that it will pass both the auto-renewed membership ID as well as its current recurring contribution ID that is used for renewal.


The hook can be implemented inside an CiviCRM extension as following : 

```php
function myextensionname_membershipextras_postOfflineAutoRenewal($membershipId, $recurContributionId) {
// Do your stuff here
}
```

