### PR TITLE
BASW-326: Don't allow editing memebership start and end dates from backend

### DIFF
--- a/CRM/MembershipExtras/Hook/AlterContent/MemberTabPage.php
+++ b/CRM/MembershipExtras/Hook/AlterContent/MemberTabPage.php
@@ -5,8 +5,13 @@
  */
 class CRM_MembershipExtras_Hook_AlterContent_MemberTabPage {
 
-  public function __construct(&$content) {
+  private $content;
+
+  private $pageObject;
+
+  public function __construct(&$content, &$pageObject) {
     $this->content = &$content;
+    $this->pageObject = &$pageObject;
   }
 
   /**
@@ -14,6 +19,7 @@ class CRM_MembershipExtras_Hook_AlterContent_MemberTabPage {
    */
   public function alterContent() {
     $this->appendJSCodeToWatchTotalAmountValueChanges();
+    $this->appendJSCodeToHideDateFieldsFromEditForm();
   }
 
   private function appendJSCodeToWatchTotalAmountValueChanges() {
@@ -27,6 +33,21 @@ class CRM_MembershipExtras_Hook_AlterContent_MemberTabPage {
         $this->content
       );
     }
+  }
+
+  private function appendJSCodeToHideDateFieldsFromEditForm() {
+    $isEditAction= $this->pageObject->_action & CRM_Core_Action::UPDATE;
+    if (!$isEditAction) {
+      return;
+    }
+
+    $this->content .=
+      '<script>
+        CRM.$("[id^=start_date_display_]").attr("disabled","disabled");
+        CRM.$(".crm-membership-form-block-start_date a").hide();
+        CRM.$("[id^=end_date_display_]").attr("disabled","disabled");
+        CRM.$(".crm-membership-form-block-end_date a").hide();
+      </script>';
   }
 
 }

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -324,7 +324,7 @@ function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$
  */
 function membershipextras_civicrm_alterContent(&$content, $context, $tplName, &$object) {
   if ($tplName == 'CRM/Member/Page/Tab.tpl') {
-    $memberTabPage  = new CRM_MembershipExtras_Hook_AlterContent_MemberTabPage($content);
+    $memberTabPage  = new CRM_MembershipExtras_Hook_AlterContent_MemberTabPage($content, $object);
     $memberTabPage->alterContent();
   }
 }


### PR DESCRIPTION
## before
the user currently can while editing a membership change either the start or end date, but since we are going to implement membership period functionality, the concept of editing is no longer clear in compare to renewing a membership since start and end date should only be updating via a renewing process or by adjusting the membership active period(s).

![2018-11-22 00_04_51-edit membership _ dmaster14](https://user-images.githubusercontent.com/6275540/48870641-43c64e80-edea-11e8-99ab-6231d36a89dd.png)


## after

The end date and start date are now appear disabled on membership edit form

![2018-11-22 00_04_16-edit membership _ dmaster14](https://user-images.githubusercontent.com/6275540/48870644-47f26c00-edea-11e8-9d69-b9a453a86a4d.png)


