### PR TITLE
Fixing a typo

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -62,7 +62,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
     $customGroups = civicrm_api3('CustomGroup', 'get', [
       'extends' => 'LineItem',
-      'name' => 'recurring_contribution_external_id',
+      'name' => 'line_item_external_id',
     ]);
 
     if (!$customGroups['count']) {


### PR DESCRIPTION
A typo where a different custom group names was used to check for the existence of "line_item_external_id" custom group before creating it which is fixed below.