### PR TITLE
BASW-211: Copy custom groups during offline auto-renew and add settin to allow for exculding some custom groups

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentPlanSettings.php
+++ b/CRM/MembershipExtras/Form/PaymentPlanSettings.php
@@ -91,7 +91,7 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
   private function getCustomGroupsToExcludeFieldOptions() {
     $customGroups = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
-      'return' => ["id", "title"],
+      'return' => ['id', 'title', 'extends'],
       'extends' => ['IN' => ['Contribution', 'ContributionRecur']],
       'options' => ['limit' => 0],
     ]);
@@ -99,7 +99,7 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
     $customGroupsOptions = [];
     if (!empty($customGroups['values'])) {
       foreach ($customGroups['values'] as $customGroup) {
-        $customGroupsOptions[$customGroup['id']] = $customGroup['title'];
+        $customGroupsOptions[$customGroup['id']] =  $customGroup['extends'] . ' : ' . $customGroup['title'];
       }
     }
 

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -14,6 +14,14 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
   private $financialTypesIDMap = [];
 
   /**
+   * The ID of the previous recurring Contribution linked
+   * with the membership that after the renewal.
+   *
+   * @var int
+   */
+  private $previousRecurContributionID;
+
+  /**
    * The ID of the recurring Contribution linked
    * with the membership that currently
    * being renewed/processed.
@@ -143,6 +151,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
   public function run() {
    $recurContributions = $this->getOfflineAutoRenewalRecurContributions();
    foreach ($recurContributions as $recurContribution) {
+     $this->previousRecurContributionID = $recurContribution['contribution_recur_id'];
      $this->currentRecurContributionID = $recurContribution['contribution_recur_id'];
 
      if (empty($recurContribution['installments'])) {
@@ -609,8 +618,8 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
 
       $nullObject = CRM_Utils_Hook::$_nullObject;
       CRM_Utils_Hook::singleton()->invoke(
-        ['membershipId', 'recurContributionId'], $membershipPayment['membership_id'],
-        $this->currentRecurContributionID, $nullObject, $nullObject, $nullObject, $nullObject,
+        ['membershipId', 'recurContributionId', 'previousRecurContributionId'], $membershipPayment['membership_id'],
+        $this->currentRecurContributionID, $this->previousRecurContributionID, $nullObject, $nullObject, $nullObject,
         'membershipextras_postOfflineAutoRenewal');
     }
   }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -463,6 +463,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
       'start_date' => $this->paymentPlanStartDate,
     ])['values'][0];
 
+    CRM_MembershipExtras_Service_CustomFieldsCopier::copy(
+      $currentRecurContribution['id'],
+      $newRecurringContribution['id'],
+      'ContributionRecur'
+    );
+
     // The new recurring contribution is now the current one.
     $this->currentRecurContributionID = $newRecurringContribution['id'];
   }
@@ -550,6 +556,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
       $contributionSoftParams['amount'] = $contribution->total_amount;
       CRM_Contribute_BAO_ContributionSoft::add($contributionSoftParams);
     }
+
+    CRM_MembershipExtras_Service_CustomFieldsCopier::copy(
+      $this->lastContribution['id'],
+      $contribution->id,
+      'Contribution'
+    );
 
     $membershipPayments = civicrm_api3('MembershipPayment', 'get', [
       'return' => 'membership_id',

--- a/CRM/MembershipExtras/Service/CustomFieldsCopier.php
+++ b/CRM/MembershipExtras/Service/CustomFieldsCopier.php
@@ -1,0 +1,25 @@
+<?php
+
+class CRM_MembershipExtras_Service_CustomFieldsCopier {
+
+  public static function copy($sourceEntityId, $destinationEntityId, $entityName) {
+    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($sourceEntityId, $entityName);
+    if (empty($customValues)) {
+      return;
+    }
+
+    $customFieldsIdsToExcludeForAutoRenew = CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew();
+
+    $customParams = [];
+    foreach ($customValues as $key => $value) {
+      if (!empty($value) && !in_array($key, $customFieldsIdsToExcludeForAutoRenew)) {
+        $customParams["custom_{$key}"] = $value;
+      }
+    }
+
+    if (!empty($customParams)) {
+      $customParams['id'] = $destinationEntityId;
+      civicrm_api3($entityName, 'create', $customParams);
+    }
+  }
+}

--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -162,7 +162,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       $this->lastContribution['id'],
       $contribution->id,
       'Contribution'
-      );
+    );
 
     return $contribution;
   }

--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -158,7 +158,11 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       ]);
     }
 
-    $this->copyContributionCustomFields($contribution->id);
+    CRM_MembershipExtras_Service_CustomFieldsCopier::copy(
+      $this->lastContribution['id'],
+      $contribution->id,
+      'Contribution'
+      );
 
     return $contribution;
   }

--- a/CRM/MembershipExtras/SettingsManager.php
+++ b/CRM/MembershipExtras/SettingsManager.php
@@ -30,6 +30,30 @@ class CRM_MembershipExtras_SettingsManager {
     return $daysToRenewInAdvance;
   }
 
+  public static function getCustomFieldsIdsToExcludeForAutoRenew() {
+    $customGroupsIdsToExcludeForAutoRenew = self::getSettingValue('membershipextras_customgroups_to_exclude_for_autorenew');
+    if (empty($customGroupsIdsToExcludeForAutoRenew)) {
+      return [];
+    }
+
+    $customFieldsToExcludeForAutoRenew = civicrm_api3('CustomField', 'get', [
+      'return' => ['id'],
+      'sequential' => 1,
+      'custom_group_id' => ['IN' => $customGroupsIdsToExcludeForAutoRenew],
+      'options' => ['limit' => 0],
+    ]);
+    if (empty($customFieldsToExcludeForAutoRenew['values'])) {
+      return [];
+    }
+
+    $customFieldsIdsToExcludeForAutoRenew = [];
+    foreach($customFieldsToExcludeForAutoRenew['values'] as $customField) {
+      $customFieldsIdsToExcludeForAutoRenew[] = $customField['id'];
+    }
+
+    return $customFieldsIdsToExcludeForAutoRenew;
+  }
+
   private static function getSettingValue($settingName) {
     return civicrm_api3('Setting', 'get', [
       'sequential' => 1,

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -44,4 +44,20 @@ return [
     'description' => 'Number of days in advance of membership end date should an offline auto-renew membership get renewed.',
     'help_text' => 'Number of days in advance of membership end date should an offline auto-renew membership get renewed.',
   ],
+  'membershipextras_customgroups_to_exclude_for_autorenew' => [
+    'name' => 'membershipextras_customgroups_to_exclude_for_autorenew',
+    'group_name' => 'MembershipExtras: Payment Plan',
+    'group' => 'membershipextras_paymentplan',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'add' => '4.7',
+    'title' => 'Custom groups to be excluded when auto-renew"',
+    'html_type' => 'select',
+    'is_required' => FALSE,
+    'extra_attributes' => [
+      'class' => 'crm-select2',
+      'multiple' => 'multiple',
+      'placeholder' => ts('- select -'),
+    ],
+  ],
 ];

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
@@ -21,3 +21,8 @@
 {htxt id="membershipextras_paymentplan_days_to_renew_in_advance"}
 {ts}Number of days in advance of membership end date should an offline auto-renew membership get renewed.{/ts}
 {/htxt}
+
+{htxt id="membershipextras_customgroups_to_exclude_for_autorenew"}
+{ts}Custom groups to be excluded (ignored) from copying during the offline auto-renewal scheduled job running{/ts}
+{/htxt}
+


### PR DESCRIPTION
## Before

When the the offline auto-renewal scheduled job auto-renew the offline memberships, the new contributions and the new recurring contribution will not have the custom fields exsisted in the previous contributions and recurring contribution, but we need all of them to be copied, we also want a setting that prevent certain custom groups fields to be copied such as odoo sync information custom group.

![2018-07-24 19_18_58-payment plan settings _ dmaster14](https://user-images.githubusercontent.com/6275540/43152157-aef3278e-8f65-11e8-8662-868dd931b448.png)


## After


The offline auto-renewal scheduled job now copy all the contributions and recurring contribution custom fields from the previous ones. it also has a new multi-select box setting that allow users to choose which custom groups to exclude during the copy.


![aaaaaa](https://user-images.githubusercontent.com/6275540/43152161-b44ba56c-8f65-11e8-843d-b005c61d72da.gif)



## Other notes

I also changed the signature of : 

membershipextras_postOfflineAutoRenewal

hook to pass the previous recurring contribution ID (the recurring contribution before the renewal in case of payment plan payments) as a third parameter.