### PR TITLE
BASW-122: Set payment plan end date to match last payment date when its completed

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -40,12 +40,20 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     }
 
     $newStatus = $this->generatePaymentPlanNewStatus();
-    if ($newStatus !== NULL) {
-      civicrm_api3('ContributionRecur', 'create', [
-        'id' => $this->recurContribution['id'],
-        'contribution_status_id' => $newStatus,
-      ]);
+    if ($newStatus == NULL) {
+      return;
     }
+
+    $updateParams = [
+      'id' => $this->recurContribution['id'],
+      'contribution_status_id' => $newStatus,
+    ];
+
+    if ($newStatus == 'Completed') {
+      $updateParams['end_date'] = $this->generateNewPaymentPlanEndDate();
+    }
+
+    civicrm_api3('ContributionRecur', 'create', $updateParams);
   }
 
   /**
@@ -127,6 +135,22 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     }
 
     return $newStatus;
+  }
+
+  private function generateNewPaymentPlanEndDate() {
+    $lastPaymentPlanContribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['receive_date'],
+      'contribution_recur_id' => $this->recurContribution['id'],
+      'options' => ['sort' => 'id DESC', 'limit' => 1],
+    ]);
+
+    $endDate = NULL;
+    if (!empty($lastPaymentPlanContribution['values'][0]['receive_date'])) {
+      $endDate = $lastPaymentPlanContribution['values'][0]['receive_date'];
+    }
+
+    return $endDate;
   }
 
 }


### PR DESCRIPTION
When the last contribution (payment)  on the payment plan is completed, the payment plan (recurring contribution)  end date is set to match the last contribution (payment) receive date.