### PR TITLE
BASW-90: Fixing tax amount validation

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -260,7 +260,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       $newLineItem = CRM_Price_BAO_LineItem::create($lineItemParms);
 
       CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution);
-      if (!empty($contribution->tax_amount)) {
+      if (!empty((float) $contribution->tax_amount)) {
         CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution, TRUE);
       }
     }


### PR DESCRIPTION
If the contribution passed tax amount was sent as string such as "0.00", then this if statment

```php
if (!empty($contribution->tax_amount)) {
    CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution, TRUE);	
}

```
will get computed to true since the passed string is no empty though the tax amount is 0 which causing problems.

In this PR I convert the type to float to ensure that the validation is correct and no financial item will be created if the tax amount is 0.