### PR TITLE
BASW-212: Fix Labels and End Dates

### DIFF
--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -59,10 +59,10 @@ class CRM_MembershipExtras_Hook_Links_RecurringContribution {
 
     if ($this->isManualPaymentPlan()) {
       $this->links[] = [
-        'name' => 'View/Update Recurring Line Items',
+        'name' => 'View/Modify Future Instalments',
         'url' => 'civicrm/recurring-contribution/edit-lineitems',
         'qs' => 'reset=1&crid=%%crid%%&cid=%%cid%%&context=contribution',
-        'title' => 'View/Update Recurring Line Items',
+        'title' => 'View/Modify Future Instalments',
       ];
     }
   }

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -39,8 +39,13 @@
       <tr id="lineitem-{$currentItem.id}" data-item-data='{$currentItem|@json_encode}' class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
         <td>{$currentItem.label}</td>
         <td>{$currentItem.start_date|date_format}</td>
-        <td>{$currentItem.end_date|date_format}</td>
-        <td><input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} /></td>
+        <td>{$largestMembershipEndDate|date_format}</td>
+        <td>
+          {if $recurringContribution.auto_renew}
+            <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />
+          {/if}
+          &nbsp;
+        </td>
         <td>{$currentItem.financial_type}</td>
         <td>{if $currentItem.tax_rate == 0}N/A{else}{$currentItem.tax_rate}%{/if}</td>
         <td nowrap>{$currentItem.line_total|crmMoney}</td>
@@ -72,6 +77,7 @@
         {if $recurringContribution.auto_renew}
           <input name="newline_auto_renew" id="newline_auto_renew" type="checkbox" checked />
         {/if}&nbsp;
+        &nbsp;
       </td>
       <td id="newline_financial_type"> - </td>
       <td id="newline_tax_rate" nowrap> - </td>
@@ -98,7 +104,8 @@
       <td>
         {if $recurringContribution.auto_renew}
           <input name="newline_donation_auto_renew" id="newline_donation_auto_renew" type="checkbox" checked />
-        {/if}&nbsp;
+        {/if}
+        &nbsp;
       </td>
       <td>
         <select class="crm-form-select" name="newline_donation_financial_type_id" id="newline_donation_financial_type_id">


### PR DESCRIPTION
## Overview
The label for the button used to open the list of line items in a recurring contribution should say "View/Modify Future Instalments". 

The end dte on each line item on the list should be the latest end date of related memberships.

## Before
Label for the button was "View/Update Recurring Line Items".
End date for each line item was the end date recorded on the membershipextras_subscription_line table.

## After
Changed label for button.
Show maximum end date for memberships on each line item end date.