### PR TITLE
BASW-122: Change payment plan recurring contribution status when paying installments

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -1,0 +1,132 @@
+<?php
+
+class CRM_MembershipExtras_Hook_Pre_EntityFinancialTrxn {
+
+  /**
+   * The created entity Financial Transaction object
+   * passed from the hook.
+   *
+   * @var CRM_Financial_DAO_EntityFinancialTrxn
+   */
+  private $entityFinancialTrx;
+
+  /**
+   * The transaction recurring contribution if exist.
+   *
+   * @var null
+   */
+  private $recurContribution = NULL;
+
+  /**
+   * @param CRM_Financial_DAO_EntityFinancialTrxn $entityFinancialTrx
+   */
+  public function __construct(&$entityFinancialTrx) {
+    $this->entityFinancialTrx = $entityFinancialTrx;
+  }
+
+  /**
+   * Updates the payment plan recurring contribution
+   * status based on the number of completed/partially paid
+   * installments.
+   */
+  public function updatePaymentPlanStatus() {
+    if ($this->entityFinancialTrx->entity_table != 'civicrm_financial_item') {
+      return;
+    }
+
+    $this->setRecurContribution();
+    if (empty($this->recurContribution) || !$this->isPaymentPlanTransaction()) {
+      return;
+    }
+
+    $newStatus = $this->generatePaymentPlanNewStatus();
+    if ($newStatus !== NULL) {
+      civicrm_api3('ContributionRecur', 'create', [
+        'id' => $this->recurContribution['id'],
+        'contribution_status_id' => $newStatus,
+      ]);
+    }
+  }
+
+  /**
+   * Sets the recurring contribution data for
+   * the financial transaction if exist.
+   */
+  private function setRecurContribution() {
+    $entityFinancialTrxn = civicrm_api3('EntityFinancialTrxn', 'get', [
+      'sequential' => 1,
+      'entity_table' => 'civicrm_contribution',
+      'financial_trxn_id' => $this->entityFinancialTrx->financial_trxn_id,
+    ]);
+    if (empty($entityFinancialTrxn['values'][0])) {
+      return;
+    }
+    $contributionId = $entityFinancialTrxn['values'][0]['entity_id'];
+
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['contribution_recur_id'],
+      'id' => $contributionId,
+    ]);
+    if (empty($contribution['values'][0]['contribution_recur_id'])) {
+      return;
+    }
+    $recurContributionID = $contribution['values'][0]['contribution_recur_id'];
+
+    $recurContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $recurContributionID,
+    ]);
+    if (empty($recurContribution['values'][0])) {
+      return;
+    }
+
+    $this->recurContribution =  $recurContribution['values'][0];
+  }
+
+  /**
+   * Determines if the transaction is a payment
+   * plan transaction.
+   *
+   * @return bool
+   */
+  private function isPaymentPlanTransaction() {
+    $payLaterProcessorID = 0;
+    $manualPaymentProcessorsIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
+
+    if ($this->recurContribution['installments'] > 1 && in_array($this->recurContribution['payment_processor_id'], $manualPaymentProcessorsIDs)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Generates the payment plan new status
+   *
+   * @return string|NULL
+   */
+  private function generatePaymentPlanNewStatus() {
+    $paidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurContribution['id'],
+      'contribution_status_id' => 'Completed',
+    ]);
+
+    $partiallyPaidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurContribution['id'],
+      'contribution_status_id' => 'Partially paid',
+    ]);
+
+    $newStatus = NULL;
+    if ($paidInstallmentsCount == 1 || $partiallyPaidInstallmentsCount == 1) {
+      $newStatus = 'In Progress';
+    }
+
+    if ($paidInstallmentsCount >= $this->recurContribution['installments']) {
+      $newStatus = 'Completed';
+    }
+
+    return $newStatus;
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -193,6 +193,13 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   }
 }
 
+function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+  if ($objectName === 'EntityFinancialTrxn') {
+    $entityFinancialTrxnHook = new CRM_MembershipExtras_Hook_Pre_EntityFinancialTrxn($objectRef);
+    $entityFinancialTrxnHook->updatePaymentPlanStatus();
+  }
+}
+
 /**
  * Determines if the membership is paid
  * using payment plan option using more than

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -163,7 +163,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
 
   if ($op === 'edit' && $objectName === 'Membership' && $contributionID) {
     $preEditMembershipHook = new CRM_MembershipExtras_Hook_PreEdit_Membership($id, $contributionID, $params);
-    $preEditMembershipHook->preventExtendingOfflinePendingRecurringMembership();
+    $preEditMembershipHook->preventExtendingPaymentPlanMembership();
   }
 
   $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithMoreThanOneInstallment();


### PR DESCRIPTION
## Before

When paying the first payment plan installment (completely or partially) or when the all the payment plan installments are completed, the recurring contribution status will stay on "pending" status.

![ddsadas](https://user-images.githubusercontent.com/6275540/40720003-3a6907fe-640d-11e8-8f23-9e81a7a3b644.gif)


## After

- When paying the first payment plan installment (completely or partially) , the recurring contribution status will change to "in progress".

- When paying (completing) all the payment plan installments, the recurring contribution will change to "Completed".

![before](https://user-images.githubusercontent.com/6275540/40720191-d8c2136e-640d-11e8-8d00-a6f38b0a7859.gif)


## Other Notes

There was a problem where the membership get extended when you finish the last payment, I fixed it in this commit : 

https://github.com/compucorp/uk.co.compucorp.membershipextras/commit/72d4c1f88c31e36f0ded05dc397a6d11aee0b016
