### PR TITLE
BASW-65: Ensure the any cancelled payment plan will not be counted in arrears

### DIFF
--- a/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
+++ b/CRM/MembershipExtras/Hook/Alter/CalculatedMembershipStatus.php
@@ -313,7 +313,8 @@ class CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus {
 
   /**
    * Checks if membership is in arrears, by checking if any pending payments
-   * associated to a payment plan land before the adjusted reference date.
+   * associated to a payment plan land before the adjusted reference date and
+   * no payment is cancelled.
    *
    * @param string $referenceDateString
    *   Date to use as reference to check if membership is in arrears
@@ -362,15 +363,17 @@ class CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus {
       FROM civicrm_membership_payment
       INNER JOIN civicrm_contribution ON civicrm_membership_payment.contribution_id = civicrm_contribution.id
       INNER JOIN civicrm_contribution_recur ON civicrm_contribution.contribution_recur_id = civicrm_contribution_recur.id
-      WHERE civicrm_membership_payment.membership_id = %1
-      AND civicrm_contribution.contribution_status_id = %2
-      AND civicrm_contribution.receive_date <= %3
+      WHERE civicrm_membership_payment.membership_id = %1 
+      AND civicrm_contribution.contribution_status_id = %2 
+      AND civicrm_contribution.receive_date <= %3 
+      AND civicrm_contribution_recur.contribution_status_id != %4 
       AND civicrm_contribution_recur.installments > 0
     ";
     $pendingContributionsResult = CRM_Core_DAO::executeQuery($query, [
       1 => [$this->membership['id'], 'Integer'],
       2 => [self::$contributionStatusValueMap['Pending'], 'String'],
       3 => [$adjustedReferenceDate, 'String'],
+      4 => [self::$contributionStatusValueMap['Cancelled'], 'String'],
     ]);
     $pendingContributionsResult->fetch();
 


### PR DESCRIPTION
## Overview

Cancelled payment plan should not be counted when considering either trigger.


## Example 

If a contact has a membership that starts at 01/01/2017 and ends at 31/12/2019

a) If the membership links to two payment plans:
1. payment plan in 12 instalments, starts 01/01/2017 ends 31/12/2018, status in progress, a pending instalment in the past
1. payment plan in 12 instalments, starts 01/08/2018 ends 31/7/2019, status pending, 12 pending instalments in the future

The membership should be in arrears.

b) If the membership links to two payment plans:
1. payment plan in 12 instalments, starts 01/01/2017 ends 31/12/2018, status cancelled, a pending instalment in the past
1. payment plan in 12 instalments, starts 01/08/2018 ends 31/7/2019, status pending, 12 pending instalments in the future

The membership should not be in arrears.