### PR TITLE
BASW-218: Remove Payment Plan Line Items

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -1,0 +1,268 @@
+<?php
+
+use CRM_MembershipExtras_ExtensionUtil as E;
+
+/**
+ * Form controller class to allow removal of line items from a recurring
+ * contribution.
+ */
+class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CRM_Core_Form {
+
+  private $recurringContributionID;
+  private $lineItemID;
+  private $recurringLineItemData = array();
+
+  /**
+   * @inheritdoc
+   */
+  public function preProcess() {
+    $this->recurringContributionID = CRM_Utils_Request::retrieve('contribution_recur_id', 'Positive', $this);
+    $this->lineItemID = CRM_Utils_Request::retrieve('line_item_id', 'Positive', $this);
+    $this->recurringLineItemData = $this->getRecurringLineItemData();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function setDefaultValues() {
+    return array(
+      'end_date' => date('Y-m-d')
+    );
+  }
+
+  /**
+   * Returns data for the line item identified by the ID sent in the request.
+   *
+   * @return array
+   */
+  private function getRecurringLineItemData() {
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->recurringContributionID,
+      'line_item_id' => $this->lineItemID,
+      'api.LineItem.getsingle' => [
+        'id' => '$value.line_item_id',
+        'entity_table' => ['IS NOT NULL' => 1],
+        'entity_id' => ['IS NOT NULL' => 1]
+      ],
+    ]);
+
+    // Flatten array
+    if ($result['count'] > 0) {
+      $lineItemData = $result['values'][0];
+      $lineDetails = $lineItemData['api.LineItem.getsingle'];
+      unset($lineItemData['api.LineItem.getsingle']);
+      unset($lineDetails['id']);
+
+      return array_merge($lineItemData, $lineDetails);
+    }
+
+    return array();
+  }
+
+  /**
+  * @inheritdoc
+  */
+  public function buildQuickForm() {
+    $lineItemLabel = $this->recurringLineItemData['label'];
+    CRM_Utils_System::setTitle(E::ts('Remove ' . $lineItemLabel . '?'));
+
+    $this->assign('lineItem', $this->recurringLineItemData);
+
+    $this->add('checkbox', 'adjust_end_date', ts('Adjust End Date?'));
+    $this->add(
+      'datepicker',
+      'end_date',
+      ts('End Date'),
+      '',
+      FALSE,
+      ['minDate' => time(), 'time' => FALSE]
+    );
+
+    $this->addButtons([
+      [
+          'type' => 'submit',
+          'name' => E::ts('Apply'),
+          'isDefault' => TRUE,
+      ],
+      [
+          'type' => 'cancel',
+          'name' => E::ts('Cancel'),
+          'isDefault' => FALSE,
+      ],
+    ]);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function postProcess() {
+    try {
+      if ($this->isLineItemAMembership()) {
+        $this->cancelMembership();
+      }
+
+      $this->adjustPendingContributions();
+      $this->updateRecurringLineItem();
+    } catch (Exception $e) {
+      CRM_Core_Session::setStatus(
+        "An error ocurred trying to remove {$this->recurringLineItemData['label']} from the current recurring contribution:" . $e->getMessage(),
+        "Error Removing {$this->recurringLineItemData['label']}",
+        'error'
+      );
+
+      return;
+    }
+
+    CRM_Core_Session::setStatus(
+      "{$this->recurringLineItemData['label']} has been removed from the active order.",
+      "Remove {$this->recurringLineItemData['label']}",
+      'success'
+    );
+
+    CRM_Core_Session::setStatus(
+      "{$this->recurringLineItemData['label']} should no longer be continued in the next period.",
+      "Remove {$this->recurringLineItemData['label']}",
+      'success'
+    );
+  }
+
+  /**
+   * Checks if line item being removed is for a membership.
+   *
+   * @return bool
+   */
+  private function isLineItemAMembership() {
+    return CRM_MembershipExtras_Service_FinancialTransactionManager::isMembership($this->recurringLineItemData['line_item_id']);
+  }
+
+  /**
+   * Cancels membership identified by entity_id of line item.
+   */
+  private function cancelMembership() {
+    civicrm_api3('Membership', 'create', [
+      'id' => $this->recurringLineItemData['entity_id'],
+      'is_override' => 1,
+      'status_override_end_date' => '',
+      'status_id' => 'Cancelled',
+      'contribution_recur_id' => 0,
+    ]);
+  }
+
+  /**
+   * Makes adjustment for remaining contributions for payment plan, removing
+   * line item and adjustinc amounts.
+   */
+  private function adjustPendingContributions() {
+    foreach ($this->getPendingContributions() as $contribution) {
+      $this->cancelContributionLineItem($contribution);
+    }
+  }
+
+  /**
+   * Returns an array with the information of pending recurring contributions
+   * for the current recurring contribution.
+   *
+   * @return array
+   */
+  private function getPendingContributions() {
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->recurringContributionID,
+      'contribution_status_id' => 'Pending',
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+    return array();
+  }
+
+  /**
+   * Executes actions on line item to remove it from its contribution and update
+   * its amounts.
+   *
+   * @param $contribution
+   */
+  private function cancelContributionLineItem($contribution) {
+    $lineItemBefore = $this->getCorrespondingContributionLineItem($contribution['id']);
+
+    // change total_price and qty of current line item to 0
+    civicrm_api3('LineItem', 'create', array(
+      'id' => $lineItemBefore['id'],
+      'qty' => 0,
+      'participant_count' => 0,
+      'line_total' => 0.00,
+      'tax_amount' => 0.00,
+    ));
+
+    // calculate balance, tax and paid amount later used to adjust transaction
+    $updatedAmount = CRM_Price_BAO_LineItem::getLineTotal($contribution['id']);
+    $taxAmount = CRM_MembershipExtras_Service_FinancialTransactionManager::calculateTaxAmountTotalFromContributionID($contribution['id']);
+
+    // Record adjusted amount by updating contribution info and create necessary financial trxns
+    $this->recordAdjustedAmount($contribution, $updatedAmount, $taxAmount);
+
+    // Record financial item on cancel of lineitem
+    CRM_MembershipExtras_Service_FinancialTransactionManager::insertFinancialItemOnDeletion($lineItemBefore);
+  }
+
+  /**
+   * Obtains information about the line item that corresponds to the one being
+   * deleted from the recurring contribution for the given contribution.
+   *
+   * @param $contributionID
+   *
+   * @return array
+   */
+  private function getCorrespondingContributionLineItem($contributionID) {
+    $lineItem = civicrm_api3('LineItem', 'getsingle', array(
+      'contribution_id' => $contributionID,
+      'price_field_value_id' => $this->recurringLineItemData['price_field_value_id'],
+    ));
+
+    return $lineItem;
+  }
+
+  /**
+   * Stores updated amounts for given contribution.
+   *
+   * @param array $contribution
+   * @param double $updatedAmount
+   * @param double $taxAmount
+   */
+  private function recordAdjustedAmount($contribution, $updatedAmount, $taxAmount = NULL) {
+    $updatedContributionDAO = new CRM_Contribute_BAO_Contribution();
+    $updatedContributionDAO->id = $contribution['id'];
+    $updatedContributionDAO->total_amount = $updatedAmount;
+    $updatedContributionDAO->net_amount = $updatedAmount - CRM_Utils_Array::value('fee_amount', $contribution, 0);
+
+    if ($taxAmount) {
+      $updatedContributionDAO->tax_amount = $taxAmount;
+    }
+
+    $updatedContributionDAO->save();
+  }
+
+  /**
+   * Updates recurring contribution line item to set end date and remove auto
+   * renew option.
+   */
+  private function updateRecurringLineItem() {
+    $params = [
+      'id' => $this->recurringLineItemData['id'],
+      'auto_renew' => false,
+    ];
+
+    if ($this->getElementValue('adjust_end_date')) {
+      $params['end_date'] = $this->getElementValue('end_date');
+    } else {
+      $params['end_date'] = date('Y-m-d');
+    }
+
+    civicrm_api3('ContributionRecurLineItem', 'create', $params);
+  }
+
+}

--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -152,7 +152,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
     civicrm_api3('Membership', 'create', [
       'id' => $this->recurringLineItemData['entity_id'],
       'status_override_end_date' => '',
-      'contribution_recur_id' => 0,
+      'contribution_recur_id' => '',
       'end_date' => $endDate,
     ]);
   }

--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
@@ -49,6 +49,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor{
 
     if ($isPaymentPlanPayment) {
       $this->setRecurContributionAutoRenew($recurContributionID);
+      $this->setRecurringLineItemsAsAutoRenew($recurContributionID);
     }
   }
 
@@ -268,6 +269,19 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor{
     civicrm_api3('ContributionRecur', 'create', [
       'id' => $recurContributionID,
       'auto_renew' => 1,
+    ]);
+  }
+
+  /**
+   * Sets recurring contribution's line items' auto_renew field to true.
+   *
+   * @param $recurContributionID
+   */
+  private function setRecurringLineItemsAsAutoRenew($recurContributionID) {
+    civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $recurContributionID,
+      'api.ContributionRecurLineItem.create' => ['id' => '$value.id', 'auto_renew' => 1],
     ]);
   }
 

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -59,6 +59,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
   public function run() {
     CRM_Utils_System::setTitle(E::ts('View/Update Recurring Line Items'));
 
+    $this->assign('recurringContributionID', $this->contribRecur['id']);
     $this->assign('periodStartDate', CRM_Utils_Array::value('start_date', $this->contribRecur));
     $this->assign('periodEndDate', CRM_Utils_Array::value('end_date', $this->contribRecur));
     $this->assign('lineItems', $this->getLineItems());

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -57,12 +57,14 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @inheritdoc
    */
   public function run() {
-    CRM_Utils_System::setTitle(E::ts('View/Update Recurring Line Items'));
+    CRM_Utils_System::setTitle(E::ts('Manage Installments'));
 
     $this->assign('recurringContributionID', $this->contribRecur['id']);
+
     $this->assign('periodStartDate', CRM_Utils_Array::value('start_date', $this->contribRecur));
     $this->assign('periodEndDate', CRM_Utils_Array::value('end_date', $this->contribRecur));
-    $this->assign('lineItems', $this->getLineItems());
+    $this->assign('lineItems', $this->getLineItems(['end_date' => ['IS NULL' => 1]]));
+
     $this->assign('autoRenewEnabled', $this->isAutoRenewEnabled());
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => FALSE]));

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -134,9 +134,10 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     if ($result['count'] > 0) {
       foreach ($result['values'] as $lineItemData) {
         $lineDetails = $lineItemData['api.LineItem.getsingle'];
-        unset($lineItemData['api.LineItem.getsingle']);
-
+        $lineDetails['tax_rate'] = $this->getTaxRateForFinancialType($lineDetails['financial_type_id']);
         $lineDetails['financial_type'] = $this->getFinancialTypeName($lineDetails['financial_type_id']);
+
+        unset($lineItemData['api.LineItem.getsingle']);
         $lineItems[] = array_merge($lineItemData, $lineDetails);
       }
     }
@@ -154,6 +155,20 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       'sequential' => 1,
       'contribution_recur_id' => $this->contribRecur['id'],
     ])['values'];
+  }
+
+  /**
+   * Returns tax rate used for given financial type ID.
+   *
+   * @param $financialTypeID
+   *
+   * @return double
+   */
+  private function getTaxRateForFinancialType($financialTypeID) {
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    $rate = round(CRM_Utils_Array::value($financialTypeID, $taxRates, 0), 2);
+
+    return $rate;
   }
 
   /**

--- a/CRM/MembershipExtras/Service/FinancialTransactionManager.php
+++ b/CRM/MembershipExtras/Service/FinancialTransactionManager.php
@@ -30,10 +30,10 @@ class CRM_MembershipExtras_Service_FinancialTransactionManager {
    *
    * @param array $lineItemBefore
    */
-  public static function insertFinancialItemOnDeletion($lineItemBefore) {
-    $lineItemAfter = civicrm_api3('LineItem', 'getsingle', array(
+  public static function insertFinancialItemOnLineItemDeletion($lineItemBefore) {
+    $lineItemAfter = civicrm_api3('LineItem', 'getsingle', [
       'id' => $lineItemBefore['id'],
-    ));
+    ]);
 
     $lineItemBefore['tax_amount'] = CRM_Utils_Array::value('tax_amount', $lineItemBefore, 0);
     $lineItemAfter['tax_amount'] = CRM_Utils_Array::value('tax_amount', $lineItemAfter, 0);
@@ -43,7 +43,7 @@ class CRM_MembershipExtras_Service_FinancialTransactionManager {
 
     if ($deltaAmount != 0 || $deltaTaxAmount != 0) {
       $previousFinancialItem = CRM_Financial_BAO_FinancialItem::getPreviousFinancialItem($lineItemBefore['id']);
-      $financialItem = array(
+      $financialItem = [
         'transaction_date' => date('YmdHis'),
         'contact_id' => $previousFinancialItem['contact_id'],
         'description' => ($lineItemAfter['qty'] > 1 ? $lineItemAfter['qty'] . ' of ' : '') . $lineItemAfter['label'],
@@ -51,7 +51,7 @@ class CRM_MembershipExtras_Service_FinancialTransactionManager {
         'financial_account_id' => $previousFinancialItem['financial_account_id'],
         'entity_id' => $lineItemBefore['id'],
         'entity_table' => 'civicrm_line_item',
-      );
+      ];
 
       self::recordChangeInAmount(
         $lineItemAfter['contribution_id'],
@@ -117,7 +117,7 @@ class CRM_MembershipExtras_Service_FinancialTransactionManager {
       $isPayment = FALSE;
     }
 
-    $adjustedTrxnValues = array(
+    $adjustedTrxnValues = [
       'from_financial_account_id' => NULL,
       'to_financial_account_id' => $toFinancialAccount,
       'total_amount' => $amount,
@@ -128,7 +128,7 @@ class CRM_MembershipExtras_Service_FinancialTransactionManager {
       'trxn_date' => date('YmdHis'),
       'currency' => $contribution['currency'],
       'is_payment' => $isPayment,
-    );
+    ];
     $adjustedTrxn = CRM_Core_BAO_FinancialTrxn::create($adjustedTrxnValues);
 
     return $adjustedTrxn->id;
@@ -175,7 +175,7 @@ class CRM_MembershipExtras_Service_FinancialTransactionManager {
   public static function isMembership($lineItemID) {
     if ($lineItemID) {
       $result = civicrm_api3('LineItem', 'getsingle', [
-        'return' => array('price_field_value_id.membership_type_id'),
+        'return' => ['price_field_value_id.membership_type_id'],
         'id' => $lineItemID,
       ]);
 
@@ -197,7 +197,7 @@ class CRM_MembershipExtras_Service_FinancialTransactionManager {
    */
   public static function createDeferredTrxn($contributionID, $lineItem, $context) {
     if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
-      $lineItem = array($contributionID => array($lineItem['id'] => $lineItem));
+      $lineItem = [$contributionID => [$lineItem['id'] => $lineItem]];
 
       $contribution = new CRM_Contribute_BAO_Contribution();
       $contribution->id = $contributionID;

--- a/CRM/MembershipExtras/Service/FinancialTransactionManager.php
+++ b/CRM/MembershipExtras/Service/FinancialTransactionManager.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * Helper class to deal with operations done on contribution line items.
+ */
+class CRM_MembershipExtras_Service_FinancialTransactionManager {
+
+  /**
+   * Returns formatted amount for tax of a given contribution by calculating the
+   * sum for tax for each line item in that contribution.
+   *
+   * @param int $contributionID
+   *
+   * @return string
+   */
+  public static function calculateTaxAmountTotalFromContributionID($contributionID) {
+    $taxAmount = CRM_Core_DAO::singleValueQuery("
+      SELECT SUM(COALESCE(tax_amount,0)) 
+      FROM civicrm_line_item 
+      WHERE contribution_id = $contributionID 
+      AND qty > 0 
+    ");
+
+    return CRM_Utils_Money::format($taxAmount, NULL, NULL, TRUE);
+  }
+
+  /**
+   * Inserts financial item to reflect change done on contribution on line item
+   * deletion.
+   *
+   * @param array $lineItemBefore
+   */
+  public static function insertFinancialItemOnDeletion($lineItemBefore) {
+    $lineItemAfter = civicrm_api3('LineItem', 'getsingle', array(
+      'id' => $lineItemBefore['id'],
+    ));
+
+    $lineItemBefore['tax_amount'] = CRM_Utils_Array::value('tax_amount', $lineItemBefore, 0);
+    $lineItemAfter['tax_amount'] = CRM_Utils_Array::value('tax_amount', $lineItemAfter, 0);
+
+    $deltaTaxAmount = $lineItemAfter['tax_amount'] - $lineItemBefore['tax_amount'];
+    $deltaAmount = $lineItemAfter['line_total'] - $lineItemBefore['line_total'];
+
+    if ($deltaAmount != 0 || $deltaTaxAmount != 0) {
+      $previousFinancialItem = CRM_Financial_BAO_FinancialItem::getPreviousFinancialItem($lineItemBefore['id']);
+      $financialItem = array(
+        'transaction_date' => date('YmdHis'),
+        'contact_id' => $previousFinancialItem['contact_id'],
+        'description' => ($lineItemAfter['qty'] > 1 ? $lineItemAfter['qty'] . ' of ' : '') . $lineItemAfter['label'],
+        'currency' => $previousFinancialItem['currency'],
+        'financial_account_id' => $previousFinancialItem['financial_account_id'],
+        'entity_id' => $lineItemBefore['id'],
+        'entity_table' => 'civicrm_line_item',
+      );
+
+      self::recordChangeInAmount(
+        $lineItemAfter['contribution_id'],
+        $financialItem,
+        $deltaAmount,
+        $deltaTaxAmount
+      );
+    }
+  }
+
+  /**
+   * Stores financial transaction entry detailing a change in cmount to a
+   * contribution.
+   *
+   * @param int $contributionId
+   * @param array $financialItem
+   * @param double $deltaAmount
+   * @param double $deltaTaxAmount
+   */
+  public static function recordChangeInAmount($contributionId, $financialItem, $deltaAmount, $deltaTaxAmount) {
+    $trxnId = ['id' => self::createFinancialTrxnEntry($contributionId, $deltaAmount + $deltaTaxAmount)];
+    $accountRelName = self::getFinancialAccountRelationship($contributionId, $financialItem['entity_id']);
+    $lineItem = civicrm_api3('LineItem', 'getsingle', ['id' => $financialItem['entity_id']]);
+
+    $financialItem['amount'] = $deltaAmount;
+    $financialItem['status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Financial_DAO_FinancialItem', 'status_id', 'Unpaid');
+    $financialItem['financial_account_id'] = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($lineItem['financial_type_id'], $accountRelName);
+
+    $ftItem = CRM_Financial_BAO_FinancialItem::create($financialItem, NULL, $trxnId);
+
+    if ($deltaTaxAmount != 0) {
+      $taxTerm = CRM_Utils_Array::value('tax_term', Civi::settings()->get('contribution_invoice_settings'));
+      $taxFinancialItemInfo = array_merge($financialItem, [
+        'amount' => $deltaTaxAmount,
+        'description' => $taxTerm,
+        'financial_account_id' => CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($lineItem['financial_type_id'], 'Sales Tax Account is'),
+      ]);
+
+      CRM_Financial_BAO_FinancialItem::create($taxFinancialItemInfo, NULL, $trxnId);
+    }
+
+    $lineItem['deferred_line_total'] = $deltaAmount;
+    $lineItem['financial_item_id'] = $ftItem->id;
+
+    self::createDeferredTrxn($contributionId, $lineItem, 'UpdateLineItem');
+  }
+
+  /**
+   * Creates a financial transaction for the given contribution.
+   *
+   * @param int $contributionId
+   * @param double $amount
+   * @param int $toFinancialAccount
+   *
+   * @return int
+   */
+  public static function createFinancialTrxnEntry($contributionId, $amount, $toFinancialAccount = NULL) {
+    $contribution = civicrm_api3('Contribution', 'getsingle', ['id' => $contributionId]);
+    $isPayment = TRUE;
+
+    if (!$toFinancialAccount) {
+      $toFinancialAccount = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($contribution['financial_type_id'], 'Accounts Receivable Account is');
+      $isPayment = FALSE;
+    }
+
+    $adjustedTrxnValues = array(
+      'from_financial_account_id' => NULL,
+      'to_financial_account_id' => $toFinancialAccount,
+      'total_amount' => $amount,
+      'net_amount' => $amount,
+      'status_id' => $contribution['contribution_status_id'],
+      'payment_instrument_id' => $contribution['payment_instrument_id'],
+      'contribution_id' => $contributionId,
+      'trxn_date' => date('YmdHis'),
+      'currency' => $contribution['currency'],
+      'is_payment' => $isPayment,
+    );
+    $adjustedTrxn = CRM_Core_BAO_FinancialTrxn::create($adjustedTrxnValues);
+
+    return $adjustedTrxn->id;
+  }
+
+  /**
+   * Returns financial account relationship name for the given contribution and
+   * line item.
+   *
+   * @param int $contributionId
+   * @param int $lineItemId
+   *
+   * @return string
+   */
+  public static function getFinancialAccountRelationship($contributionId, $lineItemId = 0) {
+    $accountRelName = 'Income Account is';
+
+    $contribution = civicrm_api3('Contribution', 'getsingle', [
+      'return' => ['revenue_recognition_date', 'receive_date'],
+      'id' => $contributionId,
+    ]);
+
+    $revenueDate = CRM_Utils_Array::value('revenue_recognition_date', $contribution, '');
+    if (!empty($revenueDate)) {
+      $revenueDate = date('Ymd', strtotime($revenueDate));
+      $date = CRM_Utils_Array::value('receive_date', $contribution, date('Y-m-d'));
+      $date = date('Ymd', strtotime($date));
+
+      if ($revenueDate > $date || self::isMembership($lineItemId)) {
+        $accountRelName = 'Deferred Revenue Account is';
+      }
+    }
+
+    return $accountRelName;
+  }
+
+  /**
+   * Checks if line item identified by given ID is for a membership.
+   *
+   * @param int $lineItemID
+   *
+   * @return bool
+   */
+  public static function isMembership($lineItemID) {
+    if ($lineItemID) {
+      $result = civicrm_api3('LineItem', 'getsingle', [
+        'return' => array('price_field_value_id.membership_type_id'),
+        'id' => $lineItemID,
+      ]);
+
+      if (!empty($result['price_field_value_id.membership_type_id'])) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Create deferred transaction for given contribution and line item if
+   * setting is enabled.
+   *
+   * @param int $contributionID
+   * @param array $lineItem
+   * @param string $context
+   */
+  public static function createDeferredTrxn($contributionID, $lineItem, $context) {
+    if (CRM_Contribute_BAO_Contribution::checkContributeSettings('deferred_revenue_enabled')) {
+      $lineItem = array($contributionID => array($lineItem['id'] => $lineItem));
+
+      $contribution = new CRM_Contribute_BAO_Contribution();
+      $contribution->id = $contributionID;
+      $contribution->find(TRUE);
+
+      CRM_Core_BAO_FinancialTrxn::createDeferredTrxn($lineItem, $contribution, TRUE, $context);
+    }
+  }
+
+}

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.tpl
@@ -1,0 +1,35 @@
+<script type="text/javascript">
+  {literal}
+  CRM.$(function () {
+    CRM.$('#adjust_end_date').click(function() {
+      if(this.checked) {
+        CRM.$('#end_date').prop('disabled', false);
+      } else {
+        CRM.$('#end_date').prop('disabled', true);
+      }
+    });
+    CRM.$('#end_date').prop('disabled', true);
+  });
+  {/literal}
+</script>
+<div class="crm-submit-buttons">
+  {include file="CRM/common/formButtons.tpl" location="top"}
+</div>
+
+<p>
+  <i>{$lineItem.label}</i> amount should be deducted from all remaining instalments after
+  the end date. Please note the changes should take effect immediately after
+  "Apply".
+</p>
+<div class="crm-section">
+  <div class="label">{$form.adjust_end_date.label}</div>
+  <div class="content">{$form.adjust_end_date.html}</div>
+  <div class="clear"></div>
+  <div class="label">{$form.end_date.label}</div>
+  <div class="content">{$form.end_date.html}</div>
+  <div class="clear"></div>
+</div>
+
+<div class="crm-submit-buttons">
+  {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.tpl
@@ -2,13 +2,18 @@
   {literal}
   CRM.$(function () {
     CRM.$('#adjust_end_date').click(function() {
+      console.log(CRM.$('#end_date_container').css('display'));
+      console.log(CRM.$('#end_date_container'));
       if(this.checked) {
-        CRM.$('#end_date').prop('disabled', false);
+        CRM.$('#end_date_container').css('display', 'inline');
       } else {
-        CRM.$('#end_date').prop('disabled', true);
+        CRM.$('#end_date_container').css('display', 'none');
       }
+      console.log(CRM.$('#end_date_container').css('display'));
+      console.log(CRM.$('#end_date_container'));
     });
-    CRM.$('#end_date').prop('disabled', true);
+
+    CRM.$('#end_date_container').css('display', 'none');
   });
   {/literal}
 </script>
@@ -23,11 +28,10 @@
 </p>
 <div class="crm-section">
   <div class="label">{$form.adjust_end_date.label}</div>
-  <div class="content">{$form.adjust_end_date.html}</div>
-  <div class="clear"></div>
-  <div class="label">{$form.end_date.label}</div>
-  <div class="content">{$form.end_date.html}</div>
-  <div class="clear"></div>
+  <div class="content">
+    {$form.adjust_end_date.html}
+    <div id="end_date_container">{$form.end_date.html}</div>
+  </div>
 </div>
 
 <div class="crm-submit-buttons">

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -1,3 +1,45 @@
+<script>
+  var recurringContributionID = {$recurringContributionID};
+
+  {literal}
+  CRM.$(function () {
+    CRM.$('.remove-line-button').each(function () {
+      CRM.$(this).click(function () {
+        var itemID = CRM.$(this).attr('itemid');
+        showLineItemRemovalConfirmation(itemID);
+
+        return false;
+      });
+    });
+  });
+
+  function showLineItemRemovalConfirmation(lineItemID) {
+    CRM.api3('ContributionRecurLineItem', 'getcount', {
+      'contribution_recur_id': recurringContributionID,
+      'end_date': {'IS NULL': 1},
+    }).done(function (result) {
+      if (result.result < 2) {
+        CRM.alert("Cannot remove the last item in an order!", null, 'alert');
+
+        return;
+      }
+
+      var formUrl = CRM.url('civicrm/recurring-contribution/remove-lineitems', {
+        reset: 1,
+        contribution_recur_id: recurringContributionID,
+        line_item_id: lineItemID
+      });
+
+      CRM.loadForm(formUrl, {
+        dialog: {width: 480}
+      }).on('crmFormSuccess', function(event, data) {
+        CRM.refreshParent('#periodsContainer');
+      });
+    });
+  }
+  {/literal}
+</script>
+<div id="confirmLineItemDeletion" style="display: none;"></div>
 <div class="right">
   Period Start Date: {$periodStartDate|date_format}
   &nbsp;&nbsp;&nbsp;
@@ -22,17 +64,18 @@
   {foreach from=$lineItems item='currentItem'}
     {assign var='subTotal' value=$subtotal+$currentItem.line_total}
     {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
-
-    <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
+    <tr id="lineitem-{$currentItem.id}" data-action="cancel"
+        class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
       <td>{$currentItem.label}</td>
       <td>{$currentItem.start_date|date_format}</td>
       <td>{$currentItem.end_date|date_format}</td>
-      <td><input type="checkbox" disabled{if $currentItem.auto_renew} checked{/if} /></td>
+      <td><input type="checkbox"
+                 disabled{if $currentItem.auto_renew} checked{/if} /></td>
       <td>{$currentItem.financial_type}</td>
       <td>{$currentItem.tax_amount|crmMoney}</td>
       <td>{$currentItem.line_total|crmMoney}</td>
       <td>
-        <a class="delete" href="">
+        <a class="remove-line-button" href="#" itemid="{$currentItem.id}">
           <span><i class="crm-i fa-trash"></i></span>
         </a>
       </td>

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -5,7 +5,7 @@
   CRM.$(function () {
     CRM.$('.remove-line-button').each(function () {
       CRM.$(this).click(function () {
-        var itemID = CRM.$(this).attr('itemid');
+        var itemID = CRM.$(this).data('itemid');
         showLineItemRemovalConfirmation(itemID);
 
         return false;
@@ -75,7 +75,7 @@
       <td>{$currentItem.tax_amount|crmMoney}</td>
       <td>{$currentItem.line_total|crmMoney}</td>
       <td>
-        <a class="remove-line-button" href="#" itemid="{$currentItem.id}">
+        <a class="remove-line-button" href="#" data-itemid="{$currentItem.id}">
           <span><i class="crm-i fa-trash"></i></span>
         </a>
       </td>

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -62,8 +62,9 @@
   {assign var='installmentTotal' value=0}
 
   {foreach from=$lineItems item='currentItem'}
-    {assign var='subTotal' value=$subtotal+$currentItem.line_total}
+    {assign var='subTotal' value=$subTotal+$currentItem.line_total}
     {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
+
     <tr id="lineitem-{$currentItem.id}" data-action="cancel"
         class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
       <td>{$currentItem.label}</td>
@@ -72,7 +73,7 @@
       <td><input type="checkbox"
                  disabled{if $currentItem.auto_renew} checked{/if} /></td>
       <td>{$currentItem.financial_type}</td>
-      <td>{$currentItem.tax_amount|crmMoney}</td>
+      <td>{if $currentItem.tax_rate == 0}N/A{else}{$currentItem.tax_rate}%{/if}</td>
       <td>{$currentItem.line_total|crmMoney}</td>
       <td>
         <a class="remove-line-button" href="#" data-itemid="{$currentItem.id}">

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -1,7 +1,6 @@
 <div id="periodsContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
-  {* Tab management *}
   <script type="text/javascript">
-    var selectedTab  = 'contributions';
+    var selectedTab  = 'current';
     {literal}
     CRM.$(function($) {
       var tabIndex = $('#tab_' + selectedTab).prevAll().length;
@@ -10,6 +9,7 @@
     });
     {/literal}
   </script>
+
   <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
     <li id="tab_current" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
       <a href="#current-subtab" title="{ts}Contributions{/ts}">

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -18,4 +18,10 @@
     <title>EditContributionRecurLineItems</title>
     <access_arguments>edit contributions</access_arguments>
   </item>
+  <item>
+    <path>civicrm/recurring-contribution/remove-lineitems</path>
+    <page_callback>CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems</page_callback>
+    <title>RecurringContribution_RemoveLineItems</title>
+    <access_arguments>edit contributions</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
As part of the management of line items associated to a payment plan (recurring contribution), we need to add a way to remove those line items and have that affect any payments that are still pending for the payment plan. To do this, the trash -bin icon on the line item list for the recurring contribution should be used to implement the removal.

1. Once the bin button is clicked, if the item is the last item in the current period tab, a notice with warning sign should appear with text "Cannot remove the last item in an order" and action should be cancelled.
2. Once the bin button is clicked, if the item is not the last item in the current period tab, a dialog with title "Remove LINE_ITEM_LABEL ?" should appear with the following components:
- Dialog body text: "LINE_ITEM_LABEL amount should be deducted from all remaining instalments after the end date. Please note the changes should take effect immediately after "Apply"."
- Adjust end date: checkbox option
- End date: datepicker that should only be shown if "Adjust end date" is checked, default to today's date
- Cancel button
- Apply button

3. If user clicks on "Apply":
- end_date in offline_contribution_recur_line_item for the corresponding item should be filled in with today's date. If "Adjust end date" is checked, the end_date should be set to the date user picked.
- auto_renew in offline_contribution_recur_line_item for the corresponding item should set to False.
- For any "Pending" instalment contribution with "Received Date" equals to or after the end_date, any line_item with same label as the recurring line item should be removed. Contribution amounts should be adjusted.
- If the line item is a membership, update the corresponding membership (linked to the recurring contribution) to have the new end_date and clear the contribution_recurr_id
- A notice should appear with text "LINE_ITEM_LABEL has been removed from the active order."
- A notice should appear with text "LINE_ITEM_LABEL should no longer be continued in the next period."
- The content of "Manage Instalments" modal should be reloaded.

## Before
The bin button was not functional.

## After
Implemented removal using a new form, which is called in a new dialog when the bin button is clicked. The form shows the required fields (the checkbox and the date picker), with the date picker disabled by default, only being enabled if the checkbox option is clicked.

The form is submitted when clicking on the *Apply* button. Post-processing of the form is used to:
- If line item is a membership, it cancels the membership.
- Cycle through pending contributions after selected end date to set corresponding line item amounts to zero, update contribution amounts by subtracting the line item's original amount and creating financial transaction records associated to the contributions to log the decrease of the contributions's amount.
- Update recurring line item to set its end-date and cancel auto-renew.

Once the form is processed, the list of line items is refreshed to show the changes made.

![basw-218-after](https://user-images.githubusercontent.com/21999940/43910543-b7f1d13c-9bc2-11e8-848a-5220bd4dc31e.gif)

