### PR TITLE
BASW-323: Create Period on Membership Sign-up

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -339,7 +339,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   private function updatePaymentPlans() {
     $manualRecurContributions = $this->getManualPaymentPlans();
 
-    foreach ($$manualRecurContributions as $paymentPlan) {
+    foreach ($manualRecurContributions as $paymentPlan) {
       $lastInstalment = $this->getLastInstalmentForPaymentPlan($paymentPlan['id']);
       $lineItems = $this->getLineItemsForContribution($lastInstalment['id']);
 

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -3,13 +3,14 @@
   var membershipextras_allMembershipData = {$allMembershipInfo};
   var membershipextras_taxRatesStr = '{$taxRates}';
   var membershipextras_taxTerm = '{$taxTerm}';
-  if (membershipextras_taxRatesStr != '') {
-    var membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
-  }
-
   var membershipextras_currency = '{$currency}';
+  var membershipextras_taxRates = [];
 
   {literal}
+  if (membershipextras_taxRatesStr != '') {
+    membershipextras_taxRates = JSON.parse(membershipextras_taxRatesStr);
+  }
+
   /**
    * Perform changes on form to add payment plan as an option to pay for
    * membership.
@@ -100,7 +101,7 @@
         var currentMembershipData = membershipextras_allMembershipData[memType];
         var taxRate = membershipextras_taxRates[currentMembershipData['financial_type_id']];
 
-        if (taxRate != undefined) {
+        if (typeof taxRate != undefined) {
           var taxAmount = (currentAmount * (taxRate / 100)) / (1 + (taxRate / 100));
           taxAmount = isNaN (taxAmount) ? 0 : taxAmount.toFixed(2);
           var taxPerPeriod = (taxAmount / parseFloat(CRM.$('#installments').val())).toFixed(2);


### PR DESCRIPTION
## Overview
As a staff member, I want to record the period of each membership so that I can view the complete history of exact dates of signup, renewal and end, and any gaps in the membership where it is cancelled or paused.

- Every time a new membership is signed up, a new membership period should also be created under that membership.
- Period start date and period end date should be the membership start date and end date.
- Payment entity should be recurring contribution if paid via payment plan. Otherwise it should be contribution.

## Before
On membership creation, no period was created.

## After
Implemented a post hook on MembershipPayment entity, so that once all the data for membership and contribution is available, the period is created.