### PR TITLE
BASW-68: Correct installment receive date calculation based on the current cycle day

### DIFF
--- a/CRM/MembershipExtras/Service/CycleDayCalculator.php
+++ b/CRM/MembershipExtras/Service/CycleDayCalculator.php
@@ -26,7 +26,7 @@ class CRM_MembershipExtras_Service_CycleDayCalculator {
         $cycleDay =  $recurContStartDate->format('j');
         break;
       case 'year':
-        $cycleDay =  $recurContStartDate->format('z');
+        $cycleDay =  (int) $recurContStartDate->format('z') + 1;
         break;
       default:
         $cycleDay = 1;


### PR DESCRIPTION
## Problem

If we have a membership set to be autorenewed and connected with a payment plan with start date = 01/01/2017 with 12 installments paid monthly, the last contribution receive date in this case will be 01/12/2017 and the cycle day will be at this case  = 1 which represents the first day of the month, Now suppose at some point the user edited the payment plan cycle day to 15 (which will represent the 15th day of the month), In this case and at the time of the membership renewal, the  newly created payment plan first contribution will receive date will be 01/01/2018 and the last one will be on 01/12/2018, but this is not correct and it should be 15/01/2018 and 15/12/2018 respectively.

In other words, the calculation should not just be based on the previous payment plan start date but also on the current cycle day and same concept should apply whether it was a payment plan paid weekly, monthly or yearly of a payment plan with single installment.


## Solution

I've updated InstallmentReceiveDateCalculator::calculate() method where it will calculate the next set of contributions receive date as before, but then it will use the cycle day to correct the date, in case of day, week, or year it will just compare the difference between the previous cycle day and the currency cycle day and just add or subtract the difference (which represents "days" in this case) to the date. And for month case it correct the date based on the cycle day  but ensure that the date won't exceed its limit so for example : 
If the cycle day = 31 and the month in which the contribution will be made only have 28 days then 28 will be used instead of adding another 3 extra days to the date (which will result in a date in the next month).


I also fixed the cycle day storage for 'Year' frequency unit since PHP consider the first day of  the year = 0 but it make more sense to consider it number 1 and not 0.