### PR TITLE
BASW-217: View a Recurring Contribution's Next Period Line Items

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -103,9 +103,9 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
         break;
     }
 
-    $nextStartDate->add(new DateInterval($interval));
+    $nextPeriodStartDate->add(new DateInterval($interval));
 
-    return $nextStartDate->format('Y-m-d');
+    return $nextPeriodStartDate->format('Y-m-d');
   }
 
   /**

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -59,16 +59,27 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
   public function run() {
     CRM_Utils_System::setTitle(E::ts('View/Update Recurring Line Items'));
 
-    $hasAutoRenewEnabled = CRM_Utils_String::strtobool(CRM_Utils_Array::value('auto_renew', $this->contribRecur)) && count($this->getMemberships());
-
     $this->assign('periodStartDate', CRM_Utils_Array::value('start_date', $this->contribRecur));
     $this->assign('periodEndDate', CRM_Utils_Array::value('end_date', $this->contribRecur));
     $this->assign('lineItems', $this->getLineItems());
-    $this->assign('autoRenewEnabled', $hasAutoRenewEnabled);
+    $this->assign('autoRenewEnabled', $this->isAutoRenewEnabled());
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
-    $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => false]));
+    $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => FALSE]));
 
     parent::run();
+  }
+
+  /**
+   * @return boolean
+   */
+  private function isAutoRenewEnabled() {
+    $isAutoRenew = CRM_Utils_String::strtobool(CRM_Utils_Array::value('auto_renew', $this->contribRecur));
+  
+    if ($isAutoRenew && count($this->getMemberships())) {
+      return TRUE;
+    }
+  
+    return FALSE;
   }
 
   /**

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -16,18 +16,24 @@
         {ts}Current Period{/ts}
       </a>
     </li>
+    {* Render next period button only if contribution has next period *}
+    {if $autoRenewEnabled}
     <li id="tab_next" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
       <a href="#next-subtab" title="{ts}Recurring Contributions{/ts}">
-        {ts}Next Period{/ts}
+        {ts}Next Period (Forecast){/ts}
       </a>
     </li>
+    {/if}
   </ul>
 
   <div id="current-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
     {include file="CRM/MembershipExtras/Page/CurrentPeriodTab.tpl"}
   </div>
+  {* Render next period tab only if contribution has next period *}
+  {if $autoRenewEnabled}
   <div id="next-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
-    [ NEXT PERIOD ]
+    {include file="CRM/MembershipExtras/Page/NextPeriodTab.tpl"}
   </div>
+  {/if}
   <div class="clear"></div>
 </div>

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -16,7 +16,6 @@
         {ts}Current Period{/ts}
       </a>
     </li>
-    {* Render next period button only if contribution has next period *}
     {if $autoRenewEnabled}
     <li id="tab_next" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
       <a href="#next-subtab" title="{ts}Recurring Contributions{/ts}">
@@ -29,7 +28,6 @@
   <div id="current-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
     {include file="CRM/MembershipExtras/Page/CurrentPeriodTab.tpl"}
   </div>
-  {* Render next period tab only if contribution has next period *}
   {if $autoRenewEnabled}
   <div id="next-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
     {include file="CRM/MembershipExtras/Page/NextPeriodTab.tpl"}

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -1,0 +1,70 @@
+<div class="right">
+  Period Start Date: {$nextPeriodStartDate|date_format}
+</div>
+<table class="selector row-highlight">
+  <tbody>
+  <tr class="columnheader">
+    <th scope="col">{ts}Item{/ts}</th>
+    <th scope="col">{ts}Financial Type{/ts}</th>
+    <th scope="col">{ts}Tax{/ts}</th>
+    <th scope="col">{ts}Amount{/ts}</th>
+    <th scope="col">&nbsp;</th>
+  </tr>
+  {assign var='subTotal' value=0}
+  {assign var='taxTotal' value=0}
+  {assign var='installmentTotal' value=0}
+
+  {foreach from=$nextPeriodLineItems item='currentItem'}
+    {assign var='subTotal' value=$subtotal+$currentItem.line_total}
+    {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
+
+    <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
+      <td>{$currentItem.label}</td>
+      <td>{$currentItem.financial_type}</td>
+      <td>{$currentItem.tax_amount|crmMoney}</td>
+      <td>{$currentItem.line_total|crmMoney}</td>
+      <td>
+        <a class="delete" href="">
+          <span><i class="crm-i fa-trash"></i></span>
+        </a>
+      </td>
+    </tr>
+  {/foreach}
+  {assign var='installmentTotal' value=$subTotal+$taxTotal}
+  </tbody>
+</table>
+<div id="current_buttons">
+  <a class="button" href="">
+    <span><i class="crm-i fa-plus"></i>&nbsp; Add Membership</span>
+  </a>
+  <a class="button" href="">
+    <span><i class="crm-i fa-plus"></i>&nbsp; Add Other Amount</span>
+  </a>
+</div>
+<div class="clear"></div>
+<div class="right">
+  <table class="form-layout-compressed" align="right">
+    <tr>
+      <td colspan="2">
+        <hr/>
+      </td>
+    </tr>
+    <tr>
+      <td class="contriTotalLeft right">{ts}Untaxed Amount:{/ts}</td>
+      <td>{$subTotal|crmMoney}</td>
+    </tr>
+    <tr>
+      <td class="contriTotalLeft right">{ts}Tax:{/ts}</td>
+      <td>{$taxTotal|crmMoney}</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <hr/>
+      </td>
+    </tr>
+    <tr>
+      <td class="contriTotalLeft right">{ts}Total per Installment:{/ts}</td>
+      <td>{$installmentTotal|crmMoney}</td>
+    </tr>
+  </table>
+</div>

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -15,7 +15,7 @@
   {assign var='installmentTotal' value=0}
 
   {foreach from=$nextPeriodLineItems item='currentItem'}
-    {assign var='subTotal' value=$subtotal+$currentItem.line_total}
+    {assign var='subTotal' value=$subTotal+$currentItem.line_total}
     {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
 
     <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -21,7 +21,7 @@
     <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
       <td>{$currentItem.label}</td>
       <td>{$currentItem.financial_type}</td>
-      <td>{$currentItem.tax_amount|crmMoney}</td>
+      <td>{$currentItem.tax_rate}</td>
       <td>{$currentItem.line_total|crmMoney}</td>
       <td>
         <a class="delete" href="">

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -21,7 +21,7 @@
     <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
       <td>{$currentItem.label}</td>
       <td>{$currentItem.financial_type}</td>
-      <td>{$currentItem.tax_rate}</td>
+      <td>{if !empty($currentItem.tax_rate)}{$currentItem.tax_rate}{else}N/A{/if}</td>
       <td>{$currentItem.line_total|crmMoney}</td>
       <td>
         <a class="delete" href="">


### PR DESCRIPTION
# Overiew
In the "Manage Installments" modal popup, we need to add a next period tab that should be shown if the recurring contribution has auto-renew enabled and it has at least one membership.
In the next period tab (default), each "offline_contribution_recur_line_item" with auto-renew = TRUE should be displayed. Each row should have the following information:
- Item - line item label
- Financial type - financial type of the line item
- Tax - the tax percentage of the financial type, show N/A if there is no tax account in the financial type
- Amount - line total of the line item
- Remove button - show as bin icon
- An "Add Membership" button and an "Add Other Amount" button should be shown under the last row

At the bottom of the tab, the following information should be shown:
- Untaxed Amount - total amount of the line_totals
- Tax - total amount of tax_amounts
- Total per installment - sum of a and b

# Before
Action did not exist

# After
Action was added only to offline manual payment recurring contributions.
![Recurring Contribution's Next Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/NextPeriodLineItems.png "Recurring Contribution's Next Period Tab")