### PR TITLE
BASW-211: Fixes and improvements to "custom fields to exclude" setting field

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentPlanSettings.php
+++ b/CRM/MembershipExtras/Form/PaymentPlanSettings.php
@@ -93,6 +93,7 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
       'sequential' => 1,
       'return' => ['id', 'title', 'extends'],
       'extends' => ['IN' => ['Contribution', 'ContributionRecur']],
+      'is_active' => 1,
       'options' => ['limit' => 0],
     ]);
 

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
@@ -23,6 +23,7 @@
 {/htxt}
 
 {htxt id="membershipextras_customgroups_to_exclude_for_autorenew"}
-{ts}Custom groups to be excluded (ignored) from copying during the offline auto-renewal scheduled job running{/ts}
+{ts}Information in selected custom groups will not be copied over to any new installments 
+ of an existing payment plan when it auto-renew.{/ts}
 {/htxt}
 


### PR DESCRIPTION
This PR : 

1- Ensure that only active custom groups appear on the "custom fields to exclude" setting field.
2- Improve the help text for the same field