### PR TITLE
BSW-221: Fixes for Donation Line Item Addtion

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -131,7 +131,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @inheritdoc
    */
   public function run() {
-    CRM_Utils_System::setTitle(E::ts('Manage Installments'));
+    CRM_Utils_System::setTitle(E::ts('Manage Instalment'));
 
     $this->assign('currentDate', date('Y-m-d'));
     $this->assign('recurringContribution', $this->contribRecur);
@@ -145,7 +145,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('membershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems));
     $this->assign('lineItems', $currentPeriodLineItems);
 
-    $this->assign('autoRenewEnabled', $this->isAutoRenewEnabled($currentPeriodLineItems));
+    $this->assign('autoRenewEnabled', $this->isAutoRenewEnabled());
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('financialTypes', $this->financialTypes);
     $this->assign('currencySymbol', $this->getCurrencySymbol());

--- a/css/style.css
+++ b/css/style.css
@@ -13,12 +13,16 @@ tr.disabled-row {
   color: #ddd;
 }
 
-input.required,
+tr.rc-new-line-item input.required,
 #newline_membership_type.required,
 #newline_donation_financial_type_id.required {
   border: 2px solid #900 !important;
 }
 
-#newline_amount, #newline_item, #newline_donation_amount, #newline_donation_item {
+#newline_amount, #newline_donation_amount {
   width: 50%;
+}
+
+tr.rc-new-line-item td, td.confirmation-icons {
+  vertical-align: middle;
 }

--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -32,6 +32,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     this.newDonationAmountField = null;
 
     this.membershipTypes = {};
+    this.financialTypes = [];
     this.recurringContribution = {};
   }
 
@@ -67,7 +68,6 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     this.newDonationAutoRenewField = CRM.$('#newline_donation_auto_renew', this.newDonationRow);
     this.newDonationFinancialTypeField = CRM.$('#newline_donation_financial_type_id', this.newDonationRow);
     this.newDonationAmountField = CRM.$('#newline_donation_amount', this.newDonationRow);
-
     this.newDonationRow.css('display', 'none');
   };
 
@@ -209,6 +209,23 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
       return false;
     });
 
+    // Shows tax rate if set when changing financial type.
+    this.newDonationFinancialTypeField.on('change', function() {
+      var selectedId = CRM.$(this).val();
+      var financialType = that.getFinancialType(selectedId);
+
+      if (!financialType) {
+        throw new Error('Invalid financial type id passed');
+      }
+
+      var rate = financialType.tax_rate || 'N/A';
+      if (rate != 'N/A') {
+        rate += ' %';
+      }
+
+      CRM.$('#newline_donation_tax_rate').text(rate);
+    });
+
     // Hides new row to add new donation.
     CRM.$('#cancel_add_donation_btn', this.currentTab).click(function () {
       that.newDonationRow.css('display', 'none');
@@ -240,6 +257,18 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
 
       return false;
     });
+  };
+
+  /**
+   * Returns financial type data for given ID.
+   * @param id
+   *
+   * @return (object)
+   */
+  CurrentPeriodLineItemHandler.prototype.getFinancialType = function(id) {
+    return financialTypes.filter(function(financialType) {
+      return financialType.id === id;
+    })[0];
   };
 
   /**

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -1,8 +1,11 @@
 <script>
+  var currentFinancialTypes = JSON.parse('{$financialTypes|@json_encode}');
+
   {literal}
   CRM.$(function () {
     var formHandler = new CRM.RecurringContribution.CurrentPeriodLineItemHandler(CRM.$('#recurringContributionID').val());
     formHandler.initializeForm(CRM.$('#current-subtab'));
+    formHandler.set('financialTypes', currentFinancialTypes);
     formHandler.addEventHandlers();
   });
   {/literal}
@@ -68,10 +71,10 @@
         </select>
       </td>
       <td nowrap>
-        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false{rdelim}" aria-label="Start Date" name="newline_start_date" type="text" value="{$currentDate}" id="newline_start_date" class="crm-form-text crm-hidden-date">
+        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="Start Date" name="newline_start_date" type="text" value="{$currentDate}" id="newline_start_date" class="crm-form-text crm-hidden-date">
       </td>
       <td nowrap>
-        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false{rdelim}" aria-label="End Date" name="newline_end_date" type="text" value="{$largestMembershipEndDate}" id="newline_end_date" class="crm-form-text crm-hidden-date">
+        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="End Date" name="newline_end_date" type="text" value="{$largestMembershipEndDate}" id="newline_end_date" class="crm-form-text crm-hidden-date">
       </td>
       <td>
         {if $recurringContribution.auto_renew}
@@ -82,7 +85,7 @@
       <td id="newline_financial_type"> - </td>
       <td id="newline_tax_rate" nowrap> - </td>
       <td><input name="newline_amount" id="newline_amount" class="crm-form-text"/></td>
-      <td nowrap>
+      <td nowrap class="confirmation-icons">
         <a class="line-apply-btn" href="" id="apply_add_membership_btn">
           <span><i class="crm-i fa-check" title="Add line item..."></i>&nbsp;</span>
         </a>
@@ -96,7 +99,7 @@
         <input name="newline_donation_item" id="newline_donation_item" class="crm-form-text"/>
       </td>
       <td nowrap>
-        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false{rdelim}" aria-label="Start Date" name="newline_donation_start_date" type="text" value="{$currentDate}" id="newline_donation_start_date" class="crm-form-text crm-hidden-date">
+        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="Start Date" name="newline_donation_start_date" type="text" value="{$currentDate}" id="newline_donation_start_date" class="crm-form-text crm-hidden-date">
       </td>
       <td nowrap>
         N/A
@@ -115,9 +118,9 @@
           {/foreach}
         </select>
       </td>
-      <td id="newline_donation_tax_rate" nowrap> - </td>
+      <td id="newline_donation_tax_rate" nowrap> N/A </td>
       <td><input name="newline_donation_amount" id="newline_donation_amount" class="crm-form-text"/></td>
-      <td nowrap>
+      <td nowrap class="confirmation-icons">
         <a class="line-apply-btn" href="" id="apply_add_donation_btn">
           <span><i class="crm-i fa-check" title="Add line item..."></i>&nbsp;</span>
         </a>
@@ -160,7 +163,7 @@
       </td>
     </tr>
     <tr>
-      <td class="contriTotalLeft right">{ts}Total per Installment:{/ts}</td>
+      <td class="contriTotalLeft right">{ts}Total per Instalment:{/ts}</td>
       <td>{$installmentTotal|crmMoney}</td>
     </tr>
   </table>

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -20,13 +20,13 @@
 
   <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
     <li id="tab_current" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
-      <a href="#current-subtab" title="{ts}Contributions{/ts}">
+      <a href="#current-subtab" title="{ts}Contributions{/ts}" class="clickable">
         {ts}Current Period{/ts}
       </a>
     </li>
     {if $autoRenewEnabled}
     <li id="tab_next" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
-      <a href="#next-subtab" title="{ts}Recurring Contributions{/ts}">
+      <a href="#next-subtab" title="{ts}Recurring Contributions{/ts}" class="clickable">
         {ts}Next Period (Forecast){/ts}
       </a>
     </li>


### PR DESCRIPTION
## Overview
Some minor issues were found testing line item addition for other amounts.

![image](https://user-images.githubusercontent.com/21999940/45639581-081fa900-ba76-11e8-8329-be3d30ed04a4.png)

## Before
- 'installment' is being used instead of 'instalment'
- Input for item was too narrow
- Input for dates allowed clearing the date
- Tax rates showed '-' by default
- Elements were aligned to top of table row
- When adding a new row, you could still navigate to the other tab and even add a new row.

## After
Implemented fixes:
- Changed 'installment' for 'instalment'
- Made input for item wider
- Removed cross icons to clear dates
- Left tax rate as 'N/A' by default.
- Centered elements vertically on new rows.
- Made tabs unclickable when adding a new row.
