### PR TITLE
BASW-118: Fix Issues on Recurring Contribution Update

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -296,7 +296,7 @@ function membershipextras_civicrm_alterCalculatedMembershipStatus(&$calculatedSt
  */
 function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
   if ($op == 'contribution.selector.recurring' && $objectName == 'Contribution') {
-    $recurContribuLinksHook = new CRM_MembershipExtras_Hook_Links_RecurringContribution($links);
+    $recurContribuLinksHook = new CRM_MembershipExtras_Hook_Links_RecurringContribution($objectId, $links, $mask);
     $recurContribuLinksHook->alterLinks();
   }
 }


### PR DESCRIPTION
## Overview
If a recurring contribution is set to auto-renew, then it will become uneditable. We need to change this to allow any auto-renew recurring contribution who are using offline payment processors (payment manual class) to be editable. 

On the other hand, when a recurring contribution that links to a membership is set to auto-renew, the id of the recurring contribution should also be filled into the membership contrib_recurr_id column.

Finally, after editing and saving the Cycle Day, the pending contributions Received date will change. However, opening the recurring contribution view modal will still show the old date. Also, when you uncheck the Auto Renew field and save, the changes do not reflect.

## Before
- All recurring contributions set to auto-renew were uneditable.
- Setting recurring contribution to auto_renew didn't set contrib_recurr_id column on membership
- Next Contribution date was not updated on cycle_date change.
- Unsetting auto_renew did not take effect

## After
Implemented the links hook to re-enable edit permission for auto-renew manual payment plans. Also, updated contrib_recur_id column if auto-renew is true. Added logic to update date of next contribution on recurring contribution. Fixed a problem where if auto-renew was set as false, the value wasn't changed on the database.
