### PR TITLE
ASE-297: Fix Creation of Contributions with Line Items with no Tax

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -264,7 +264,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       $newLineItem = CRM_Price_BAO_LineItem::create($lineItemParms);
 
       CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution);
-      if (!empty((float) $contribution->tax_amount)) {
+      if (!empty((float) $newLineItem->tax_amount)) {
         CRM_Financial_BAO_FinancialItem::add($newLineItem, $contribution, TRUE);
       }
     }


### PR DESCRIPTION
## Overview
When a membership is signed up with multiple price fields then for a 12 instalment payment plan, only 2 contributions are created, and a DB error is thrown.

![image](https://user-images.githubusercontent.com/21999940/48207778-644cce00-e33f-11e8-9491-062466c072c2.png)

## Before
When a payment plan was created using a price set, and some of the selected items had tax while others didn't, a financial transaction for the tax was still created for line items without tax, causing the error, as the 'amount' field was not included in the insert query because the value was null for line items without tax. 'Amount' field is defined as NOT NULL in the database.

## After
Fixed by only creating financial item for tax if the line item has a tax amount defined.