### PR TITLE
BASW-263: Implement Recurring Line Items Price Auto Update

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -183,6 +183,8 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
 
         throw new Exception($message);
       }
+
+      $transaction->commit();
     }
 
     return TRUE;

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -236,7 +236,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
          AND ccr.auto_renew = 1 
          AND (
           ccr.contribution_status_id != ' . $cancelledStatusID . ' 
-          OR  ccr.contribution_status_id != ' . $refundedStatusID . '
+          AND ccr.contribution_status_id != ' . $refundedStatusID . '
          )
          AND ppp.next_period IS NULL
          AND (

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -165,8 +165,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
         $this->currentInstallmentsNumber = $recurContribution['installments'];
       }
 
-      $tx = new CRM_Core_Transaction();
-
+      $transaction = new CRM_Core_Transaction();
       try {
         $this->setLastContribution();
 
@@ -179,14 +178,8 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
 
         $this->dispatchMembershipRenewalHook();
       } catch (Exception $e) {
-        $tx->rollback();
-        $message = "An error ocurred renewing a payment plan with id({$recurContribution['contribution_recur_id']}): " . $e->getMessage();
-
-        CRM_Core_Session::setStatus(
-          $message,
-          "Error Renewing Payment Plan",
-          'error'
-        );
+        $transaction->rollback();
+        $message = "An error occurred renewing a payment plan with id({$recurContribution['contribution_recur_id']}): " . $e->getMessage();
 
         throw new Exception($message);
       }

--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -265,7 +265,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       $newLineItem = CRM_Price_BAO_LineItem::create($lineItemParms);
 
       CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution);
-      if (!empty((float) $contribution->tax_amount)) {
+      if (!empty((float) $contribution->tax_amount) && !empty($newLineItem->tax_amount)) {
         CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution, TRUE);
       }
     }


### PR DESCRIPTION
## Overview
In the auto-renew process, if price auto-update is turned on and a membership is not opt-out of the price auto-update, the new line items created for the new recurring contribution, copied from the line items associated to the previous recurring contribution, should update the price to the membership type's latest value.

## Before
On renewal, the line items copied from the previous recurring contribution always had the original price set when creating the membership.

## After
The flags for price auto-update and price update opt-out are now checked to calculate the line item's price for line items related to memberships.

Fixed several bugs found when renewing recurring contribution:
- On renewal, line items of the new recurring contribution were duplicated, as they were being added both by renewal line item copying and line item post hook. Fixed by only using hook to add line items to the first payment plan created (ie. not renewal).
- Any exceptions triggered when renewing a payment plan would stop execution and leave the payment plan in an inconsistent state (eg. only the first instalment created, and the rest missing). Fixed by enveloping each renewal of a payment plan in an atomic transaction, rolled back if an exception is caught.
- Obtaining list of payment plans to be renewed was looking for payment plans that were not Canceled nor Refunded. This caused both cancelled and refunded payment plans to slip through, as the condition `ccr.contribution_status_id != ' . $cancelledStatusID . ' OR ccr.contribution_status_id != ' . $refundedStatusID . '` always evaluates to true. Changed the condition conjunction to AND, as we need the payment plan's status to be neither Cancelled nor Refunded.
- Removed minor warnings and notices caused by using deprecated code and accessing unset array keys.
- When updating membership prices, line items added to next period only were always being processed as existing memberships. This caused prices for donations and new memberships to get incorrectly calculated. Fixed by checking if the line item is for an existing membership or not. Also refactored the code for CRM_MembershipExtras_Job_OfflineAutoRenewal::calculateLineItemUnitPrice() to clean it up.
- On renewal of payment plans with one or less instalments, ALL line items were being duplicated on each renewal. Fixed by only copying line items with no end date.
- Line items added to next period with no tax were being treated as having tax, as only the contribution's tax amount was being checked to create the financial transaction for the line item, which caused an exception to be thrown, as tax_amoun was null, and the DB table did not accept null values. Fixed by checking line item tax_amount too and only inserting a financial line item for tax if the value is > 0.

