### PR TITLE
BASW-113: Fix Permissions for Payment Plan Cancellation

### DIFF
--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -10,6 +10,6 @@
     <path>civicrm/recurring-contribution/cancel</path>
     <page_callback>CRM_MembershipExtras_Form_CancelRecurringContribution</page_callback>
     <title>Cancel Recurring Contribution</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>edit contributions,edit memberships</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
Permission to cancel a payment plan’s recurring contribution was 'administer CiviCRM'. We need to change this so users with edit contributions AND edit memberships permissions.

## Before
Permission set on route in Menu XML was administer CiviCRM.

## After
Permission to cancel recurring contributions was changed from administer CiviCRM to require both edit contributions AND edit memberships permissions.