### PR TITLE
BASW-279: Disable Tabs With Jquery API

### DIFF
--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -121,6 +121,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     // Shows new line in table to add new membership.
     CRM.$('#add_membership_btn', this.currentTab).click(function () {
       that.newMembershipRow.css('display', 'table-row');
+      CRM.$('#periodsContainer').tabs({ disabled: true });
       CRM.$('.clickable').addClass('disabled-click');
       CRM.$('.rc-line-item').addClass('disabled-row');
       CRM.$('.auto-renew-line-checkbox').attr('disabled', true);
@@ -131,6 +132,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     // Hides line in table to add new membership.
     CRM.$('#cancel_add_membership_btn', this.currentTab).click(function () {
       that.newMembershipRow.css('display', 'none');
+      CRM.$('#periodsContainer').tabs({ disabled: false });
       CRM.$('.clickable').removeClass('disabled-click');
       CRM.$('.rc-line-item').removeClass('disabled-row');
       CRM.$('.auto-renew-line-checkbox').attr('disabled', false);
@@ -206,6 +208,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     // Show new row on table to add donation.
     CRM.$('#add_other_btn', this.currentTab).click(function () {
       that.newDonationRow.css('display', 'table-row');
+      CRM.$('#periodsContainer').tabs({ disabled: true });
       CRM.$('.clickable').addClass('disabled-click');
       CRM.$('.rc-line-item').addClass('disabled-row');
       CRM.$('.auto-renew-line-checkbox').attr('disabled', true);
@@ -233,6 +236,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     // Hides new row to add new donation.
     CRM.$('#cancel_add_donation_btn', this.currentTab).click(function () {
       that.newDonationRow.css('display', 'none');
+      CRM.$('#periodsContainer').tabs({ disabled: false });
       CRM.$('.clickable').removeClass('disabled-click');
       CRM.$('.rc-line-item').removeClass('disabled-row');
       CRM.$('.auto-renew-line-checkbox').attr('disabled', false);

--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -13,6 +13,7 @@ CRM.$(function () {
   CRM.$('#next_buttons #addOtherAmount').on('click', function(e) {
     e.preventDefault();
     CRM.$('#addLineItemRow').show();
+    CRM.$('#periodsContainer').tabs({ disabled: true });
     CRM.$('#periodsContainer').find('tr').not(CRM.$('#addLineItemRow')).addClass('disabled-row');
     CRM.$('#periodsContainer').find('a').not(CRM.$('#addLineItemRow').find('a')).addClass('disabled-click');
   });
@@ -20,6 +21,7 @@ CRM.$(function () {
   CRM.$('#next_buttons #addMembership').on('click', function(e) {
     e.preventDefault();
     CRM.$('#addMembershipRow').show();
+    CRM.$('#periodsContainer').tabs({ disabled: true });
     CRM.$('#periodsContainer').find('tr').not(CRM.$('#addMembershipRow')).addClass('disabled-row');
     CRM.$('#periodsContainer').find('a').not(CRM.$('#addMembershipRow').find('a')).addClass('disabled-click');
   });
@@ -27,6 +29,7 @@ CRM.$(function () {
   CRM.$('.cancel-add-next-period-line-button').on('click', function(e) {
     e.preventDefault();
     CRM.$('#addLineItemRow').hide();
+    CRM.$('#periodsContainer').tabs({ disabled: false });
     CRM.$('#periodsContainer').find('tr').removeClass('disabled-row');
     CRM.$('#periodsContainer').find('a').removeClass('disabled-click');
   });
@@ -34,6 +37,7 @@ CRM.$(function () {
   CRM.$('.cancel-add-next-period-membership-button').on('click', function(e) {
     e.preventDefault();
     CRM.$('#addMembershipRow').hide();
+    CRM.$('#periodsContainer').tabs({ disabled: false });
     CRM.$('#periodsContainer').find('tr').removeClass('disabled-row');
     CRM.$('#periodsContainer').find('a').removeClass('disabled-click');
   });


### PR DESCRIPTION
## Overview
Currently, when clicking on any of those buttons, a .disabled-click class is applied to the tab's <a> elements. The style for that class (grayish color, no pointer cursor) is coming from the membershipextra's own stylesheet.

But the tabs are jQuery UI tabs, and those already provide an api which includes also a disable() method.

When you invoke that method, a .ui-state-disabled class is applied to the tabs, and that class works fine also in shoreditch.

## Before
Tabs were disable by adding the `disabled-click` class to <a> elements of all tabs.

![Recurring Contribution's Next Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-279-before.png "Recurring Contribution's Next Period Tab")

## After
Tabs are being disabled by invoking the `disable()` method

![Recurring Contribution's Next Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-279-after.png "Recurring Contribution's Next Period Tab")

![Recurring Contribution's Next Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-279-next-period-after.png "Recurring Contribution's Next Period Tab")
