### PR TITLE
BASW-90: Fix Styling and Usability Problems

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
@@ -46,6 +46,9 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan {
    * juggles around exiting ones.
    */
   private function addPaymentPlanSection() {
+    $paymentToggler = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String', $this->form, FALSE);
+    $this->form->assign('contribution_type_toggle', $paymentToggler);
+
     $this->form->add('text', 'installments', ts('Number of Installments'), '', FALSE);
     $this->form->addRule('installments', ts('Installments must be a number.'), 'numeric');
     $this->form->setDefaults(['installments' => self::DEFAULT_INSTALLMENTS_NUMBER]);

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -1,4 +1,6 @@
 <script type="text/javascript">
+  var togglerValue = '{$contribution_type_toggle}';
+
   {literal}
   /**
    * Perform changes on form to add payment plan as an option to pay for
@@ -20,6 +22,8 @@
     CRM.$('#recordContribution legend:first').html('Contribution and Payment Plan');
     CRM.$('#installments_row').insertAfter(CRM.$('#financial_type_id').parent().parent());
     CRM.$('#first_installment').insertAfter(CRM.$('#installments_row'));
+    CRM.$('span.crm-error').css('display', 'none');
+    CRM.$('label span.crm-error').css('display', 'inline');
   }
 
   /**
@@ -88,7 +92,8 @@
    * new events added.
    */
   function initializeMembershipForm() {
-    CRM.$('#contribution_toggle').click();
+    var idToggleOption = '#' + togglerValue + '_toggle';
+    CRM.$(idToggleOption).click();
     CRM.$('#invoice_date_summary').html(CRM.$('#receive_date').val());
   }
   {/literal}
@@ -99,7 +104,7 @@
       <input name="contribution_type_toggle" id="contribution_toggle" value="contribution" type="radio">
       <label for="contribution_toggle">Contribution</label>
       &nbsp;
-      <input name="contribution_type_toggle" id="plan_toggle" value="payment_plan" type="radio">
+      <input name="contribution_type_toggle" id="payment_plan_toggle" value="payment_plan" type="radio">
       <label for="plan_toggle">Payment Plan</label>
     </td>
   </tr>
@@ -111,7 +116,7 @@
       {$form.installments.html}
       {$form.installments_frequency.label} <span class="marker">*</span>
       {$form.installments_frequency.html}
-      {$form.installments_frequency_unit.html} <span class="marker">*</span>
+      {$form.installments_frequency_unit.html}
     </td>
   </tr>
   <tr id="first_installment">


### PR DESCRIPTION
## Overview
Validation message for installments details fields goes outside the frame, of the modal dialog to create memberships.

## Before
Validation Messages for installment quantity and frequency were breaking styling of the form. Also, when validation failed, the form was being shown again, but as if a single contribution was used, instead of a payment plan.

![image](https://user-images.githubusercontent.com/21999940/40894311-565cef84-676e-11e8-8f8f-af90087b9df4.png)

## After
Altered template to remove messages that were causing break and added logic so if validation fails, the state of the form is preserved according to what payment option was chosen, contribution or payment plan.

![image](https://user-images.githubusercontent.com/21999940/40894341-76fde784-676e-11e8-8274-027c51200767.png)
