### PR TITLE
BASW-212: Fix Listing of Items on Current Period

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -140,7 +140,10 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('periodStartDate', CRM_Utils_Array::value('start_date', $this->contribRecur));
     $this->assign('periodEndDate', CRM_Utils_Array::value('end_date', $this->contribRecur));
 
-    $currentPeriodLineItems = $this->getLineItems(['is_removed' => 0]);
+    $currentPeriodLineItems = $this->getLineItems([
+      'is_removed' => 0,
+      'start_date' => ['IS NOT NULL' => 1],
+    ]);
     $this->assign('largestMembershipEndDate', $this->getLargestMembershipEndDate($currentPeriodLineItems));
     $this->assign('membershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems));
     $this->assign('lineItems', $currentPeriodLineItems);

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -140,10 +140,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('periodStartDate', CRM_Utils_Array::value('start_date', $this->contribRecur));
     $this->assign('periodEndDate', CRM_Utils_Array::value('end_date', $this->contribRecur));
 
-    $currentPeriodLineItems = $this->getLineItems([
-      'is_removed' => 0,
-      'start_date' => ['IS NOT NULL' => 1],
-    ]);
+    $currentPeriodLineItems = $this->getCurrentPeriodLineItems();
     $this->assign('largestMembershipEndDate', $this->getLargestMembershipEndDate($currentPeriodLineItems));
     $this->assign('membershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems));
     $this->assign('lineItems', $currentPeriodLineItems);
@@ -155,6 +152,26 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => TRUE]));
 
     parent::run();
+  }
+
+  /**
+   * Obtains list of line items for the current period.
+   *
+   * @return array
+   */
+  private function getCurrentPeriodLineItems() {
+    $conditions = [
+      'is_removed' => 0,
+      'start_date' => ['IS NOT NULL' => 1],
+    ];
+
+    if (!$this->contribRecur['installments']) {
+      $conditions['end_date'] = ['IS NULL' => 1];
+    }
+
+    $currentPeriodLineItems = $this->getLineItems($conditions);
+
+    return $currentPeriodLineItems;
   }
 
   /**

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -25,7 +25,9 @@
       <th scope="col">{ts}Item{/ts}</th>
       <th scope="col">{ts}Start Date{/ts}</th>
       <th scope="col">{ts}End Date{/ts}</th>
-      <th scope="col">{ts}Renew Automatically{/ts}</th>
+      {if $recurringContribution.auto_renew}
+        <th scope="col">{ts}Renew Automatically{/ts}</th>
+      {/if}
       <th scope="col">{ts}Financial Type{/ts}</th>
       <th scope="col">{ts}Tax{/ts}</th>
       <th scope="col">{ts}Amount{/ts}</th>
@@ -43,12 +45,11 @@
         <td>{$currentItem.label}</td>
         <td>{$currentItem.start_date|date_format}</td>
         <td>{$largestMembershipEndDate|date_format}</td>
-        <td>
-          {if $recurringContribution.auto_renew}
-            <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />
-          {/if}
-          &nbsp;
-        </td>
+        {if $recurringContribution.auto_renew}
+          <td>
+              <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />
+          </td>
+        {/if}&nbsp;
         <td>{$currentItem.financial_type}</td>
         <td>{if $currentItem.tax_rate == 0}N/A{else}{$currentItem.tax_rate}%{/if}</td>
         <td nowrap>{$currentItem.line_total|crmMoney}</td>
@@ -76,12 +77,11 @@
       <td nowrap>
         <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="End Date" name="newline_end_date" type="text" value="{$largestMembershipEndDate}" id="newline_end_date" class="crm-form-text crm-hidden-date">
       </td>
-      <td>
-        {if $recurringContribution.auto_renew}
-          <input name="newline_auto_renew" id="newline_auto_renew" type="checkbox" checked />
-        {/if}&nbsp;
-        &nbsp;
-      </td>
+      {if $recurringContribution.auto_renew}
+        <td>
+            <input name="newline_auto_renew" id="newline_auto_renew" type="checkbox" checked />&nbsp;
+        </td>
+      {/if}&nbsp;
       <td id="newline_financial_type"> - </td>
       <td id="newline_tax_rate" nowrap> - </td>
       <td><input name="newline_amount" id="newline_amount" class="crm-form-text"/></td>
@@ -104,12 +104,11 @@
       <td nowrap>
         N/A
       </td>
-      <td>
-        {if $recurringContribution.auto_renew}
-          <input name="newline_donation_auto_renew" id="newline_donation_auto_renew" type="checkbox" checked />
-        {/if}
-        &nbsp;
-      </td>
+      {if $recurringContribution.auto_renew}
+        <td>
+            <input name="newline_donation_auto_renew" id="newline_donation_auto_renew" type="checkbox" checked />&nbsp;
+        </td>
+      {/if}
       <td>
         <select class="crm-form-select" name="newline_donation_financial_type_id" id="newline_donation_financial_type_id">
           <option value="">- {ts}select{/ts} -</option>


### PR DESCRIPTION
## Overview

Three issues need to be addressed:
- When a line was added on next period, it was also shown on current period.
- Auto renew column should not be shown if recurring contribution is NOT set to auto-renew.
- If the number of instalments of the payment plan is empty or 0, "membershipextras_subscription_line" with an end date should also be excluded from the view.

## Before
- Adding a line item to next period also showed it on current period.
- Auto renew column on line item list was shown, even if recurring contribution was not set to auto-renew.
- If the number of instalments was empty or 0, line items with an end date were being shown.

## After
- Filtered line items shown on current period so they have a start date.
- Auto renew column is not shown if recurring contribution is not set to auto-renew.
- If the number of instalments of the payment plan is empty or 0, line items with an end date are excluded.

![image](https://user-images.githubusercontent.com/21999940/45706910-14be0300-bb43-11e8-927d-e8bec569f829.png)
