### PR TITLE
BASW-122: Fix Status Calculation of Plans with 1 Installment

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -102,7 +102,7 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     $payLaterProcessorID = 0;
     $manualPaymentProcessorsIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
 
-    if ($this->recurContribution['installments'] > 1 && in_array($this->recurContribution['payment_processor_id'], $manualPaymentProcessorsIDs)) {
+    if (in_array($this->recurContribution['payment_processor_id'], $manualPaymentProcessorsIDs)) {
       return TRUE;
     }
 
@@ -130,7 +130,8 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
       $newStatus = 'In Progress';
     }
 
-    if ($paidInstallmentsCount >= $this->recurContribution['installments']) {
+    $arePaymentsCompleted = $paidInstallmentsCount >= $this->recurContribution['installments'];
+    if ($arePaymentsCompleted && $this->recurContribution['installments'] > 1) {
       $newStatus = 'Completed';
     }
 


### PR DESCRIPTION
## Overview
If a recurring contribution using offline payment processor has only one installment, when the first instalment is marked as completed/ partially paid (a payment is recorded), then the recurring contribution should be set to 'In Progress'.

http://nimb.ws/qIQgiV

## Before
Calculation of status was only done for recurring contributions with at least 2 installments.

## After
Status is calculated for every manual payment plan, regardless of amount of installments, but the 'Completed' status is only applied to those with at least 2 installments.