### PR TITLE
BASW-281: Fix Shoreditch Compatibility Issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,11 +8,13 @@
 .crm-container a.disabled-click,
 .crm-container a.button.clickable.disabled-click {
   pointer-events: none;
-  color: #ddd;
+  color: #ddd !important;
+
 }
 
-tr.disabled-row {
-  color: #ddd;
+tr.disabled-row th,
+tr.disabled-row td {
+  color: #ddd !important;
 }
 
 tr.rc-new-line-item input.required,
@@ -27,4 +29,9 @@ tr.rc-new-line-item input.required,
 
 tr.rc-new-line-item td, td.confirmation-icons {
   vertical-align: middle;
+}
+
+#current_buttons,
+#next_buttons {
+  padding-top: 8px !important;
 }

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -132,7 +132,7 @@
   </table>
 </form>
 
-<div>
+<div id="current_buttons">
   <a class="button clickable" href="" id="add_membership_btn">
     <span><i class="crm-i fa-plus"></i>&nbsp; Add Membership</span>
   </a>


### PR DESCRIPTION
## Overview
Fix Shoreditch compatibility issues like

1. Flashing Row
2. Line Buttons appearing too close to the table header when table is empty
3. Next Period tab Line buttons appearing very off-styled on Shoreditch

## After
![Recurring Contribution's Current Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-281-current-period.png "Recurring Contribution's Current Period Tab")

![Recurring Contribution's Curent Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-281-current-period-flashing.png "Recurring Contribution's Current Period Tab")

![Recurring Contribution's Next Period Tab](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/BASW-281-next-period.png "Recurring Contribution's Next Period Tab")