### PR TITLE
BASW-222: Fix Add Membership Line to Standard Multi-line Membership Order (Next Period)

### DIFF
--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -11,17 +11,19 @@ CRM.$(function () {
   });
 
   CRM.$('#next_buttons #addOtherAmount').on('click', function(e) {
-    e.preventDefault();
     CRM.$('#addLineItemRow').show();
     CRM.$('#periodsContainer').find('tr').not(CRM.$('#addLineItemRow')).addClass('disabled-row');
     CRM.$('#periodsContainer').find('a').not(CRM.$('#addLineItemRow').find('a')).addClass('disabled-click');
+
+    return false;
   });
 
   CRM.$('#next_buttons #addMembership').on('click', function(e) {
-    e.preventDefault();
     CRM.$('#addMembershipRow').show();
     CRM.$('#periodsContainer').find('tr').not(CRM.$('#addMembershipRow')).addClass('disabled-row');
     CRM.$('#periodsContainer').find('a').not(CRM.$('#addMembershipRow').find('a')).addClass('disabled-click');
+
+    return false;
   });
 
   CRM.$('.cancel-add-next-period-line-button').on('click', function(e) {
@@ -159,7 +161,6 @@ function showMembershipAddLineItemConfirmation() {
       newMembershipAmount = CRM.$('#newMembershipAmount').val();
 
     var membershipType = getMembershipType(membershipTypeId),
-      priceFieldValue = getDefaultPriceFieldValueForMembershipType(membershipTypeId),
       financialType = getFinancialType(membershipType.financial_type_id),
       taxAmount = Number(financialType.tax_rate) * amount;
 
@@ -169,7 +170,7 @@ function showMembershipAddLineItemConfirmation() {
       'price_field_id.price_set_id.name': 'default_membership_type_amount'
     }).done(function(priceFieldValueResult) {
       if (priceFieldValueResult.count > 0) {
-        priceFieldValue = priceFieldValueResult.values[0];
+        var priceFieldValue = priceFieldValueResult.values[0];
 
         createLineItem({
           label: membershipType.name,
@@ -213,7 +214,7 @@ function createLineItem(params) {
       }
 
       CRM.alert(
-        ts(createdLineItemId.label + ' will now be continued in the next period.'),
+        ts(params.label + ' will now be continued in the next period.'),
         null,
         'success'
       );
@@ -237,8 +238,21 @@ function roundUp(num, decimalPlaces) {
   return +(Math.round(num + "e+" + decimalPlaces)  + "e-" + decimalPlaces);
 }
 
+/**
+ * @param {string} memTypeId 
+ * 
+ * @returns {Object}
+ */
 function getMembershipType(memTypeId) { 
-  return membershipTypes[memTypeId];
+  var result = CRM.$.grep(membershipTypes, function(membershipType){
+    return membershipType.id == memTypeId;
+  });
+  
+  if (result.length === 0) {
+    return {};
+  }
+
+  return result[0];
 }
 
 function showNextPeriodLineItemRemovalConfirmation(lineItemData) {

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -49,11 +49,11 @@ var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
     <td>
       <select class="crm-form-select" name="financial_type_id" id="financialType">
         {foreach from=$financialTypes item='financialType'}
-        <option value={$financialType.id}>{$financialType.name}</option>
+          <option value={$financialType.id}>{$financialType.name}</option>
         {/foreach}
       </select>
     </td>
-    <td id="financialTypeTaxRate">{if !empty($financialTypes[0].tax_rate)}{$financialTypes[0].tax_rate}{else}N/A{/if}</td>
+    <td id="financialTypeTaxRate" nowrap>{if !empty($financialTypes[0].tax_rate)}{$financialTypes[0].tax_rate}{else}N/A{/if}</td>
     <td>
       {$currencySymbol}&nbsp; <input type="text" class="four crm-form-text" size="4" id="amount" />
     </td>
@@ -80,24 +80,24 @@ var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
     <td>
       {$currencySymbol}&nbsp; <input type="text" class="four crm-form-text" size="4" id="newMembershipAmount" />
     </td>
-    <td>
+    <td nowrap class="confirmation-icons">
       <a href="#" class="cancel-add-next-period-membership-button">
-        <span><i class="crm-i fa-times crm-i-red"></i></span>
+        <span><i class="crm-i fa-times"></i></span>
       </a>
       <a href="#" class="confirm-add-next-period-membership-button">
-        <span><i class="crm-i fa-check crm-i-green"></i></span>
+        <span><i class="crm-i fa-check"></i></span>
       </a>
     </td>
   </tr>
   </tbody>
 </table>
 <div id="next_buttons">
-  <button class="crm-button" id="addMembership">
+  <a href="" class="button clickable" id="addMembership">
     <span><i class="crm-i fa-plus"></i>&nbsp; Add Membership</span>
-  </button>
-  <button class="crm-button" id="addOtherAmount">
+  </a>
+  <a href="" class="button clickable" id="addOtherAmount">
     <span><i class="crm-i fa-plus"></i>&nbsp; Add Other Amount</span>
-  </button>
+  </a>
 </div>
 <div class="clear"></div>
 <div class="right">


### PR DESCRIPTION
## Before
Issues reported
1. When "Add Membership" is clicked, the Financial Type column still says "select a membership type" even when an item from the dropdown has been selected - [Screenshot here](http://nimb.ws/cJfPs4)

2. When "Add Membership" or "Add Other Amount" is clicked, other buttons are still clickable even though they shouldn't be. - [Screenshot here](http://nimb.ws/Unc6FI)

3. "Add Membership" and "Add Other Amount" buttons are not compatible with Shoreditch

## After
Points above have been fixed.

![Recurring Contribution's Next Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-222-fix-after.gif "Recurring Contribution's Next Period Tab")