### PR TITLE
DD-50: Fix membership renewal broken form

### DIFF
--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -3,7 +3,10 @@
   var membershipextras_allMembershipData = {$allMembershipInfo};
   var membershipextras_taxRatesStr = '{$taxRates}';
   var membershipextras_taxTerm = '{$taxTerm}';
-  var membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
+  if (membershipextras_taxRatesStr != '') {
+    var membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
+  }
+
   var membershipextras_currency = '{$currency}';
 
   {literal}


### PR DESCRIPTION
## Problem

The membership renewal form is broken, it looks like this currently : 

![ddddd](https://user-images.githubusercontent.com/6275540/43413464-03ccea80-9428-11e8-9579-ae409ba3c4a9.gif)


## Solution

The templates/CRM/Member/Form/PaymentPlanToggler.tpl file was parsing the tax rates JSON using JSON.pare(membershipextras_taxRatesStr), but if there are no tax accounts configured then the membershipextras_taxRatesStr will be empty and a JS error will be thrown that break the form. I added a check to ensure that the tax rates are not empty before parsing them.


![vvfdvfdvfd](https://user-images.githubusercontent.com/6275540/43413602-6c97ff46-9428-11e8-9aed-ce093f0d60f4.gif)
