### PR TITLE
BASW-212: View a Recurring Contribution's Line Items

### DIFF
--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -56,6 +56,15 @@ class CRM_MembershipExtras_Hook_Links_RecurringContribution {
         $this->mask |= CRM_Core_Action::UPDATE;
       }
     }
+
+    if ($this->isManualPaymentPlan()) {
+      $this->links[] = [
+        'name' => 'View/Update Recurring Line Items',
+        'url' => 'civicrm/recurring-contribution/edit-lineitems',
+        'qs' => 'reset=1&crid=%%crid%%&cid=%%cid%%&context=contribution',
+        'title' => 'View/Update Recurring Line Items',
+      ];
+    }
   }
 
   /**
@@ -68,7 +77,7 @@ class CRM_MembershipExtras_Hook_Links_RecurringContribution {
       'id' => $this->recurringContributionID
     ]);
 
-    $paymentProcessorID = $recurringContribution['payment_processor_id'];
+    $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $recurringContribution);
     $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
     $isOfflineContribution = in_array($paymentProcessorID, $manualPaymentProcessors);
 

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -3,10 +3,63 @@ use CRM_MembershipExtras_ExtensionUtil as E;
 
 class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_Page {
 
+  /**
+   * ID of the recurring contribution being viewed.
+   *
+   * @var int
+   */
+  private $contribRecur;
+
+  /**
+   * List of available financial types in the system.
+   *
+   * @var array
+   */
+  private $financialTypes;
+
+  /**
+   * @inheritdoc
+   */
+  public function __construct($title = NULL, $mode = NULL) {
+    parent::__construct($title, $mode);
+
+    $this->contribRecur = $this->getRecurringContribution();
+    $this->financialTypes = $this->getFinancialTypes();
+  }
+
+  /**
+   * Loads recurring contribution identified by ID set in request.
+   *
+   * @return array
+   */
+  private function getRecurringContribution() {
+    $recurringContributionID = CRM_Utils_Request::retrieveValue('crid', 'Positive', 0);
+
+    return $result = civicrm_api3('ContributionRecur', 'getsingle', [
+      'id' => $recurringContributionID,
+    ]);
+  }
+
+  /**
+   * Loads available financial types.
+   *
+   * @return array
+   */
+  private function getFinancialTypes() {
+    $financialTypes = civicrm_api3('FinancialType', 'get', []);
+
+    return $financialTypes['values'];
+  }
+
+  /**
+   * @inheritdoc
+   */
   public function run() {
     // Example: Set the page-title dynamically; alternatively, declare a static title in xml/Menu/*.xml
     CRM_Utils_System::setTitle(E::ts('View/Update Recurring Line Items'));
 
+    $this->assign('periodStartDate', CRM_Utils_Array::value('start_date', $this->contribRecur));
+    $this->assign('periodEndDate', CRM_Utils_Array::value('end_date', $this->contribRecur));
     $this->assign('lineItems', $this->getLineItems());
 
     parent::run();
@@ -18,7 +71,44 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @return array
    */
   private function getLineItems() {
+    $lineItems = array();
 
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->contribRecur['id'],
+      'api.LineItem.getsingle' => [
+        'id' => '$value.line_item_id',
+        'entity_table' => ['IS NOT NULL' => 1],
+        'entity_id' => ['IS NOT NULL' => 1]
+      ],
+    ]);
+
+    if ($result['count'] > 0) {
+      foreach ($result['values'] as $lineItemData) {
+        $lineDetails = $lineItemData['api.LineItem.getsingle'];
+        unset($lineItemData['api.LineItem.getsingle']);
+
+        $lineDetails['financial_type'] = $this->getFinancialTypeName($lineDetails['financial_type_id']);
+        $lineItems[] = array_merge($lineItemData, $lineDetails);
+      }
+    }
+
+    return $lineItems;
+  }
+
+  /**
+   * Returns the financil type's name identified by the given ID.
+   *
+   * @param int $id
+   *
+   * @return string
+   */
+  private function getFinancialTypeName($id) {
+    if (in_array($id, array_keys($this->financialTypes))) {
+      return $this->financialTypes[$id]['name'];
+    }
+
+    return '';
   }
 
 }

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -1,0 +1,24 @@
+<?php
+use CRM_MembershipExtras_ExtensionUtil as E;
+
+class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_Page {
+
+  public function run() {
+    // Example: Set the page-title dynamically; alternatively, declare a static title in xml/Menu/*.xml
+    CRM_Utils_System::setTitle(E::ts('View/Update Recurring Line Items'));
+
+    $this->assign('lineItems', $this->getLineItems());
+
+    parent::run();
+  }
+
+  /**
+   * Obtains list of line items for the current recurring contribution.
+   *
+   * @return array
+   */
+  private function getLineItems() {
+
+  }
+
+}

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -35,7 +35,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
   private function getRecurringContribution() {
     $recurringContributionID = CRM_Utils_Request::retrieveValue('crid', 'Positive', 0);
 
-    return $result = civicrm_api3('ContributionRecur', 'getsingle', [
+    return civicrm_api3('ContributionRecur', 'getsingle', [
       'id' => $recurringContributionID,
     ]);
   }
@@ -46,7 +46,9 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @return array
    */
   private function getFinancialTypes() {
-    $financialTypes = civicrm_api3('FinancialType', 'get', []);
+    $financialTypes = civicrm_api3('FinancialType', 'get', [
+      'options' => ['limit' => 0],
+    ]);
 
     return $financialTypes['values'];
   }
@@ -55,7 +57,6 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @inheritdoc
    */
   public function run() {
-    // Example: Set the page-title dynamically; alternatively, declare a static title in xml/Menu/*.xml
     CRM_Utils_System::setTitle(E::ts('View/Update Recurring Line Items'));
 
     $this->assign('periodStartDate', CRM_Utils_Array::value('start_date', $this->contribRecur));

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -1,0 +1,78 @@
+<div class="right">
+  Period Start Date: {$periodStartDate|date_format}
+  &nbsp;&nbsp;&nbsp;
+  Period End Date: {$periodEndDate|date_format}
+</div>
+<table class="selector row-highlight">
+  <tbody>
+  <tr class="columnheader">
+    <th scope="col">{ts}Item{/ts}</th>
+    <th scope="col">{ts}Start Date{/ts}</th>
+    <th scope="col">{ts}End Date{/ts}</th>
+    <th scope="col">{ts}Renew Automatically{/ts}</th>
+    <th scope="col">{ts}Financial Type{/ts}</th>
+    <th scope="col">{ts}Tax{/ts}</th>
+    <th scope="col">{ts}Amount{/ts}</th>
+    <th scope="col">&nbsp;</th>
+  </tr>
+  {assign var='subTotal' value=0}
+  {assign var='taxTotal' value=0}
+  {assign var='installmentTotal' value=0}
+
+  {foreach from=$lineItems item='currentItem'}
+    {assign var='subTotal' value=$subtotal+$currentItem.line_total}
+    {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
+
+    <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
+      <td>{$currentItem.label}</td>
+      <td>{$currentItem.start_date|date_format}</td>
+      <td>{$currentItem.end_date|date_format}</td>
+      <td>{$currentItem.auto_renew}</td>
+      <td>{$currentItem.financial_type}</td>
+      <td>{$currentItem.tax_amount|crmMoney}</td>
+      <td>{$currentItem.line_total|crmMoney}</td>
+      <td>
+        <a class="delete" href="">
+          <span><i class="crm-i fa-trash"></i></span>
+        </a>
+      </td>
+    </tr>
+  {/foreach}
+  {assign var='installmentTotal' value=$subTotal+$taxTotal}
+  </tbody>
+</table>
+<div id="current_buttons">
+  <a class="button" href="">
+    <span><i class="crm-i fa-plus"></i>&nbsp; Add Membership</span>
+  </a>
+  <a class="button" href="">
+    <span><i class="crm-i fa-plus"></i>&nbsp; Add Other Amount</span>
+  </a>
+</div>
+<div class="clear"></div>
+<div class="right">
+  <table class="form-layout-compressed" align="right">
+    <tr>
+      <td colspan="2">
+        <hr/>
+      </td>
+    </tr>
+    <tr>
+      <td class="contriTotalLeft right">{ts}Untaxed Amount:{/ts}</td>
+      <td>{$subTotal|crmMoney}</td>
+    </tr>
+    <tr>
+      <td class="contriTotalLeft right">{ts}Tax:{/ts}</td>
+      <td>{$taxTotal|crmMoney}</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <hr/>
+      </td>
+    </tr>
+    <tr>
+      <td class="contriTotalLeft right">{ts}Total per Installment:{/ts}</td>
+      <td>{$installmentTotal|crmMoney}</td>
+    </tr>
+  </table>
+</div>

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -27,7 +27,7 @@
       <td>{$currentItem.label}</td>
       <td>{$currentItem.start_date|date_format}</td>
       <td>{$currentItem.end_date|date_format}</td>
-      <td>{$currentItem.auto_renew}</td>
+      <td><input type="checkbox" disabled{if $currentItem.auto_renew} checked{/if} /></td>
       <td>{$currentItem.financial_type}</td>
       <td>{$currentItem.tax_amount|crmMoney}</td>
       <td>{$currentItem.line_total|crmMoney}</td>

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -1,3 +1,75 @@
-<h3></h3>
+<div id="periodsContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
+  {* Tab management *}
+  <script type="text/javascript">
+    var selectedTab  = 'contributions';
+    {literal}
+    CRM.$(function($) {
+      var tabIndex = $('#tab_' + selectedTab).prevAll().length;
+      $("#periodsContainer").tabs({active: tabIndex});
+      $(".crm-tab-button").addClass("ui-corner-bottom");
+    });
+    {/literal}
+  </script>
+  <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
+    <li id="tab_current" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
+      <a href="#current-subtab" title="{ts}Contributions{/ts}">
+        {ts}Current Period{/ts}
+      </a>
+    </li>
+    <li id="tab_next" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
+      <a href="#next-subtab" title="{ts}Recurring Contributions{/ts}">
+        {ts}Next Period{/ts}
+      </a>
+    </li>
+  </ul>
 
-[ LINE TEM LIST ]
+  <div id="current-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
+    <div class="right">
+      Period Start Date: {$periodStartDate|date_format}
+      &nbsp;&nbsp;&nbsp;
+      Period End Date: {$periodEndDate|date_format}
+    </div>
+    <table class="selector row-highlight">
+      <tbody>
+      <tr class="columnheader">
+        <th scope="col">{ts}Item{/ts}</th>
+        <th scope="col">{ts}Start Date{/ts}</th>
+        <th scope="col">{ts}End Date{/ts}</th>
+        <th scope="col">{ts}Renew Automatically{/ts}</th>
+        <th scope="col">{ts}Financial Type{/ts}</th>
+        <th scope="col">{ts}Tax{/ts}</th>
+        <th scope="col">{ts}Amount{/ts}</th>
+        <th scope="col">&nbsp;</th>
+      </tr>
+      {foreach from=$lineItems item='currentItem'}
+        <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
+          <td>{$currentItem.label}</td>
+          <td>{$currentItem.start_date|date_format}</td>
+          <td>{$currentItem.end_date|date_format}</td>
+          <td>{$currentItem.auto_renew}</td>
+          <td>{$currentItem.financial_type}</td>
+          <td>{$currentItem.tax_amount|crmMoney}</td>
+          <td>{$currentItem.line_total|crmMoney}</td>
+          <td>
+            <a class="delete" href="">
+              <span><i class="crm-i fa-trash"></i></span>
+            </a>
+          </td>
+        </tr>
+      {/foreach}
+      </tbody>
+    </table>
+    <div id="current_buttons">
+      <a class="button" href="">
+        <span><i class="crm-i fa-plus"></i>&nbsp; Add Membership</span>
+      </a>
+      <a class="button" href="">
+        <span><i class="crm-i fa-plus"></i>&nbsp; Add Other Amount</span>
+      </a>
+    </div>
+  </div>
+  <div id="next-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
+    [ NEXT PERIOD ]
+  </div>
+  <div class="clear"></div>
+</div>

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -24,49 +24,7 @@
   </ul>
 
   <div id="current-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
-    <div class="right">
-      Period Start Date: {$periodStartDate|date_format}
-      &nbsp;&nbsp;&nbsp;
-      Period End Date: {$periodEndDate|date_format}
-    </div>
-    <table class="selector row-highlight">
-      <tbody>
-      <tr class="columnheader">
-        <th scope="col">{ts}Item{/ts}</th>
-        <th scope="col">{ts}Start Date{/ts}</th>
-        <th scope="col">{ts}End Date{/ts}</th>
-        <th scope="col">{ts}Renew Automatically{/ts}</th>
-        <th scope="col">{ts}Financial Type{/ts}</th>
-        <th scope="col">{ts}Tax{/ts}</th>
-        <th scope="col">{ts}Amount{/ts}</th>
-        <th scope="col">&nbsp;</th>
-      </tr>
-      {foreach from=$lineItems item='currentItem'}
-        <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
-          <td>{$currentItem.label}</td>
-          <td>{$currentItem.start_date|date_format}</td>
-          <td>{$currentItem.end_date|date_format}</td>
-          <td>{$currentItem.auto_renew}</td>
-          <td>{$currentItem.financial_type}</td>
-          <td>{$currentItem.tax_amount|crmMoney}</td>
-          <td>{$currentItem.line_total|crmMoney}</td>
-          <td>
-            <a class="delete" href="">
-              <span><i class="crm-i fa-trash"></i></span>
-            </a>
-          </td>
-        </tr>
-      {/foreach}
-      </tbody>
-    </table>
-    <div id="current_buttons">
-      <a class="button" href="">
-        <span><i class="crm-i fa-plus"></i>&nbsp; Add Membership</span>
-      </a>
-      <a class="button" href="">
-        <span><i class="crm-i fa-plus"></i>&nbsp; Add Other Amount</span>
-      </a>
-    </div>
+    {include file="CRM/MembershipExtras/Page/CurrentPeriodTab.tpl"}
   </div>
   <div id="next-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
     [ NEXT PERIOD ]

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -1,0 +1,3 @@
+<h3></h3>
+
+[ LINE TEM LIST ]

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -12,4 +12,10 @@
     <title>Cancel Recurring Contribution</title>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/recurring-contribution/edit-lineitems</path>
+    <page_callback>CRM_MembershipExtras_Page_EditContributionRecurLineItems</page_callback>
+    <title>EditContributionRecurLineItems</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -16,6 +16,6 @@
     <path>civicrm/recurring-contribution/edit-lineitems</path>
     <page_callback>CRM_MembershipExtras_Page_EditContributionRecurLineItems</page_callback>
     <title>EditContributionRecurLineItems</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>edit contributions</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
We need to add a "View/Modify Future Instalments" action to any recurring contribution that uses an offline payment processor (payment processor with payment manual class).
When the action is selected, a "Manage Instalments" modal popup should appear.
In the current period tab (default), each "offline_contribution_recur_line_item" with empty end date should be displayed. Each row should have the following information:
- Item - line item label
- Start date - start_date in offline_contribution_recur_line_item
- End date - biggest end date among all linked memberships
- Renew automatically - auto_renew in offline_contribution_recur_line_item. This should not show if the recurring contribution is not auto-renew.
- Financial type - financial type of the line item
- Tax - the tax percentage of the financial type, show N/A if there is no tax account in the financial type
- Amount - line total of the line item
- Remove button - show as bin icon
- An "Add Membership" button and an "Add Other Amount" button should be shown under the last row

At the bottom of the tab, the following information should be shown: 
- Untaxed Amount - total amount of the line_totals
- Tax - total amount of tax_amounts
- Total per instalment - sum of a and b

## Before
Action did not exist.

## After
Action was aded only to offline manual payment recurring contributions, and a new page added to implement the tabs. Only the first tab was implemented, showing the line items for the current period.

![image](https://user-images.githubusercontent.com/21999940/43395723-b2479a42-93c4-11e8-9f1b-d2e83415dea9.png)
