### PR TITLE
BASW-217: Fix View Modify Future Installments Action - Next Period

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -145,11 +145,11 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('membershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems));
     $this->assign('lineItems', $currentPeriodLineItems);
 
-    $this->assign('autoRenewEnabled', $this->isAutoRenewEnabled($currentPeriodLineItems));
+    $this->assign('showNextPeriodTab', $this->showNextPeriodTab($currentPeriodLineItems));
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('financialTypes', $this->financialTypes);
     $this->assign('currencySymbol', $this->getCurrencySymbol());
-    $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => TRUE]));
+    $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => TRUE, 'is_removed' => 0]));
 
     parent::run();
   }
@@ -196,14 +196,8 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    *
    * @return boolean
    */
-  private function isAutoRenewEnabled() {
-    $isAutoRenew = CRM_Utils_String::strtobool(CRM_Utils_Array::value('auto_renew', $this->contribRecur));
-  
-    if ($isAutoRenew && count($this->getMemberships())) {
-      return TRUE;
-    }
-  
-    return FALSE;
+  private function showNextPeriodTab() {
+    return CRM_Utils_String::strtobool(CRM_Utils_Array::value('auto_renew', $this->contribRecur)) && count($this->getMemberships());
   }
 
   /**

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -24,7 +24,7 @@
         {ts}Current Period{/ts}
       </a>
     </li>
-    {if $autoRenewEnabled}
+    {if $showNextPeriodTab}
     <li id="tab_next" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
       <a href="#next-subtab" title="{ts}Recurring Contributions{/ts}">
         {ts}Next Period (Forecast){/ts}
@@ -36,7 +36,7 @@
   <div id="current-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
     {include file="CRM/MembershipExtras/Page/CurrentPeriodTab.tpl"}
   </div>
-  {if $autoRenewEnabled}
+  {if $showNextPeriodTab}
   <div id="next-subtab" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
     {include file="CRM/MembershipExtras/Page/NextPeriodTab.tpl"}
   </div>

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -22,7 +22,7 @@ var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
   {assign var='installments' value=$recurringContribution.installments|intval}
 
   {foreach from=$nextPeriodLineItems item='currentItem'}
-    {if ($installments || !$currentItem.end_date)}
+    {if ($installments || (!$installments && !$currentItem.end_date))}
       {assign var='subTotal' value=$subTotal+$currentItem.line_total}
       {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
 

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -19,24 +19,27 @@ var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
   {assign var='subTotal' value=0}
   {assign var='taxTotal' value=0}
   {assign var='installmentTotal' value=0}
+  {assign var='installments' value=$recurringContribution.installments|intval}
 
   {foreach from=$nextPeriodLineItems item='currentItem'}
-    {assign var='subTotal' value=$subTotal+$currentItem.line_total}
-    {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
+    {if ($installments || !$currentItem.end_date)}
+      {assign var='subTotal' value=$subTotal+$currentItem.line_total}
+      {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
 
-    <tr id="lineitem-{$currentItem.id}" data-action="cancel"
-        data-item-data='{$currentItem|@json_encode}'
-        class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
-      <td>{$currentItem.label}</td>
-      <td>{$currentItem.financial_type}</td>
-      <td>{if !empty($currentItem.tax_rate)}{$currentItem.tax_rate}{else}N/A{/if}</td>
-      <td>{$currentItem.line_total|crmMoney}</td>
-      <td>
-        <a class="remove-next-period-line-button">
-          <span><i class="crm-i fa-trash"></i></span>
-        </a>
-      </td>
-    </tr>
+      <tr id="lineitem-{$currentItem.id}" data-action="cancel"
+          data-item-data='{$currentItem|@json_encode}'
+          class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
+        <td>{$currentItem.label}</td>
+        <td>{$currentItem.financial_type}</td>
+        <td>{if !empty($currentItem.tax_rate)}{$currentItem.tax_rate} %{else}N/A{/if}</td>
+        <td>{$currentItem.line_total|crmMoney}</td>
+        <td>
+          <a class="remove-next-period-line-button">
+            <span><i class="crm-i fa-trash"></i></span>
+          </a>
+        </td>
+      </tr>
+    {/if}
   {/foreach}
   {assign var='installmentTotal' value=$subTotal+$taxTotal}
   <tr id="addLineItemRow" style="display: none">


### PR DESCRIPTION
## Overview
1. Line Items should display with percentage symbol next.
2. If the number of installments of the payment plan is empty or 0, `membershipextras_subscription_line` with an end date should be excluded from the view.

## Before
1. Percentage sign does not show next to tax rate.
2. Line items show regardless of if the payment plan has 0 installments and if the `membershipextras_subscription_line`  has an `end_date`.

## After
1. Percentage sign shows next to the tax rate now.
2. `membershipextras_subscription_line` are excluded when the payment plan has 0 installments and the `membershipextras_subscription_line`  has an `end_date`.

![basw-217-fix-after](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/Fix-BASW-217.png)