### PR TITLE
BASW-113: Set 'Override Until' Date to Null when Cancelling Recurring Contribution and Membership

### DIFF
--- a/CRM/MembershipExtras/Form/CancelRecurringContribution.php
+++ b/CRM/MembershipExtras/Form/CancelRecurringContribution.php
@@ -91,6 +91,7 @@ class CRM_MembershipExtras_Form_CancelRecurringContribution extends CRM_Core_For
       'api.Membership.create' => [
         'id' => '$value.membership_id',
         'is_override' => 1,
+        'status_override_end_date' => '',
         'status_id' => 'Cancelled',
       ],
     ]);


### PR DESCRIPTION
## Overview
If Membership is Cancelled when cancelling a recurring contribution, we need to make sure the 'status_override_end_date' field is set to null. This is not happening.

## Before
Updating the membership's status to 'Cancelled' when canceling a recurring contribution was setting it as an overridden status, but did not take into account the membership could already be in an overridden status until a specified date. This caused the membership to exit the cancelled status on the date specified for the previous status.

## After
Set the `status_override_end_date` field to null whan cancelling the membership.