### PR TITLE
BASW-122: Only Recalculate Status For Manual Payment Plans

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -63,7 +63,7 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
    * contribution.
    */
   public function preProcess() {
-    if ($this->operation == 'edit') {
+    if ($this->operation == 'edit' && $this->isManualPaymentPlan()) {
       $this->rectifyPaymentPlanStatus();
     }
   }


### PR DESCRIPTION
## Overview
When the full number of instalment contributions are marked as completed, the recurring contribution need to be marked as completed too. The recurring contribution end date should also be set to the cycle day of the last interval. This should only happen for manual payment plans.

## Before
Recalculation of status was being done for any recurring contribution, regardless of if it was a manual payment plan or not.

## After
Recalculation of recurring contribution status is done only for manual payment plans.