### PR TITLE
BASW-175: Unlock the Amount Field for Payment Plan when no Priceset is Used

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -300,3 +300,16 @@ function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$
     $recurContribuLinksHook->alterLinks();
   }
 }
+
+function membershipextras_civicrm_alterContent(&$content, $context, $tplName, &$object) {
+  $snippet = CRM_Utils_Request::retrieve('snippet', 'Int');
+  $priceSetID = CRM_Utils_Request::retrieve('priceSetId', 'Int');
+
+  if ($tplName == 'CRM/Member/Page/Tab.tpl' && $snippet == CRM_Core_Smarty::PRINT_NOFORM && !empty($priceSetID)) {
+    $content = preg_replace(
+      '/cj\(\'#total_amount\'\)\.val\((.+)\);/',
+      'cj(\'#total_amount\').val(${1}).change();',
+      $content
+    );
+  }
+}

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -45,7 +45,6 @@
    */
   function setupPayPlanTogglingEvents() {
     CRM.$('#contribution_toggle').click(function() {
-      CRM.$('#total_amount').prop('readonly', false);
       CRM.$('#installments_row').hide();
       CRM.$("label[for='receive_date']").html('Received');
       CRM.$('#trxn_id').parent().parent().show();
@@ -53,7 +52,6 @@
     });
 
     CRM.$('#payment_plan_toggle').click(function() {
-      CRM.$('#total_amount').prop('readonly', true);
       CRM.$('#installments_row').show();
       CRM.$("label[for='receive_date']").html('Payment Plan Start Date');
       CRM.$('#trxn_id').parent().parent().hide();
@@ -84,9 +82,6 @@
     CRM.$('#installments, #total_amount').change(function () {
       var currentAmount = parseFloat(CRM.$('#total_amount').val().replace(/[^0-9\.]+/g, ""));
       var amountPerPeriod = currentAmount / parseFloat(CRM.$('#installments').val());
-      console.log(CRM.$('#total_amount').val());
-      console.log(currentAmount);
-      console.log(amountPerPeriod);
       CRM.$('#amount_summary').html(amountPerPeriod.toFixed(2));
     });
   }
@@ -100,6 +95,11 @@
     CRM.$(idToggleOption).click();
     CRM.$('#invoice_date_summary').html(CRM.$('#receive_date').val());
   }
+
+  if (typeof buildAutoRenew !== 'function') {
+    function buildAutoRenew() {};
+  }
+
   {/literal}
 </script>
 <table id="payment_plan_fields">


### PR DESCRIPTION
## Overview
We want to allow the staff to edit the amount for a payment plan when the following criteria are met:

1. the staff is creating new membership using payment plan or renewing a membership using payment plan
2. priceset option is not used

The final value in the amount field will be the amount for the payment plan. It will be divided by the number of instalments and then used as the instalment contribution amount and the line amount.

## Before
Total amount field was being made read-only if payment plan was used to paid for a membership.

## After
Total amount field is set to readonly if priceset is used to pay for the membership exclusively.

Also fixed a problem with updating amount of first invoice when using price set.