### PR TITLE
BASW-219: Remove Line From Multi Line Membership Order

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -67,7 +67,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
 
     $this->assign('autoRenewEnabled', $this->isAutoRenewEnabled());
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
-    $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => FALSE]));
+    $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => TRUE]));
 
     parent::run();
   }

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -139,6 +139,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
         $lineDetails['tax_rate'] = $this->getTaxRateForFinancialType($lineDetails['financial_type_id']);
         $lineDetails['financial_type'] = $this->getFinancialTypeName($lineDetails['financial_type_id']);
 
+        unset($lineDetails['id']);
         unset($lineItemData['api.LineItem.getsingle']);
         $lineItems[] = array_merge($lineItemData, $lineDetails);
       }

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -13,6 +13,14 @@
     });
   });
 
+  CRM.$('.auto-renew-line-checkbox').change(function() {
+    if (!this.checked) {
+      var itemData = CRM.$(this).closest('tr').data('item-data');
+      console.log(itemData);
+      showNextPeriodLineItemRemovalConfirmation(itemData);
+    }
+  })
+
   function showLineItemRemovalConfirmation(lineItemID) {
     CRM.api3('ContributionRecurLineItem', 'getcount', {
       'contribution_recur_id': recurringContributionID,
@@ -65,13 +73,13 @@
     {assign var='subTotal' value=$subTotal+$currentItem.line_total}
     {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
 
-    <tr id="lineitem-{$currentItem.id}" data-action="cancel"
+    <tr id="lineitem-{$currentItem.id}" data-action="cancel" data-item-data='{$currentItem|@json_encode}'
         class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
       <td>{$currentItem.label}</td>
       <td>{$currentItem.start_date|date_format}</td>
       <td>{$currentItem.end_date|date_format}</td>
       <td><input type="checkbox"
-                 disabled{if $currentItem.auto_renew} checked{/if} /></td>
+            class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} /></td>
       <td>{$currentItem.financial_type}</td>
       <td>{if $currentItem.tax_rate == 0}N/A{else}{$currentItem.tax_rate}%{/if}</td>
       <td>{$currentItem.line_total|crmMoney}</td>

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -1,3 +1,77 @@
+<script>
+var recurringContributionID = {$recurringContributionID};
+
+{literal}
+  CRM.$(function () {
+    CRM.$('.remove-next-period-line-button').each(function () {
+      CRM.$(this).click(function (e) {
+        e.preventDefault();
+
+        var itemData = CRM.$(this).closest('tr').data('item-data');
+        showNextPeriodLineItemRemovalConfirmation(itemData);
+
+        CRM.$('#periodsContainer').on('crmLoad', function(event, data) {
+          CRM.$('#tab_next a').click();
+        });
+      });
+    });
+  });
+
+  function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
+    CRM.confirm({
+      title: 'Remove ' + lineItemData.label + '?',
+      message: 'Please note the changes should take effect immediately after "Apply"',
+      options: {
+        no: 'Cancel',
+        yes: 'Apply'
+      }
+    }).on('crmConfirm:yes', function() {
+      CRM.api3('ContributionRecurLineItem', 'create', {
+        'id': lineItemData.id,
+        'auto_renew': 0,
+      }).done(function (lineRemovalRes) {
+        
+        if (lineRemovalRes.is_error) {
+          CRM.alert('Cannot remove the last item in an order!', null, 'error');
+          return;
+        }
+
+        if (lineItemData.entity_table === 'civicrm_membership') {
+          CRM.api3('Membership', 'create', {
+            'id': lineItemData.entity_id,
+            'contribution_recur_id': '',
+          }).done(function (membershipUnlinkRes) {
+            
+            if (membershipUnlinkRes.is_error) {
+              CRM.alert('Cannot unlink the associated membership', null, 'alert');
+              return;
+            }
+            
+            CRM.refreshParent('#periodsContainer');
+            CRM.alert(
+              lineItemData.label + ' should no longer be continued in the next period.',
+              null,
+              'success'
+            );
+            return;
+          });
+        } else {
+          CRM.refreshParent('#periodsContainer');
+          CRM.alert(
+            lineItemData.label + ' should no longer be continued in the next period.',
+            null,
+            'success'
+          );
+          return;
+        }
+
+      });
+    }).on('crmConfirm:no', function() {
+      return;
+    });
+  }
+{/literal}
+</script>
 <div class="right">
   Period Start Date: {$nextPeriodStartDate|date_format}
 </div>
@@ -18,13 +92,15 @@
     {assign var='subTotal' value=$subTotal+$currentItem.line_total}
     {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
 
-    <tr id="lineitem-{$currentItem.id}" data-action="cancel" class="crm-entity {cycle values="odd-row,even-row"}">
+    <tr id="lineitem-{$currentItem.id}" data-action="cancel"
+        data-item-data='{$currentItem|@json_encode}'
+        class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
       <td>{$currentItem.label}</td>
       <td>{$currentItem.financial_type}</td>
       <td>{if !empty($currentItem.tax_rate)}{$currentItem.tax_rate}{else}N/A{/if}</td>
       <td>{$currentItem.line_total|crmMoney}</td>
       <td>
-        <a class="delete" href="">
+        <a class="remove-next-period-line-button" href="#">
           <span><i class="crm-i fa-trash"></i></span>
         </a>
       </td>


### PR DESCRIPTION
## Review
To manage recurring pledges, we need to implement the following:
1. In the "View/Modify Future Instalments" next period tab, user can click on the bin button on each of the line item to perform a removal action.
2. Once the bin button is clicked, a dialog with title "Remove LINE_ITEM_LABEL?" should appear with the following components:
- dialog body text - "Please note the changes should take effect immediately after "Apply"."
- Cancel button
- Apply button
3. If user clicked on "Apply":
- auto_renew in offline_contribution_recur_line_item for the corresponding item should set to False.
- if the line item is a membership, clear the contribution_recurr_id of the corresponding membership (linked to the recurring contribution)
- a notice should appear with text "LINE_ITEM_LABEL should no longer be continued in the next period."
- the content of "Manage Instalments" modal should be reloaded.
4. If user clicked on "Cancel", the action should be cancelled and no change is made.
5. User can also uncheck "Renew automatically" field for any of the line in "Current period" tab to perform the same action. Point 2-4 also apply here.

## Before
The checkbox in the Current Period tab and bin button in the Next Period tab was not functional.

## After
Action was added only to offline manual payment recurring contributions.
![Recurring Contribution's Next Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/RemoveLineItemAutorenew.gif "Recurring Contribution's Next Period Tab")