### PR TITLE
DD-58: Fix Payment Plans with 1 Instalment Creation

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -172,7 +172,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   }
 
   static $isFirstPaymentPlanContribution = TRUE;
-  $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithMoreThanOneInstallment();
+  $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithAtLeastOneInstallment();
   $membershipContributionCreation = ($objectName === 'Contribution' && $op === 'create' && !empty($params['membership_id']));
   if ($membershipContributionCreation && $isPaymentPlanPayment && $isFirstPaymentPlanContribution) {
     $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
@@ -197,12 +197,12 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
  *
  * @return bool
  */
-function _membershipextras_isPaymentPlanWithMoreThanOneInstallment() {
+function _membershipextras_isPaymentPlanWithAtLeastOneInstallment() {
   $installmentsCount = CRM_Utils_Request::retrieve('installments', 'Int');
   $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
   $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
-  if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 1) {
+  if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 0) {
     return TRUE;
   }
 


### PR DESCRIPTION
## Overview
Creation with payment plans with only one instalment was not creating the associated recurring contribution. This has been fixed in phase-3 workbranch by means of PR #80 , but we need to have this fix as part of forth-coming release.

## Before
Creation with payment plans with only one instalment was not creating the associated recurring contribution. This was because only payment plans with more than one instalment were being processed. 

##After
Fixed by changing condition to have at least one instalment.