### PR TITLE
DD-58: Prevent duplicate autorenewal activities when paying using pricefield with more than one membership

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -610,18 +610,21 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
       'contribution_id' => $this->lastContribution['id'],
     ])['values'];
 
+    $membershipIds = [];
     foreach ($membershipPayments as $membershipPayment) {
       $membership = new CRM_Member_DAO_Membership();
       $membership->id = $membershipPayment['membership_id'];
       $membership->end_date = MembershipEndDateCalculator::calculate($membershipPayment['membership_id']);
       $membership->save();
 
-      $nullObject = CRM_Utils_Hook::$_nullObject;
-      CRM_Utils_Hook::singleton()->invoke(
-        ['membershipId', 'recurContributionId', 'previousRecurContributionId'], $membershipPayment['membership_id'],
-        $this->currentRecurContributionID, $this->previousRecurContributionID, $nullObject, $nullObject, $nullObject,
-        'membershipextras_postOfflineAutoRenewal');
+      $membershipIds[] = $membershipPayment['membership_id'];
     }
+
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    CRM_Utils_Hook::singleton()->invoke(
+      ['membershipIds', 'recurContributionId', 'previousRecurContributionId'], $membershipIds,
+      $this->currentRecurContributionID, $this->previousRecurContributionID, $nullObject, $nullObject, $nullObject,
+      'membershipextras_postOfflineAutoRenewal');
   }
 
 }


### PR DESCRIPTION
## Problem

When the user buy two (or more) Direct Debit memberships (possible via pricefields) and the memberships are set to be autorenewed , then a number of offline_direct_debit_auto_renewal activities that equals the number of the memberships will be created. Only one should be created.

## Solution

I changed the hook location so it get called outside the loop that renew memberships, and instead of passing a single membership ID each time, I now send all the memberships ids at one in array (in the first hook parameter)