### PR TITLE
ASE-257: Ensure Created Jobs are Disabled

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -28,6 +28,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       'description' => ts('Automatically renew any offline/paylater membership that is configured to be auto-renewed'),
       'api_entity' => 'OfflineAutoRenewalJob',
       'api_action' => 'run',
+      'is_active' => 0,
     ]);
   }
 


### PR DESCRIPTION
## Overview
We need to check the extension's process to see if any of the scheduled jobs created by the extension are automatically turned on during the installation process.
We need to make sure all scheduled jobs created by these extensions are turned off by default.

## Before
Jobs created by this extension were enabled by default after installation

## After
Jobs created by the extension are now disabled on extension installation.