### PR TITLE
BASW-122: Fix Recurring Contribution End Date/Status Calculation on Completion

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Implements pre hook on ContributionRecur entity.
+ */
+class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
+
+  /**
+   * Operation being performed.
+   *
+   * @var string
+   */
+  private $operation;
+
+  /**
+   * Current data for the recurring contribution, if it's being updated.
+   *
+   * @var array
+   */
+  private $recurringContribution;
+
+  /**
+   * List of parameters that are being used to create/update the recurring
+   * contribution.
+   *
+   * @var array
+   */
+  private $params;
+
+  /**
+   * CRM_MembershipExtras_Hook_Pre_ContributionRecur constructor.
+   *
+   * @param string $op
+   * @param int $id
+   * @param array $params
+   */
+  public function __construct($op, $id, &$params) {
+    $this->operation = $op;
+    $this->recurringContribution = $this->getRecurringContribution($id);
+    $this->params = &$params;
+  }
+
+  /**
+   * Loads the data for the given recurring contribution ID and returns it.
+   *
+   * @param int $id
+   *
+   * @return array
+   */
+  private function getRecurringContribution($id) {
+    if (empty($id)) {
+      return [];
+    }
+
+    return civicrm_api3('ContributionRecur', 'getsingle', [
+      'sequential' => 1,
+      'id' => $id,
+    ]);
+  }
+
+  /**
+   * Pre-processes the parameters being used to create or update the recurring
+   * contribution.
+   */
+  public function preProcess() {
+    if ($this->operation == 'edit' && $this->isManualPaymentPlan()) {
+      $this->rectifyPaymentPlanStatus();
+    }
+  }
+
+  /**
+   * Calculates recurring contribution status.
+   */
+  private function rectifyPaymentPlanStatus() {
+    $status = $this->calculateRecurringContributionStatus();
+
+    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');
+    $statusID = array_search($status, $contributionStatus);
+    $this->params['contribution_status_id'] = $statusID;
+
+    if ($status === 'Completed' && $this->recurringContribution['installments'] > 1) {
+      $this->params['end_date'] = $this->generateNewPaymentPlanEndDate();
+    }
+  }
+
+  /**
+   * Generates end date for recurring contribution from last paid contribution.
+   *
+   * @return string
+   */
+  private function generateNewPaymentPlanEndDate() {
+    $lastPaymentPlanContribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['receive_date'],
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'options' => ['sort' => 'id DESC', 'limit' => 1],
+    ]);
+
+    $endDate = NULL;
+    if (!empty($lastPaymentPlanContribution['values'][0]['receive_date'])) {
+      $endDate = $lastPaymentPlanContribution['values'][0]['receive_date'];
+    }
+
+    return $endDate;
+  }
+
+  /**
+   * Calculates the status of the current recurring contribution.
+   *
+   * @return string
+   */
+  private function calculateRecurringContributionStatus() {
+    $paidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'contribution_status_id' => 'Completed',
+    ]);
+
+    $partiallyPaidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'contribution_status_id' => 'Partially paid',
+    ]);
+
+    $allPaid = $paidInstallmentsCount >= $this->recurringContribution['installments'];
+    $moreThanOneInstallment = $this->recurringContribution['installments'] > 1;
+
+    switch (true) {
+      case $moreThanOneInstallment && $allPaid:
+        $status = 'Completed';
+        break;
+
+      case $paidInstallmentsCount >= 1 || $partiallyPaidInstallmentsCount >=  1:
+        $status = 'In Progress';
+        break;
+
+      default:
+        $status = 'Pending';
+    }
+
+    return $status;
+  }
+
+  /**
+   * Checks if current recurring contribution corresponds to a manual payment
+   * plan.
+   */
+  private function isManualPaymentPlan() {
+    $payLaterProcessorID = 0;
+    $manualPaymentProcessorsIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
+    $isManualPaymentProcessor = in_array($this->recurringContribution['payment_processor_id'], $manualPaymentProcessorsIDs);
+
+    if ($isManualPaymentProcessor) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -125,7 +125,7 @@ function membershipextras_civicrm_alterSettingsFolders(&$metaDataFolders = NULL)
 }
 
 /**
- * Implements hook_civicrm_pre().
+ * Implements hook_civicrm_navigationMenu().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
  */
@@ -187,6 +187,11 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
     $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
     $paymentPlanProcessor->alterLineItemParameters();
     $firstPaymentPlanContributionId = $params['contribution_id'];
+  }
+
+  if ($objectName == 'ContributionRecur') {
+    $contributionRecurPreHook = new CRM_MembershipExtras_Hook_Pre_ContributionRecur($op, $id, $params);
+    $contributionRecurPreHook->preProcess();
   }
 }
 

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -3,13 +3,15 @@
   var membershipextras_allMembershipData = {$allMembershipInfo};
   var membershipextras_taxRatesStr = '{$taxRates}';
   var membershipextras_taxTerm = '{$taxTerm}';
-  if (membershipextras_taxRatesStr != '') {
-    var membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
-  }
-
   var membershipextras_currency = '{$currency}';
+  var membershipextras_taxRates = [];
 
   {literal}
+
+  if (membershipextras_taxRatesStr != '') {
+    membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
+  }
+
   /**
    * Perform changes on form to add payment plan as an option to pay for
    * membership.


### PR DESCRIPTION
## Overview
When the full number of instalment contributions are marked as completed, the recurring contribution need to be marked as completed too. The recurring contribution end date should also be set to the cycle day of the last interval.

## Before
On completion of payment plan, end date was being set as actual date, instead of receive date of last installment of the payment plan.

## After
The recurring contribution end date is now set to the receive date of the last installment.
