### PR TITLE
BASW-169: Removing the financial account from PP payment processor

### DIFF
--- a/CRM/MembershipExtras/PaymentProcessor/OfflineRecurringContribution.php
+++ b/CRM/MembershipExtras/PaymentProcessor/OfflineRecurringContribution.php
@@ -93,15 +93,7 @@ class CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution {
       'class_name' => 'Payment_Manual',
       'is_recur' => '1',
       'payment_instrument_id' => 'EFT',
-      'financial_account_id' => $this->getDepositBankAccountId(),
     ];
-  }
-
-  private function getDepositBankAccountId() {
-    return civicrm_api3('FinancialAccount', 'getvalue', [
-      'return' => 'id',
-      'name' => 'Deposit Bank Account',
-    ]);
   }
 
   public function setAsDefaultPaymentPlanProcessor() {


### PR DESCRIPTION
## Problem

If the site does not have a financial account  type called '**Deposit Bank Account**' then it will cause problems during the extension installation.


## Solution

 I removed the financial account type parameter during the creation of "Offline Recurring Contribution" (PP) payment processor.