### PR TITLE
BASW-122: Release of Fixes to Master Branch

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -102,7 +102,7 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     $payLaterProcessorID = 0;
     $manualPaymentProcessorsIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
 
-    if ($this->recurContribution['installments'] > 1 && in_array($this->recurContribution['payment_processor_id'], $manualPaymentProcessorsIDs)) {
+    if (in_array($this->recurContribution['payment_processor_id'], $manualPaymentProcessorsIDs)) {
       return TRUE;
     }
 
@@ -130,7 +130,8 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
       $newStatus = 'In Progress';
     }
 
-    if ($paidInstallmentsCount >= $this->recurContribution['installments']) {
+    $arePaymentsCompleted = $paidInstallmentsCount >= $this->recurContribution['installments'];
+    if ($arePaymentsCompleted && $this->recurContribution['installments'] > 1) {
       $newStatus = 'Completed';
     }
 

--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -40,18 +40,20 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     }
 
     $newStatus = $this->generatePaymentPlanNewStatus();
-    if ($newStatus !== NULL) {
-      $params = [
-        'id' => $this->recurContribution['id'],
-        'contribution_status_id' => $newStatus,
-      ];
-      
-      if ($newStatus === 'Completed') {
-        $params['end_date'] = date('Y-m-d H:i:s');
-      }
-      
-      civicrm_api3('ContributionRecur', 'create', $params);
+    if ($newStatus == NULL) {
+      return;
     }
+
+    $updateParams = [
+      'id' => $this->recurContribution['id'],
+      'contribution_status_id' => $newStatus,
+    ];
+
+    if ($newStatus == 'Completed') {
+      $updateParams['end_date'] = $this->generateNewPaymentPlanEndDate();
+    }
+
+    civicrm_api3('ContributionRecur', 'create', $updateParams);
   }
 
   /**
@@ -133,6 +135,22 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     }
 
     return $newStatus;
+  }
+
+  private function generateNewPaymentPlanEndDate() {
+    $lastPaymentPlanContribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['receive_date'],
+      'contribution_recur_id' => $this->recurContribution['id'],
+      'options' => ['sort' => 'id DESC', 'limit' => 1],
+    ]);
+
+    $endDate = NULL;
+    if (!empty($lastPaymentPlanContribution['values'][0]['receive_date'])) {
+      $endDate = $lastPaymentPlanContribution['values'][0]['receive_date'];
+    }
+
+    return $endDate;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -6,7 +6,7 @@
 class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
 
   /**
-   * Operation being performe.
+   * Operation being performed.
    *
    * @var string
    */
@@ -63,30 +63,9 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
    * contribution.
    */
   public function preProcess() {
-    if ($this->operation == 'edit' && $this->isPaymentPlanStatusChange()) {
+    if ($this->operation == 'edit' && $this->isManualPaymentPlan()) {
       $this->rectifyPaymentPlanStatus();
     }
-  }
-
-  /**
-   * Checks if the recurring contribution is a payment plan and if its status is
-   * being changed.
-   *
-   * @return bool
-   */
-  private function isPaymentPlanStatusChange() {
-    if (!$this->isManualPaymentPlan()) {
-      return FALSE;
-    }
-
-    $oldStatus = CRM_Utils_Array::value('contribution_status_id', $this->recurringContribution);
-    $newStatus = CRM_Utils_Array::value('contribution_status_id', $this->params);
-
-    if ($newStatus && $newStatus != $oldStatus) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
   /**
@@ -100,8 +79,29 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
     $this->params['contribution_status_id'] = $statusID;
 
     if ($status === 'Completed' && $this->recurringContribution['installments'] > 1) {
-      $this->params['end_date'] = date('Y-m-d H:i:s');
+      $this->params['end_date'] = $this->generateNewPaymentPlanEndDate();
     }
+  }
+
+  /**
+   * Generates end date for recurring contribution from last paid contribution.
+   *
+   * @return string
+   */
+  private function generateNewPaymentPlanEndDate() {
+    $lastPaymentPlanContribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['receive_date'],
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'options' => ['sort' => 'id DESC', 'limit' => 1],
+    ]);
+
+    $endDate = NULL;
+    if (!empty($lastPaymentPlanContribution['values'][0]['receive_date'])) {
+      $endDate = $lastPaymentPlanContribution['values'][0]['receive_date'];
+    }
+
+    return $endDate;
   }
 
   /**

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -125,7 +125,7 @@ function membershipextras_civicrm_alterSettingsFolders(&$metaDataFolders = NULL)
 }
 
 /**
- * Implements hook_civicrm_pre().
+ * Implements hook_civicrm_navigationMenu().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
  */

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -3,13 +3,14 @@
   var membershipextras_allMembershipData = {$allMembershipInfo};
   var membershipextras_taxRatesStr = '{$taxRates}';
   var membershipextras_taxTerm = '{$taxTerm}';
-  if (membershipextras_taxRatesStr != '') {ldelim}
-    var membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
-  {rdelim}
-
   var membershipextras_currency = '{$currency}';
+  var membershipextras_taxRates = [];
 
   {literal}
+  if (membershipextras_taxRatesStr != '') {
+    membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
+  }
+
   /**
    * Perform changes on form to add payment plan as an option to pay for
    * membership.


### PR DESCRIPTION
## Overview
If a recurring contribution using offline payment processor has a fixed number (e.g. 12) of instalments, when the first instalment is marked as completed/ partially paid (a payment is recorded), then the recurring contribution should be set to in progress. When that number of instalment contributions are marked as completed (a full payment is recorded), the recurring contribution need to be marked as completed too. The recurring contribution end date should also be set to the cycle day of the last interval.

This only applies to recurring contributions using offline payment processor (processor with payment manual class). Also, if the number of instalments is equal to or smaller than 1, the recurring contribution should neither be marked as completed nor having the end date set, but should only go from Pending to In Progress when the first payment is completed.

The series of fixes implemented for BASW-122 now need to be sent to master branch to be released to clint installations.

PR's: #109 #108 #105 #106 #107 
