### PR TITLE
SHOR-45: Fix HTML for membership extra payment plan form elements

### DIFF
--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -143,12 +143,13 @@
     </td>
   </tr>
   <tr id="installments_row">
-    <td nowrap>
-      {$form.installments.label} <span class="marker">*</span>
+    <td class="label" nowrap>
+      {$form.installments.label}<span class="crm-marker">*</span>
     </td>
     <td nowrap>
       {$form.installments.html}
-      {$form.installments_frequency.label} <span class="marker">*</span>
+      &nbsp;
+      {$form.installments_frequency.label} <span class="crm-marker">*</span>
       {$form.installments_frequency.html}
       {$form.installments_frequency_unit.html}
     </td>


### PR DESCRIPTION
## Overview
This PR covers the non proportional space between `Number of Installments` and `Intervals` field of `New Membership` form under `Payment Plan` option

## Before/After with shoreditch
before
<img width="1636" alt="47983057-1e51f900-e0f8-11e8-9988-4874c07dd44b" src="https://user-images.githubusercontent.com/3340537/48250256-acddb780-e423-11e8-9abc-4bdd94b58bc3.png">


after
<img width="1026" alt="47983088-3b86c780-e0f8-11e8-8510-b817ad59083c" src="https://user-images.githubusercontent.com/3340537/48250241-a18a8c00-e423-11e8-847e-96d9ebbe6dfd.png">


## Before/After with vanila civicrm
Before
<img width="782" alt="shor-45 - without shore ditch" src="https://user-images.githubusercontent.com/3340537/47983058-1eea8f80-e0f8-11e8-89ba-7ae93db98ea1.png">

After
<img width="1640" alt="shor-45 - after - with vanila" src="https://user-images.githubusercontent.com/3340537/47983087-3b86c780-e0f8-11e8-9e23-be0a9f936dd8.png">

## Technical Details
 Checking the issue. I found out that the issue is not related to the changes of the Shoreditch or some other CSS. The reason of this improper CSS is because the HTML is not consistent.

### Reason of the issue

Between Payment Plan Start Date and Time there are some which are non-breaking space which adds some space letters between the form elements making them look a bit far from each other as compared to Number of Instalments and Intervals which don’t have any in between
<img width="1636" alt="shor-45 - issue is not related to shoreditch" src="https://user-images.githubusercontent.com/3340537/48250537-a996fb80-e424-11e8-993f-afcc4862ef6f.png">

Since it is not in Shoreditch. The improper spacing is in vanilla Civicrm as well
<img width="782" alt="shor-45 - without shore ditch" src="https://user-images.githubusercontent.com/3340537/48250560-be738f00-e424-11e8-8c5d-380f91ae2163.png">

### Fix

The fix was to either

find some generic class which adds margin to the left elements, but after searching deep. I couldn’t find any html class in civicrm which suffice the purpose.

The other one was to add simple in between Number of Instalments and Intervals .This is a simple and fast solution . Also with no regressions. So , I went for this solution.

### Other enhancements

While checking the html I found out that the default civicrm uses crm-marker as a class for adding * market for any mandatory field (Checked this in the contact form element)

So, I have changed marker class from the * element to crm-marker.

## Technical Solution
* Changed `marker` class to `crm-marker` for the mandatory field `*` markers span
* Added `&nbsp` for the spacing.