### PR TITLE
BASW-259: Upgrader

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -254,7 +254,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     }
 
     $result = civicrm_api3('Contribution', 'getsingle', [
-      'options' => ['sort' => 'id DESC'],
+      'options' => ['sort' => 'id DESC', 'limit' => 1],
       'contribution_recur_id' => $paymentPlanId,
     ]);
   }

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -15,7 +15,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     $this->createPaymentProcessor();
     $this->createLineItemExternalIDCustomField();
     $this->executeSqlFile('sql/set_unique_external_ids.sql');
-    $this->createOfflineSubLineItemsForPaymentPlans();
+    $this->updatePaymentPlans();
   }
 
   /**
@@ -343,7 +343,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
    * Finds all payment plans and populate the offline recurring contribution
    * line item for the payment plans using an offline payment processor
    */
-  private function createOfflineSubLineItemsForPaymentPlans() {
+  private function updatePaymentPlans() {
     $recurContributions = $this->getAllPaymentPlans();
 
     foreach ($recurringContributions as $paymentPlan) {
@@ -385,6 +385,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   public function upgrade_0001() {
     $this->executeSqlFile('sql/auto_install.sql');
     $this->createPeriodLinkCustomFields();
+    $this->updatePaymentPlans();
 
     return TRUE;
   }


### PR DESCRIPTION
## Overview
### Part 1
1. As a part of phase 3 upgrader, the extension should find all pre-existing offline payment plans and populate the "Offline Recurring Contribution Line Item" information for them.
2. For each pre-existing recurring contribution using an offline payment processor (payment processor with Payment Manual class):
    * create a copy of each line item of the last installment contribution
    * the contribution_id of the copied line items should NULL
    * a record should be created in "membershipextras_subscription_line" table for each of the copied line item:
        * contribution_recur_id - the id of the recurring contribution
        * line_item_id - the id of the copied line item
        * start_date - start date of the recurring contribution
        * end_date - end date of the recurring contribution. If empty, leave empty.
        * auto_renew - true if the recurring contribution auto-renews, otherwise false
        * is_removed - False

### Part 2 (Needs to be run also during installation)
1. As a part of phase 3 upgrader, the extension should find all pre-existing payment plans that meet the criteria below and populate the "Related Payment Plan Periods" for them.
    * payment plan that uses an offline payment processor (payment processor with Payment Manual class)
    * payment plan whose number of installment is larger than 0
    * payment plan whose end date is not empty and is more a month earlier than today
    * payment plans whose auto-renew is set to True
2. the contact has more than one payment plans that meet criteria a, b and c
3. Find all memberships that are linked to payment plan that meets the criteria. Fill in the  "Previous Payment Plan Period" and "Next Payment Plan Period" with number 0.
4. This needs to be part of the installer too.

## Before
Action was not present.

## After
Action has been implemented.