### PR TITLE
BASW-262: Update Renewal with No Instalments to Use Subscription Line Items

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/LineItem.php
+++ b/CRM/MembershipExtras/Hook/Post/LineItem.php
@@ -101,7 +101,7 @@ class CRM_MembershipExtras_Hook_Post_LineItem {
     $contributionID = $this->lineItem->contribution_id;
 
     if (empty($contributionID)) {
-      return array();
+      return [];
     }
 
     if (!in_array($contributionID, $contributionKeys)) {
@@ -124,7 +124,7 @@ class CRM_MembershipExtras_Hook_Post_LineItem {
         self::$contributions[$contributionID] = $result['values'][0];
       }
       else {
-        self::$contributions[$contributionID] = array();
+        self::$contributions[$contributionID] = [];
       }
     }
 

--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
@@ -84,7 +84,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor{
     $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
-    if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 1) {
+    if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 0) {
       return TRUE;
     }
 

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -150,32 +150,32 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * @return True
    */
   public function run() {
-   $recurContributions = $this->getOfflineAutoRenewalRecurContributions();
+    $recurContributions = $this->getOfflineAutoRenewalRecurContributions();
 
-   foreach ($recurContributions as $recurContribution) {
-     $this->previousRecurContributionID = $recurContribution['contribution_recur_id'];
-     $this->currentRecurContributionID = $recurContribution['contribution_recur_id'];
+    foreach ($recurContributions as $recurContribution) {
+      $this->previousRecurContributionID = $recurContribution['contribution_recur_id'];
+      $this->currentRecurContributionID = $recurContribution['contribution_recur_id'];
 
-     if (empty($recurContribution['installments'])) {
-       $this->currentInstallmentsNumber = 1;
-     }
-     else {
-       $this->currentInstallmentsNumber = $recurContribution['installments'];
-     }
+      if (empty($recurContribution['installments'])) {
+        $this->currentInstallmentsNumber = 1;
+      }
+      else {
+        $this->currentInstallmentsNumber = $recurContribution['installments'];
+      }
 
-     $this->setLastContribution();
+      $this->setLastContribution();
 
-     if ($this->currentInstallmentsNumber > 1) {
-       $this->renewWithInstallmentsPaymentPlan();
-     }
-     else {
-       $this->renewNoInstallmentsPaymentPlan();
-     }
+      if ($this->currentInstallmentsNumber > 1) {
+        $this->renewWithInstallmentsPaymentPlan();
+      }
+      else {
+        $this->renewNoInstallmentsPaymentPlan();
+      }
 
-     $this->dispatchMembershipRenewalHook();
-   }
+      $this->dispatchMembershipRenewalHook();
+    }
 
-   return TRUE;
+    return TRUE;
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -604,6 +604,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
         'entity_table' => ['IS NOT NULL' => 1],
         'entity_id' => ['IS NOT NULL' => 1],
       ],
+      'options' => ['limit' => 0],
     ]);
 
     if ($result['count'] > 0) {
@@ -731,6 +732,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
         'entity_table' => ['IS NOT NULL' => 1],
         'entity_id' => ['IS NOT NULL' => 1]
       ],
+      'options' => ['limit' => 0],
     ]);
 
     foreach ($lineItems['values'] as $line) {

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -144,11 +144,15 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('largestMembershipEndDate', $this->getLargestMembershipEndDate($currentPeriodLineItems));
     $this->assign('membershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems));
     $this->assign('lineItems', $currentPeriodLineItems);
-    $this->assign('showNextPeriodTab', $this->showNextPeriodTab($currentPeriodLineItems));
+    $this->assign('showNextPeriodTab', $this->showNextPeriodTab());
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('financialTypes', $this->financialTypes);
     $this->assign('currencySymbol', $this->getCurrencySymbol());
-    $this->assign('nextPeriodLineItems', $this->getLineItems(['auto_renew' => TRUE, 'is_removed' => 0]));
+    $this->assign('nextPeriodLineItems', $this->getLineItems([
+      'auto_renew' => TRUE,
+      'end_date' => ['IS NULL' => 1],
+      'is_removed' => 0,
+    ]));
 
     parent::run();
   }
@@ -162,6 +166,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $conditions = [
       'is_removed' => 0,
       'start_date' => ['IS NOT NULL' => 1],
+      'end_date' => ['IS NULL' => 1],
     ];
 
     if (!$this->contribRecur['installments']) {

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -172,7 +172,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   }
 
   static $isFirstPaymentPlanContribution = TRUE;
-  $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithMoreThanOneInstallment();
+  $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithAtLeastOneInstallment();
   $membershipContributionCreation = ($objectName === 'Contribution' && $op === 'create' && !empty($params['membership_id']));
   if ($membershipContributionCreation && $isPaymentPlanPayment && $isFirstPaymentPlanContribution) {
     $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
@@ -191,18 +191,17 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
 }
 
 /**
- * Determines if the membership is paid
- * using payment plan option using more than
- * one installment or not.
+ * Determines if the membership is paid using payment plan option having at
+ * least one instalment.
  *
  * @return bool
  */
-function _membershipextras_isPaymentPlanWithMoreThanOneInstallment() {
+function _membershipextras_isPaymentPlanWithAtLeastOneInstallment() {
   $installmentsCount = CRM_Utils_Request::retrieve('installments', 'Int');
   $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
   $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
-  if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 1) {
+  if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 0) {
     return TRUE;
   }
 


### PR DESCRIPTION
## Overview

When "Renew offline auto-renewal memberships" scheduled job is run, any payment plans that meet criteria to auto-renew and have a number of instalments less than or equal to 1, should use line items on membershipextras_subscription_line to determine the line items for the new contribution.

For each membershipextras_subscription_line which is auto-renew and not is_removed in the recurring contribution, the system should:
- Make a copy of the linked line item and link it to the recurring contribution
- Make a copy of the membershipextras_subscription_line, linking it to the recurring contribution and making the start date of the copied membershipextras_subscription_line be the received date of the last instalment plus one interval. the end date should be empty.
- The end date of the original membershipextras_subscription_line should be 1 day earlier than the new membershipextras_subscription_line's start date.

The last contribution should be used as a template to create a new pending contribution under the same recurring contribution and should contain a copy of the auto-renew line items linked to the recurring contribution. The amount fields should reflect the actual amount based on the line items, both for the new contribution and the recurring contribution.

For each membership line item, if the user already have a membership with same type, we should extend that membership for a term.  If the user does not have any membership with same type, a new membership needs to be created with start date of the recurring contribution start date.

## Before
Line items to be included in new contribution was determined by line items set on the last contribution associated to the recurring contribution.

## After
Fixed some bugs that were causing problems on creation of payment plans with only one instalment, where the recurring line items were not being copied and associated to the recurring contribution.

Implemented logic to duplicate recurring line items that are set to renew, are not removed and do not have end dates, to be used for the new contribution, setting the end dates of the original line items.

Updated logic so the list of line items to be used on the new contribution on renewal is determined by those line items set to renew, are not removed and don't have an end date for the payment plan.