### PR TITLE
SHOR-45: Fix Markup of forms to use default civi markup

### DIFF
--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -104,12 +104,14 @@
 </script>
 <table id="payment_plan_fields">
   <tr id="contributionTypeToggle">
-    <td colspan="2" align="center">
-      <input name="contribution_type_toggle" id="contribution_toggle" value="contribution" type="radio">
-      <label for="contribution_toggle">Contribution</label>
-      &nbsp;
-      <input name="contribution_type_toggle" id="payment_plan_toggle" value="payment_plan" type="radio">
-      <label for="payment_plan_toggle">Payment Plan</label>
+    <td colspan="2">
+      <p>
+        <input name="contribution_type_toggle" id="contribution_toggle" value="contribution" type="radio">
+        <label for="contribution_toggle">Contribution</label>
+        &nbsp;
+        <input name="contribution_type_toggle" id="payment_plan_toggle" value="payment_plan" type="radio">
+        <label for="payment_plan_toggle">Payment Plan</label>
+      </p>
     </td>
   </tr>
   <tr id="installments_row">

--- a/templates/CRM/MembershipExtras/Form/CancelRecurringContribution.tpl
+++ b/templates/CRM/MembershipExtras/Form/CancelRecurringContribution.tpl
@@ -1,17 +1,16 @@
 <div class="crm-block crm-form-block crm-payment-plan-cancel-form-block">
-<div class="messages status no-popup">
-  <div class="icon inform-icon"></div>
-  WARNING - This action sets the CiviCRM recurring contribution status to cancelled, but does NOT send a cancellation request to the payment processor. You will need to ensure that this recurring payment (subscription) is cancelled by the payment processor.
-</div>
-<strong> Are you sure you want to mark this recurring contribution as cancelled? </strong>
-<br/>
-<br/>
-</strong>
+  <div class="messages status no-popup">
+    <div class="icon inform-icon"></div>
+    WARNING - This action sets the CiviCRM recurring contribution status to cancelled, but does NOT send a cancellation request to the payment processor. You will need to ensure that this recurring payment (subscription) is cancelled by the payment processor.
+  </div>
+  <p>
+    <strong> Are you sure you want to mark this recurring contribution as cancelled? </strong>
+  </p>
   <table class="form-layout-compressed">
     <tbody>
       <tr>
         <td class="label">
-          <label">{$form.cancel_pending_installments.label}</label>
+          <label>{$form.cancel_pending_installments.label}</label>
         </td>
         <td>
           {$form.cancel_pending_installments.html}
@@ -19,7 +18,7 @@
       </tr>
       <tr>
         <td class="label">
-          <label">{$form.cancel_memberships.label}</label>
+          <label>{$form.cancel_memberships.label}</label>
         </td>
         <td>
           {$form.cancel_memberships.html}

--- a/templates/CRM/MembershipExtras/Form/CancelRecurringContribution.tpl
+++ b/templates/CRM/MembershipExtras/Form/CancelRecurringContribution.tpl
@@ -1,22 +1,33 @@
-Are you sure you want to mark this recurring contribution as cancelled?
-<br><br>
-<strong>
-  WARNING - This action sets the CiviCRM recurring contribution status to
-  Cancelled, but does NOT send a cancellation request to the payment
-  processor. You will need to ensure that this recurring payment
-  (subscription) is cancelled by the payment processor.
+<div class="crm-block crm-form-block crm-payment-plan-cancel-form-block">
+<div class="messages status no-popup">
+  <div class="icon inform-icon"></div>
+  WARNING - This action sets the CiviCRM recurring contribution status to cancelled, but does NOT send a cancellation request to the payment processor. You will need to ensure that this recurring payment (subscription) is cancelled by the payment processor.
+</div>
+<strong> Are you sure you want to mark this recurring contribution as cancelled? </strong>
+<br/>
+<br/>
 </strong>
-<br><br>
-<div class="crm-section">
-  <div class="label">{$form.cancel_pending_installments.label}</div>
-  <div class="content">{$form.cancel_pending_installments.html}</div>
-  <div class="clear"></div>
-</div>
-<div class="crm-section">
-  <div class="label">{$form.cancel_memberships.label}</div>
-  <div class="content">{$form.cancel_memberships.html}</div>
-  <div class="clear"></div>
-</div>
-<div class="crm-submit-buttons">
-  {include file="CRM/common/formButtons.tpl" location="bottom"}
+  <table class="form-layout-compressed">
+    <tbody>
+      <tr>
+        <td class="label">
+          <label">{$form.cancel_pending_installments.label}</label>
+        </td>
+        <td>
+          {$form.cancel_pending_installments.html}
+        </td>
+      </tr>
+      <tr>
+        <td class="label">
+          <label">{$form.cancel_memberships.label}</label>
+        </td>
+        <td>
+          {$form.cancel_memberships.html}
+        </td>
+      </tr>      
+    </tbody>
+  </table>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
 </div>

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.tpl
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.tpl
@@ -1,11 +1,22 @@
-{foreach from=$settingFields item=elementName}
-    <div class="crm-section">
-        <div class="label">{$form.$elementName.label} {help id=$elementName file="CRM/MembershipExtras/Form/PaymentPlanSettings.hlp"}</div>
-        <div class="content">{$form.$elementName.html}</div>
-        <div class="clear"></div>
-    </div>
-{/foreach}
-
-<div class="crm-submit-buttons">
+<div class="crm-block crm-form-block">
+  <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>  
+  <table class="form-layout-compressed">
+    <tbody>
+      {foreach from=$settingFields item=elementName}
+        <tr>
+          <td class="label">
+            <label>{$form.$elementName.label} {help id=$elementName file="CRM/MembershipExtras/Form/PaymentPlanSettings.hlp"}</label>
+          </td>
+          <td>
+            {$form.$elementName.html}
+          </td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
 </div>


### PR DESCRIPTION
## Overview
PR contains HTML fixes for Membership extras form so that they follow the default form markup of civicrm.

### Before fix
#### With vanilla CiviCRM
* Payment Plan Settings form 1
  <img width="789" alt="payment plan settings-1 - intial - vanila civi" src="https://user-images.githubusercontent.com/3340537/42676129-8df69a18-8694-11e8-8e3e-01cf60203797.png">
* Payment Plan Settings form 2
  <img width="769" alt="payment plan settings-2 - intial - vanila civi" src="https://user-images.githubusercontent.com/3340537/42676130-8e35c40e-8694-11e8-8fa7-1288e2431729.png">
#### With Shoreditch Enabled
* Payment Plan Settings form 1
  <img width="803" alt="payment plan settings-1 - intial - shoreditch" src="https://user-images.githubusercontent.com/3340537/42676159-ad7b94c4-8694-11e8-80bd-5a421341f07f.png">
* Payment Plan Settings form 2
  <img width="863" alt="payment plan settings-2 - intial - shoreditch" src="https://user-images.githubusercontent.com/3340537/42676160-adb7996a-8694-11e8-8b20-35397a18ee59.png">
### After fix
#### With vanilla CiviCRM
* Payment Plan Settings form 1
  <img width="750" alt="payment plan settings-1 - final - vanila civi" src="https://user-images.githubusercontent.com/3340537/42676280-2d78022a-8695-11e8-9258-a60bdedbe12c.png">
* Payment Plan Settings form 2
  <img width="731" alt="payment plan settings-2 - final - vanila civi" src="https://user-images.githubusercontent.com/3340537/42676279-2d37cc00-8695-11e8-8062-c880ce377007.png">
#### With Shoreditch Enabled
* Payment Plan Settings form 1
  <img width="732" alt="payment plan settings-1 - final - shoreditch" src="https://user-images.githubusercontent.com/3340537/42676305-4503b9ca-8695-11e8-984d-791e43d1da57.png">
* Payment Plan Settings form 2
  <img width="738" alt="payment plan settings-2 - final - shoreditch" src="https://user-images.githubusercontent.com/3340537/42676304-44c1603e-8695-11e8-8118-00d6ac807aca.png">

### Changes from b209668 and 475272a
* Alignment fix for *Contribution and Payment Plan* toggle button box.
  #### Before/After with Shoreditch
  
  <img width="1680" alt="contribution and payment plan - toggle - shoreditch - before" src="https://user-images.githubusercontent.com/3340537/43010354-d38e3788-8c5d-11e8-8e25-1930da4e9d9c.png">

  <img width="1666" alt="contribution and payment plan - toggle - shore ditch - after" src="https://user-images.githubusercontent.com/3340537/43010353-d3570290-8c5d-11e8-9915-62f5405d35ab.png">
  
 #### Before/After with Default Civi
  
  <img width="1680" alt="contribution and payment plan - toggle - default - before" src="https://user-images.githubusercontent.com/3340537/43010304-b2985d56-8c5d-11e8-9e4f-96fa39eaeb8a.png">
  <img width="1549" alt="contribution and payment plan -toggle - default -after" src="https://user-images.githubusercontent.com/3340537/43010305-b2cd31ac-8c5d-11e8-801b-2144203c9ff3.png">

#### Other details
 After alignment markup fixes. The alignment looks perfect with default Civi but looks a bit misaligned from left by 20px. To have this working with shoreditch we will need a new PR to the shoreditch theme as this will be a shoreditch specific fix. Please refer SHOR-50 (https://compucorp.atlassian.net/browse/SHOR-50)
