### PR TITLE
BASW-91: Show if Payment Processors are Live or Not on Settings

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentPlanSettings.php
+++ b/CRM/MembershipExtras/Form/PaymentPlanSettings.php
@@ -57,7 +57,7 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
    * @param array $defaultProcessorField
    */
   private function addDefaultProcessorField($defaultProcessorField) {
-    $processorOptions = array('' => ts('- select -')) + ManualPaymentProcessors::getIDNameTestMap();
+    $processorOptions = array('' => ts('- select -')) + ManualPaymentProcessors::getIDNameMap();
 
     $this->add(
       $defaultProcessorField['html_type'],

--- a/CRM/MembershipExtras/Form/PaymentPlanSettings.php
+++ b/CRM/MembershipExtras/Form/PaymentPlanSettings.php
@@ -57,7 +57,7 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
    * @param array $defaultProcessorField
    */
   private function addDefaultProcessorField($defaultProcessorField) {
-    $processorOptions = array('' => ts('- select -')) + ManualPaymentProcessors::getIDNameMap();
+    $processorOptions = array('' => ts('- select -')) + ManualPaymentProcessors::getIDNameTestMap();
 
     $this->add(
       $defaultProcessorField['html_type'],

--- a/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
+++ b/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
@@ -24,11 +24,12 @@ class CRM_MembershipExtras_Service_ManualPaymentProcessors {
   }
 
   /**
-   * Builds an array mapping manual payment processor id's to processor name.
+   * Builds an array mapping manual payment processor id's to processor name and
+   * if it is a live or test processor.
    *
    * @return array
    */
-  public static function getIDNameMap() {
+  public static function getIDNameTestMap() {
     $offlineRecPaymentProcessors = civicrm_api3('PaymentProcessor', 'get', [
       'sequential' => 1,
       'class_name' => 'Payment_Manual',
@@ -38,7 +39,8 @@ class CRM_MembershipExtras_Service_ManualPaymentProcessors {
     $recPaymentProcessors = [];
     if (!empty($offlineRecPaymentProcessors['values'])) {
       foreach ($offlineRecPaymentProcessors['values'] as $paymentProcessor) {
-        $recPaymentProcessors[$paymentProcessor['id']] = $paymentProcessor['name'];
+        $testOrLive = $paymentProcessor['is_test'] ? 'Test - ': 'Live - ';
+        $recPaymentProcessors[$paymentProcessor['id']] = $testOrLive . $paymentProcessor['name'];
       }
     }
 

--- a/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
+++ b/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
@@ -24,12 +24,11 @@ class CRM_MembershipExtras_Service_ManualPaymentProcessors {
   }
 
   /**
-   * Builds an array mapping manual payment processor id's to processor name and
-   * if it is a live or test processor.
+   * Builds an array mapping manual payment processor id's to processor name.
    *
    * @return array
    */
-  public static function getIDNameTestMap() {
+  public static function getIDNameMap() {
     $offlineRecPaymentProcessors = civicrm_api3('PaymentProcessor', 'get', [
       'sequential' => 1,
       'class_name' => 'Payment_Manual',


### PR DESCRIPTION
## Overview
Manually adding a new payment processor creates two different items, with the same name, one with is_test = 0, the other one with is_test = 1. This made it impossible to know which was which on the extension's settings form, where we were just showing the processor's name.

## Before
Settings page for the extension only showed processor's name on the selection bx used to define default payment processor.

## After
Added 'Live - ' and 'Test - ' prefixes correspondingly to each processor, so users can know which is which.