### PR TITLE
BASW-256: Set Subscription Line End Date

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -52,6 +52,7 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
           }
         }
       }
+
       civicrm_api3('ContributionRecur', 'create', [
         'id' => $this->recurContribution['id'],
         'contribution_status_id' => $newStatus,
@@ -59,6 +60,11 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     }
   }
 
+  /**
+   * Returns LineItems associated to a recurring contribution
+   * 
+   * @return array
+   */
   private function getSubscriptionLines() {
     $lines = civicrm_api3('ContributionRecurLineItem', 'get', [
       'sequential' => 1,

--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -42,15 +42,7 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     $newStatus = $this->generatePaymentPlanNewStatus();
     if ($newStatus !== NULL) {
       if ($newStatus === 'Completed') {
-        $subscriptionLines = $this->getSubscriptionLines();
-        foreach($subscriptionLines as $line) {
-          if (!empty($line['start_date']) && empty($line['end_date'])) {
-            civicrm_api3('ContributionRecurLineItem', 'create', [
-              'id' => $line['id'],
-              'end_date' => $this->recurContribution['end_date'],
-            ]);
-          }
-        }
+        $this->updateSubscriptionLinesEndDate();
       }
 
       civicrm_api3('ContributionRecur', 'create', [
@@ -61,17 +53,38 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
   }
 
   /**
+   * Updates subscription line items end date
+   */
+  private function updateSubscriptionLinesEndDate() {
+    $subscriptionLines = $this->getSubscriptionLines();
+    foreach($subscriptionLines as $line) {
+      if (!empty($line['start_date']) && empty($line['end_date'])) {
+        civicrm_api3('ContributionRecurLineItem', 'create', [
+          'id' => $line['id'],
+          'end_date' => $this->recurContribution['end_date'],
+        ]);
+      }
+    }
+  }
+
+  /**
    * Returns LineItems associated to a recurring contribution
    * 
    * @return array
    */
   private function getSubscriptionLines() {
-    $lines = civicrm_api3('ContributionRecurLineItem', 'get', [
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
       'sequential' => 1,
       'contribution' => $this->recurContribution['id'],
+      'options' => ['limit' => 0],
     ]);
 
-    return $lines;
+    $subscriptionLines = [];
+    if ($result['count']) {
+      $subscriptionLines = $result['values'];
+    }
+    
+    return $subscriptionLines;
   }
 
   /**


### PR DESCRIPTION
## Overview
When a payment plan is marked as completed, all subscription lines that meet the below conditions should have their end date set to the payment plan end date:
1. start date is not empty
2. end date is empty

## Before
Action did not exist

## After
When a payment plan's status changes to `Completed`, all subscription lines matching the criteria in the overview above are have their `end_date` set to the payment plan's `end_date`