### PR TITLE
BASW-219: Fix Modal Reload Auto Switch To Next Period Tab

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -78,9 +78,18 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('autoRenewEnabled', $this->isAutoRenewEnabled());
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('financialTypes', $this->financialTypes);
+    $this->assign('currencySymbol', $this->getCurrencySymbol());
     $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => TRUE]));
 
     parent::run();
+  }
+
+  /**
+   * @return string
+   */
+  private function getCurrencySymbol() {
+    $config = CRM_Core_Config::singleton();
+    return CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_Currency', $config->defaultCurrency, 'symbol', 'name');
   }
 
   /**

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -1,6 +1,7 @@
 <div id="periodsContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
   <script type="text/javascript">
-    var selectedTab  = 'current';
+    var selectedTab  = window.CompucorpMembershipExtras_selectedTab || 'current';
+    window.CompucorpMembershipExtras_selectedTab = 'current';
     {literal}
     CRM.$(function($) {
       var tabIndex = $('#tab_' + selectedTab).prevAll().length;
@@ -11,7 +12,7 @@
   </script>
 
   <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
-    <li id="tab_current" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
+    <li id="tab_current" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
       <a href="#current-subtab" title="{ts}Contributions{/ts}">
         {ts}Current Period{/ts}
       </a>

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -76,54 +76,7 @@ var disableClicks = false;
         }
       }
 
-      CRM.confirm({
-        title: 'Add ' + label + '?',
-        message: 'Please note the changes should take effect immediately after "Apply".',
-        options: {
-          no: 'Cancel',
-          yes: 'Apply'
-        }
-      }).on('crmConfirm:yes', function() {
-        var financialType = getFinancialType(financial_type_id),
-            taxAmount = financialType.tax_rate * amount;
-
-        CRM.api3('LineItem', 'create', {
-          label: label,
-          entity_id: recurringContributionID,
-          qty: 1.0,
-          unit_price: amount,
-          line_total: amount,
-          tax_amount: taxAmount,
-          financial_type_id: financial_type_id,
-          entity_table: 'civicrm_contribution_recur',
-        }).done(function(lineItemResult) {
-          if (lineItemResult.is_error) {
-            CRM.alert(lineItemResult.error_message, null, 'error');
-            return;
-          }
-
-          var createdLineItemId = lineItemResult.id;
-          CRM.api3('ContributionRecurLineItem', 'create', {
-            contribution_recur_id: recurringContributionID,
-            line_item_id: createdLineItemId,
-            auto_renew: true,
-          }).done(function(result) {
-            if (result.is_error) {
-              CRM.alert(result.error_message, null, 'error');
-              return;
-            }
-
-            CRM.alert(
-              label + ' will now be continued in the next period.',
-              null,
-              'success'
-            );
-            CRM.refreshParent('#periodsContainer');
-          });
-        });
-      }).on('crmConfirm:no', function() {
-        return;
-      })
+      showAddOtherAmountConfirmation(label, amount, financial_type_id)
       
     });
   });
@@ -187,6 +140,57 @@ var disableClicks = false;
       return;
     });
   }
+
+  function showAddOtherAmountConfirmation(label, amount, financial_type_id) {
+    CRM.confirm({
+        title: 'Add ' + label + '?',
+        message: 'Please note the changes should take effect immediately after "Apply".',
+        options: {
+          no: 'Cancel',
+          yes: 'Apply'
+        }
+      }).on('crmConfirm:yes', function() {
+        var financialType = getFinancialType(financial_type_id),
+            taxAmount = financialType.tax_rate * amount;
+
+        CRM.api3('LineItem', 'create', {
+          label: label,
+          entity_id: recurringContributionID,
+          qty: 1.0,
+          unit_price: amount,
+          line_total: amount,
+          tax_amount: taxAmount,
+          financial_type_id: financial_type_id,
+          entity_table: 'civicrm_contribution_recur',
+        }).done(function(lineItemResult) {
+          if (lineItemResult.is_error) {
+            CRM.alert(lineItemResult.error_message, null, 'error');
+            return;
+          }
+
+          var createdLineItemId = lineItemResult.id;
+          CRM.api3('ContributionRecurLineItem', 'create', {
+            contribution_recur_id: recurringContributionID,
+            line_item_id: createdLineItemId,
+            auto_renew: true,
+          }).done(function(result) {
+            if (result.is_error) {
+              CRM.alert(result.error_message, null, 'error');
+              return;
+            }
+
+            CRM.alert(
+              label + ' will now be continued in the next period.',
+              null,
+              'success'
+            );
+            CRM.refreshParent('#periodsContainer');
+          });
+        });
+      }).on('crmConfirm:no', function() {
+        return;
+      });
+  }
 {/literal}
 </script>
 <div class="right">
@@ -237,7 +241,7 @@ var disableClicks = false;
     </td>
     <td id="financialTypeTaxRate">{if !empty($financialTypes[0].tax_rate)}{$financialTypes[0].tax_rate}{else}N/A{/if}</td>
     <td>
-      <input type="text" class="four crm-form-text" size="4" id="amount" />
+      {$currencySymbol}&nbsp; <input type="text" class="four crm-form-text" size="4" id="amount" />
     </td>
     <td>
       <a href="#" class="cancel-add-next-period-line-button">

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -11,9 +11,7 @@ var financialTypes = JSON.parse('{$financialTypes|@json_encode}');
         var itemData = CRM.$(this).closest('tr').data('item-data');
         showNextPeriodLineItemRemovalConfirmation(itemData);
 
-        CRM.$('#periodsContainer').on('crmLoad', function(event, data) {
-          CRM.$('#tab_next a').click();
-        });
+        window.CompucorpMembershipExtras_selectedTab = 'next';
       });
     });
 

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -1,7 +1,6 @@
 <script>
 var recurringContributionID = {$recurringContributionID};
 var financialTypes = JSON.parse('{$financialTypes|@json_encode}');
-var disableClicks = false;
 
 {literal}
   CRM.$(function () {
@@ -9,36 +8,27 @@ var disableClicks = false;
     CRM.$('.remove-next-period-line-button').each(function () {
       CRM.$(this).click(function (e) {
         e.preventDefault();
-        
-        if(!disableClicks) {
-          var itemData = CRM.$(this).closest('tr').data('item-data');
-          showNextPeriodLineItemRemovalConfirmation(itemData);
+        var itemData = CRM.$(this).closest('tr').data('item-data');
+        showNextPeriodLineItemRemovalConfirmation(itemData);
 
-          CRM.$('#periodsContainer').on('crmLoad', function(event, data) {
-            CRM.$('#tab_next a').click();
-          });
-        }
+        CRM.$('#periodsContainer').on('crmLoad', function(event, data) {
+          CRM.$('#tab_next a').click();
+        });
       });
     });
 
     CRM.$('#next_buttons #addOtherAmount').on('click', function(e) {
       e.preventDefault();
-
-      if (!disableClicks) {
-        CRM.$('#addLineItemRow').show();
-        CRM.$('#periodsContainer').find('*').not(CRM.$('#addLineItemRow').find('*')).css('cursor', 'not-allowed');
-        CRM.$('#addLineItemRow').css('cursor', 'auto');
-        CRM.$('#addLineItemRow').css('opacity', 1);
-
-        disableClicks = true;
-      }
+      CRM.$('#addLineItemRow').show();
+      CRM.$('#periodsContainer').find('tr').not(CRM.$('#addLineItemRow')).addClass('disabled-row');
+      CRM.$('#periodsContainer').find('a').not(CRM.$('#addLineItemRow').find('a')).addClass('disabled-click');
     });
 
     CRM.$('.cancel-add-next-period-line-button').on('click', function(e) {
       e.preventDefault();
-
       CRM.$('#addLineItemRow').hide();
-      CRM.$('#periodsContainer').find('*').css('cursor', 'auto');
+      CRM.$('#periodsContainer').find('tr').removeClass('disabled-row');
+      CRM.$('#periodsContainer').find('a').removeClass('disabled-click');
     });
 
     CRM.$('#financialType').on('change', function() {
@@ -61,23 +51,25 @@ var disableClicks = false;
 
       if (!label.length) {
         CRM.alert('Item label is required', null, 'error');
+        
         return;
       }
 
       if (!amount.length) {
         CRM.alert('Item amount is required', null, 'error');
+
         return;
       } else {
         try {
           amount = parseInt(amount);
         } catch(error) {
           CRM.alert('Amount you entered is not valid', null, 'error');
+
           return;
         }
       }
 
       showAddOtherAmountConfirmation(label, amount, financial_type_id)
-      
     });
   });
 
@@ -103,6 +95,7 @@ var disableClicks = false;
         
         if (lineRemovalRes.is_error) {
           CRM.alert('Cannot remove the last item in an order!', null, 'error');
+
           return;
         }
 
@@ -114,6 +107,7 @@ var disableClicks = false;
             
             if (membershipUnlinkRes.is_error) {
               CRM.alert('Cannot unlink the associated membership', null, 'alert');
+
               return;
             }
             
@@ -123,6 +117,7 @@ var disableClicks = false;
               null,
               'success'
             );
+
             return;
           });
         } else {
@@ -132,6 +127,7 @@ var disableClicks = false;
             null,
             'success'
           );
+
           return;
         }
 
@@ -165,6 +161,7 @@ var disableClicks = false;
         }).done(function(lineItemResult) {
           if (lineItemResult.is_error) {
             CRM.alert(lineItemResult.error_message, null, 'error');
+
             return;
           }
 
@@ -176,6 +173,7 @@ var disableClicks = false;
           }).done(function(result) {
             if (result.is_error) {
               CRM.alert(result.error_message, null, 'error');
+
               return;
             }
 
@@ -193,6 +191,31 @@ var disableClicks = false;
   }
 {/literal}
 </script>
+<style>
+  {literal}
+    .crm-container a:hover .crm-i.fa-check,
+    .crm-container a:hover .crm-i.fa-times,
+    .crm-container a:hover .crm-i.fa-trash {
+      color: #8A1F11;
+      cursor: pointer;
+    }
+
+    .crm-container a.disabled-click,
+    .crm-container a.button.clickable.disabled-click {
+      pointer-events: none;
+      color: #ddd;
+    }
+
+    tr.disabled-row {
+      color: #ddd;
+    }
+
+    input.required,
+    #newline_membership_type.required {
+      border: 2px solid #900 !important;
+    }
+  {/literal}
+</style>
 <div class="right">
   Period Start Date: {$nextPeriodStartDate|date_format}
 </div>


### PR DESCRIPTION
## Overview
As per the ticket (BASW-219) overview, after modal pop reloads when a line item is removed, it should automatically switch to the next period tab

## Before
After modal popup reloads, it does not automatically switch to the next period tab.

## After
Modal popup switches to next period tab when line item is removed

![basw-219-after](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/RemoveLineItemFix.gif)