### PR TITLE
BASW-264: Payment Plan Period Links

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -180,7 +180,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       'collapse_display' => 1,
       'weight' => 10,
       'is_active' => 0,
-      'table_name' => 'civicrm_value_related_payme_21',
+      'table_name' => 'civicrm_value_payment_plan_periods',
       'is_multiple' => 0,
       'collapse_adv_display' => 0,
       'is_reserved' => 0,
@@ -188,7 +188,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       'api.CustomField.create' => [
         [
           'custom_group_id' => '$value.id',
-          'name' => 'previous_payment_plan_period',
+          'name' => 'previous_period',
           'label' => E::ts('Previous Payment Plan Period'),
           'data_type' => 'Int',
           'html_type' => 'Text',
@@ -199,10 +199,10 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
           'is_view' => 1,
           'is_selector' => 0,
           'custom_group_name' => 'related_payment_plan_periods',
-          'column_name' => 'previous_payment_plan_period',
+          'column_name' => 'previous_period',
         ], [
           'custom_group_id' => '$value.id',
-          'name' => 'next_payment_plan_period',
+          'name' => 'next_period',
           'label' => E::ts('Next Payment Plan Period'),
           'data_type' => 'Int',
           'html_type' => 'Text',
@@ -213,7 +213,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
           'is_view' => 1,
           'is_selector' => 0,
           'custom_group_name' => 'related_payment_plan_periods',
-          'column_name' => 'next_payment_plan_period',
+          'column_name' => 'next_period',
         ]
       ],
     ]);

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -169,12 +169,64 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   }
 
   /**
+   * Add Related Payment Plan Periods' Custom Fields
+   */
+  private function createPeriodLinkCustomFields() {
+    civicrm_api3('CustomGroup', 'create', [
+      'name' => 'related_payment_plan_periods',
+      'title' => E::ts('Related Payment Plan Periods'),
+      'extends' => 'ContributionRecur',
+      'style' => 'Inline',
+      'collapse_display' => 1,
+      'weight' => 10,
+      'is_active' => 0,
+      'table_name' => 'civicrm_value_related_payme_21',
+      'is_multiple' => 0,
+      'collapse_adv_display' => 0,
+      'is_reserved' => 0,
+      'is_public' => 1,
+      'api.CustomField.create' => [
+        [
+          'custom_group_id' => '$value.id',
+          'name' => 'previous_payment_plan_period',
+          'label' => E::ts('Previous Payment Plan Period'),
+          'data_type' => 'Int',
+          'html_type' => 'Text',
+          'is_required' => 0,
+          'is_searchable' => 0,
+          'weight' => 2,
+          'is_active' => 0,
+          'is_view' => 1,
+          'is_selector' => 0,
+          'custom_group_name' => 'related_payment_plan_periods',
+          'column_name' => 'previous_payment_plan_period',
+        ], [
+          'custom_group_id' => '$value.id',
+          'name' => 'next_payment_plan_period',
+          'label' => E::ts('Next Payment Plan Period'),
+          'data_type' => 'Int',
+          'html_type' => 'Text',
+          'is_required' => 0,
+          'is_searchable' => 0,
+          'weight' => 2,
+          'is_active' => 0,
+          'is_view' => 1,
+          'is_selector' => 0,
+          'custom_group_name' => 'related_payment_plan_periods',
+          'column_name' => 'next_payment_plan_period',
+        ]
+      ],
+    ]);
+  }
+
+  /**
    * Adds membershipextras_contribution_recur_line_item table to DB.
    *
    * @return bool
    */
   public function upgrade_0001() {
     $this->executeSqlFile('sql/auto_install.sql');
+    $this->createPeriodLinkCustomFields();
 
     return TRUE;
   }

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -46,6 +46,23 @@
             <is_multiple>0</is_multiple>
             <collapse_adv_display>0</collapse_adv_display>
         </CustomGroup>
+        <CustomGroup>
+            <name>related_payment_plan_periods</name>
+            <title>Related Payment Plan Periods</title>
+            <extends>ContributionRecur</extends>
+            <style>Inline</style>
+            <collapse_display>1</collapse_display>
+            <help_pre></help_pre>
+            <help_post></help_post>
+            <weight>10</weight>
+            <is_active>1</is_active>
+            <table_name>civicrm_value_related_payme_21</table_name>
+            <is_multiple>0</is_multiple>
+            <collapse_adv_display>0</collapse_adv_display>
+            <created_date>2018-09-20 10:46:12</created_date>
+            <is_reserved>0</is_reserved>
+            <is_public>1</is_public>
+        </CustomGroup>
     </CustomGroups>
     <CustomFields>
         <CustomField>
@@ -112,6 +129,42 @@
             <note_rows>4</note_rows>
             <column_name>external_id</column_name>
             <custom_group_name>membership_external_id</custom_group_name>
+        </CustomField>
+        <CustomField>
+            <name>previous_payment_plan_period</name>
+            <label>Previous Payment Plan Period</label>
+            <data_type>Int</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>0</is_searchable>
+            <is_search_range>0</is_search_range>
+            <weight>1</weight>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>255</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>previous_payment_plan_period_24</column_name>
+            <in_selector>0</in_selector>
+            <custom_group_name>related_payment_plan_periods</custom_group_name>
+        </CustomField>
+        <CustomField>
+            <name>next_payment_plan_period</name>
+            <label>Next Payment Plan Period</label>
+            <data_type>Int</data_type>
+            <html_type>Text</html_type>
+            <is_required>0</is_required>
+            <is_searchable>0</is_searchable>
+            <is_search_range>0</is_search_range>
+            <weight>2</weight>
+            <is_active>1</is_active>
+            <is_view>1</is_view>
+            <text_length>255</text_length>
+            <note_columns>60</note_columns>
+            <note_rows>4</note_rows>
+            <column_name>next_payment_plan_period_25</column_name>
+            <in_selector>0</in_selector>
+            <custom_group_name>related_payment_plan_periods</custom_group_name>
         </CustomField>
     </CustomFields>
 </CustomData>

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -56,7 +56,7 @@
             <help_post></help_post>
             <weight>10</weight>
             <is_active>1</is_active>
-            <table_name>civicrm_value_related_payme_21</table_name>
+            <table_name>civicrm_value_payment_plan_periods</table_name>
             <is_multiple>0</is_multiple>
             <collapse_adv_display>0</collapse_adv_display>
             <created_date>2018-09-20 10:46:12</created_date>
@@ -131,7 +131,7 @@
             <custom_group_name>membership_external_id</custom_group_name>
         </CustomField>
         <CustomField>
-            <name>previous_payment_plan_period</name>
+            <name>previous_period</name>
             <label>Previous Payment Plan Period</label>
             <data_type>Int</data_type>
             <html_type>Text</html_type>
@@ -144,12 +144,12 @@
             <text_length>255</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>previous_payment_plan_period_24</column_name>
+            <column_name>previous_period</column_name>
             <in_selector>0</in_selector>
             <custom_group_name>related_payment_plan_periods</custom_group_name>
         </CustomField>
         <CustomField>
-            <name>next_payment_plan_period</name>
+            <name>next_period</name>
             <label>Next Payment Plan Period</label>
             <data_type>Int</data_type>
             <html_type>Text</html_type>
@@ -162,7 +162,7 @@
             <text_length>255</text_length>
             <note_columns>60</note_columns>
             <note_rows>4</note_rows>
-            <column_name>next_payment_plan_period_25</column_name>
+            <column_name>next_period</column_name>
             <in_selector>0</in_selector>
             <custom_group_name>related_payment_plan_periods</custom_group_name>
         </CustomField>


### PR DESCRIPTION
## Overview
1. Creating a custom fieldset "Related Payment Plan Periods" for recurring contribution entity. It should contain two read-only integer fields:
  - Previous Payment Plan Period
  - Next Payment Plan Period
2. We need to also add this to an upgrader which is only run when upgrading process.

## Before
Feature was not present.

## After
Feature has been implemented. 

![Payment Plan Period Links](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-264.png "BASW-264")
