### PR TITLE
BASW-122: Fixing issues with payment plan status update

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -1,6 +1,6 @@
 <?php
 
-class CRM_MembershipExtras_Hook_Pre_EntityFinancialTrxn {
+class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
 
   /**
    * The created entity Financial Transaction object
@@ -46,6 +46,7 @@ class CRM_MembershipExtras_Hook_Pre_EntityFinancialTrxn {
         'contribution_status_id' => $newStatus,
       ]);
     }
+    $a = 5*5;
   }
 
   /**
@@ -118,7 +119,7 @@ class CRM_MembershipExtras_Hook_Pre_EntityFinancialTrxn {
     ]);
 
     $newStatus = NULL;
-    if ($paidInstallmentsCount == 1 || $partiallyPaidInstallmentsCount == 1) {
+    if ($paidInstallmentsCount >= 1 || $partiallyPaidInstallmentsCount >=  1) {
       $newStatus = 'In Progress';
     }
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -195,7 +195,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
 
 function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName === 'EntityFinancialTrxn') {
-    $entityFinancialTrxnHook = new CRM_MembershipExtras_Hook_Pre_EntityFinancialTrxn($objectRef);
+    $entityFinancialTrxnHook = new CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn($objectRef);
     $entityFinancialTrxnHook->updatePaymentPlanStatus();
   }
 }


### PR DESCRIPTION
It appear that I mistakenly changed the class name before committing it from CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn to CRM_MembershipExtras_Hook_Pre_EntityFinancialTrxn so in this PR I changed it back.

I also changed the payment plan status update code so it is "In Progress" whenever the number of partially or paid payments is >= 1 . the "Completed" statues will still override it if the total number of paid installments >= the payment plan installments number.

