### PR TITLE
BASW-141: Fix Problems With Payment Toggler

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
@@ -47,7 +47,7 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan {
    */
   private function addPaymentPlanSection() {
     $paymentToggler = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String', $this->form, FALSE);
-    $this->form->assign('contribution_type_toggle', $paymentToggler);
+    $this->form->assign('contribution_type_toggle', $paymentToggler ?: 'contribution');
 
     $this->form->add('text', 'installments', ts('Number of Installments'), '', FALSE);
     $this->form->addRule('installments', ts('Installments must be a number.'), 'numeric');

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -51,12 +51,14 @@
       CRM.$('#trxn_id').parent().parent().show();
       CRM.$('#first_installment').hide();
     });
-    CRM.$('#plan_toggle').click(function() {
+
+    CRM.$('#payment_plan_toggle').click(function() {
       CRM.$('#total_amount').prop('readonly', true);
       CRM.$('#installments_row').show();
       CRM.$("label[for='receive_date']").html('Payment Plan Start Date');
       CRM.$('#trxn_id').parent().parent().hide();
       CRM.$('#first_installment').show();
+      CRM.$('#installments').change();
 
       if (CRM.$('#membership_type_id_1').val()) {
         CRM.$('#membership_type_id_1').change();
@@ -79,10 +81,12 @@
       }
     });
 
-    CRM.$('#installments, #installments_frequency, #installments_frequency_unit').change(function () {
+    CRM.$('#installments, #total_amount').change(function () {
       var currentAmount = parseFloat(CRM.$('#total_amount').val().replace(/[^0-9\.]+/g, ""));
       var amountPerPeriod = currentAmount / parseFloat(CRM.$('#installments').val());
-
+      console.log(CRM.$('#total_amount').val());
+      console.log(currentAmount);
+      console.log(amountPerPeriod);
       CRM.$('#amount_summary').html(amountPerPeriod.toFixed(2));
     });
   }
@@ -105,7 +109,7 @@
       <label for="contribution_toggle">Contribution</label>
       &nbsp;
       <input name="contribution_type_toggle" id="payment_plan_toggle" value="payment_plan" type="radio">
-      <label for="plan_toggle">Payment Plan</label>
+      <label for="payment_plan_toggle">Payment Plan</label>
     </td>
   </tr>
   <tr id="installments_row">


### PR DESCRIPTION
## Overview
When creating a membership, if the default installment options are unchanged, the amount for the first invoice will not be calculated, and remain empty. Also, the payment toggler stopped working.

## Before
Payment toggle stopped working and ceased to show installments options. If the default installment options are unchanged, the amount for the first invoice was not be calculated.

![screenshot_04_06_2018__12_42](https://user-images.githubusercontent.com/21999940/40931139-920c2d20-67ef-11e8-918b-83b6f3076f61.jpg)

## After
Fixed both problems by fixing id used in selector to obtain DOM node and precalculating invoice amount by simulating a change event on number of installments.

![image](https://user-images.githubusercontent.com/21999940/40931219-e25bca42-67ef-11e8-8ae9-1dd6ea0bd756.png)
