### PR TITLE
BASW-67: Fix Double Recurring Contribution on Single Instalment Payment Plans

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
@@ -83,7 +83,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor{
     $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
-    if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 1) {
+    if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 0) {
       return TRUE;
     }
 

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -3,9 +3,9 @@
   var membershipextras_allMembershipData = {$allMembershipInfo};
   var membershipextras_taxRatesStr = '{$taxRates}';
   var membershipextras_taxTerm = '{$taxTerm}';
-  if (membershipextras_taxRatesStr != '') {
+  if (membershipextras_taxRatesStr != '') {ldelim}
     var membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
-  }
+  {rdelim}
 
   var membershipextras_currency = '{$currency}';
 


### PR DESCRIPTION
## Overview
When creating a membership and paying for it with a single instalment, offline auto-renew payment
plan, two recurring contributions were being created. 

## Before
The problem occurred becuse the logic to determine if the membership was a payment plan was checking if instalments for it were more than one, excluding plans with instlments = 1. This falsely led the system to believe the payment plan was a renewal, creating second recurring contribution for it.

## After
Fixed by changing logic to check for instalments > 0, instead of > 1. Also fixed a syntax error on the PaymentPlanToggler template file.