### PR TITLE
BASW-338: Allow users to view membership periods in membership tab

### DIFF
--- a/css/membershipPeriodsNestedView.css
+++ b/css/membershipPeriodsNestedView.css
@@ -1,22 +1,42 @@
 .membership-period-collapse-icon:before {
-  content: '► ';
+  content: '\f054';
+  font-family: 'FontAwesome';
+  font-weight: normal;
+  margin-right: 13px;
+  color: #4d4d69;
   cursor: pointer;
 }
+
+
 
 .membership-period-expand-icon:before {
-  content: '▼ ';
+  content: '\f078';
+  font-family: 'FontAwesome';
+  font-weight: normal;
+  margin-right: 13px;
+  color: #4d4d69;
   cursor: pointer;
 }
 
-.periods-nested-view-no-right-border td {
-  border-right: 0 !important;
+.periods-nested-view-table td {
+  border-right: 1px !important;
   text-align: left;
 }
 
+.periods-nested-view-table th{
+  background:#f3f6f7 !important;
+}
+
 .membership-period-inactive td{
-  color: #FF0000 !important;
+  color: #cf3458 !important;
 }
 
 .membership-period-in-past td{
   color: #c2c2c2 !important;
+}
+
+.periods-table-container {
+  padding-top: 0 !important;
+  border: 1px !important;
+  border-color: #0a0a0a !important;
 }

--- a/css/membershipPeriodsNestedView.css
+++ b/css/membershipPeriodsNestedView.css
@@ -10,12 +10,13 @@
 
 .periods-nested-view-no-right-border td {
   border-right: 0 !important;
+  text-align: left;
 }
 
-.membership-period-inactive {
-  color: #FF0000;
+.membership-period-inactive td{
+  color: #FF0000 !important;
 }
 
-.membership-period-in-past {
-  color: #c2c2c2;
+.membership-period-in-past td{
+  color: #c2c2c2 !important;
 }

--- a/css/membershipPeriodsNestedView.css
+++ b/css/membershipPeriodsNestedView.css
@@ -1,0 +1,21 @@
+.membership-period-collapse-icon:before {
+  content: '► ';
+  cursor: pointer;
+}
+
+.membership-period-expand-icon:before {
+  content: '▼ ';
+  cursor: pointer;
+}
+
+.periods-nested-view-no-right-border td {
+  border-right: 0 !important;
+}
+
+.membership-period-inactive {
+  color: #FF0000;
+}
+
+.membership-period-in-past {
+  color: #c2c2c2;
+}

--- a/js/membershipPeriodsNestedView.js
+++ b/js/membershipPeriodsNestedView.js
@@ -1,0 +1,102 @@
+CRM.$(document).on('init.dt', function (event, settings) {
+  /**
+   * When opening the membership tab, there could be more
+   * that one datatable already initialized by other tabs,
+   * so we here loop through all the visible datatables
+   * to ensure that the nested membership period view is added
+   * to the membership tab datatables since when the user open the
+   * membership tab, the membership datatable will be the only visible
+   * one.
+   *
+   * I used this method because I couldn't find any other way
+   * to obtain reference to the memberships datatable.
+   */
+  CRM.$.each(CRM.$.fn.dataTable.tables(true), function () {
+    var activeMembershipsContainer = CRM.$(this).closest('#memberships').attr('id');
+    if (typeof activeMembershipsContainer != 'undefined') {
+      addMembershipPeriodsNestedView(CRM.$(this), activeMembershipsContainer);
+    }
+
+    var inactiveMembershipsContainer = CRM.$(this).closest('#inactive-memberships').attr('id');
+    if (typeof inactiveMembershipsContainer != 'undefined') {
+      addMembershipPeriodsNestedView(CRM.$(this), inactiveMembershipsContainer);
+    }
+  });
+});
+
+function addMembershipPeriodsNestedView(membershipTableReference, tableContainerId) {
+  initializePeriodsNestedViewExpandIcon(tableContainerId);
+  addMembershipPeriodsViewClickListener(membershipTableReference, tableContainerId);
+}
+
+function initializePeriodsNestedViewExpandIcon(tableContainerId) {
+  CRM.$('#' + tableContainerId + ' table td.crm-membership-membership_type').addClass('membership-period-collapse-icon');
+}
+
+function addMembershipPeriodsViewClickListener(membershipTableReference, tableContainerId) {
+  var membershipDataTable = membershipTableReference.DataTable();
+  CRM.$('#' + tableContainerId + ' table').on('click', 'td.crm-membership-membership_type', function () {
+    handleMembershipRowClick(CRM.$(this), membershipDataTable);
+  });
+}
+
+function handleMembershipRowClick(selectedMembershipRowReference, membershipDataTable) {
+  var selectedMembershipRow = selectedMembershipRowReference.closest('tr');
+  var selectedMembershipDataTableRow = membershipDataTable.row(selectedMembershipRow);
+
+  if (selectedMembershipDataTableRow.child.isShown()) {
+    selectedMembershipDataTableRow.child.hide();
+    CRM.$(selectedMembershipRowReference).removeClass('membership-period-expand-icon');
+    CRM.$(selectedMembershipRowReference).addClass('membership-period-collapse-icon');
+  }
+  else {
+    var selectedMembershipId = (selectedMembershipRow.attr('id')).replace('crm-membership_', '');
+    CRM.api3('MembershipPeriod', 'get', {
+      'sequential': 1,
+      'membership_id': selectedMembershipId,
+      'options': {'sort':'start_date ASC','limit':0}
+    }).done(function(periodsAPIResponse) {
+      selectedMembershipDataTableRow.child(formatMembershipPeriodsTable(periodsAPIResponse)).show();
+      selectedMembershipRowReference.removeClass('membership-period-collapse-icon');
+      selectedMembershipRowReference.addClass('membership-period-expand-icon');
+    });
+  }
+}
+
+function formatMembershipPeriodsTable(periodsAPIResponse) {
+  var periodTableMarkup = '<table class="periods-nested-view-no-right-border">';
+  periodTableMarkup += '<tr><th>Term</th><th>Start Date</th><th>End Date</th><th>Actions</th></tr>';
+
+  for(var i=0; i < periodsAPIResponse.count; i++) {
+    var membershipPeriod = periodsAPIResponse.values[i];
+
+    var rowActions = '<a href="/civicrm/view/membershipPeriod?id=' + membershipPeriod.id +'" class="action-item crm-hover-button" title="View Membership Period">View</a>' +
+      '<a href="/civicrm/edit/membershipPeriod?id=' + membershipPeriod.id +'" class="action-item crm-hover-button" title="Edit Membership Period">Edit</a>';
+
+    periodTableMarkup +=
+      '<tr class="' + getPeriodColorCSSClass(membershipPeriod) + '">'+
+      '<td>Term ' + (i+1) + '</td>'+
+      '<td>'+ CRM.utils.formatDate(membershipPeriod.start_date) +'</td>'+
+      '<td>'+ CRM.utils.formatDate(membershipPeriod.end_date) +'</td>'+
+      '<td>' + rowActions +'</td>'+
+      '</tr>';
+  }
+
+  periodTableMarkup += '</table>';
+
+  return periodTableMarkup;
+}
+
+function getPeriodColorCSSClass(membershipPeriod) {
+  var periodEndDate = CRM.utils.formatDate(membershipPeriod.end_date, 'yymmdd');
+  var currentDate = CRM.utils.formatDate(new Date(), 'yymmdd');
+  if (currentDate > periodEndDate) {
+    return 'membership-period-in-past';
+  }
+
+  if (membershipPeriod.is_active == 0) {
+    return 'membership-period-inactive';
+  }
+
+  return '';
+}

--- a/js/membershipPeriodsNestedView.js
+++ b/js/membershipPeriodsNestedView.js
@@ -57,6 +57,7 @@ function handleMembershipRowClick(selectedMembershipRowReference, membershipData
       'options': {'sort':'start_date ASC','limit':0}
     }).done(function(periodsAPIResponse) {
       selectedMembershipDataTableRow.child(formatMembershipPeriodsTable(periodsAPIResponse)).show();
+      CRM.$(".periods-nested-view-table").closest('td').addClass('periods-table-container');
       selectedMembershipRowReference.removeClass('membership-period-collapse-icon');
       selectedMembershipRowReference.addClass('membership-period-expand-icon');
     });
@@ -64,7 +65,7 @@ function handleMembershipRowClick(selectedMembershipRowReference, membershipData
 }
 
 function formatMembershipPeriodsTable(periodsAPIResponse) {
-  var periodTableMarkup = '<table class="periods-nested-view-no-right-border">';
+  var periodTableMarkup = '<table class="periods-nested-view-table">';
   periodTableMarkup += '<tr><th>Term</th><th>Start Date</th><th>End Date</th><th>Actions</th></tr>';
 
   for(var i=0; i < periodsAPIResponse.count; i++) {

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -359,4 +359,13 @@ function membershipextras_civicrm_pageRun($page) {
       'page-header'
     );
   }
+
+  if (get_class($page) === 'CRM_Member_Page_Tab') {
+    _membershipextras_civicrm_addMembershipPeriodsNestedViewToMembershipTab();
+  }
+}
+
+function _membershipextras_civicrm_addMembershipPeriodsNestedViewToMembershipTab() {
+  Civi::resources()->addStyleFile('uk.co.compucorp.membershipextras', 'css/membershipPeriodsNestedView.css');
+  Civi::resources()->addScriptFile('uk.co.compucorp.membershipextras', 'js/membershipPeriodsNestedView.js');
 }


### PR DESCRIPTION
## User Story

As a staff member, I want to see the period of each membership signup and renewal so that I can know the complete membership history of this contact. 
 Membership periods should be nested under each membership type where active periods are in black color, past periods are in gray color and inactive periods are in red, the periods should also be ordered by start date in Ascending order.

## Before

There is no place to view the current membership periods.

## After

Membership periods can be viewed by expanding the membership type field : 

+ On Legacy screen
![cccaaaa](https://user-images.githubusercontent.com/6275540/49288832-bd6cd500-f499-11e8-9a71-6c3bcff52bbc.gif)

+ On Shoreditch screen
![ddadasads](https://user-images.githubusercontent.com/6275540/49308044-fd01e400-f4ce-11e8-9a79-cd3ab11a291d.gif)


## Technical Notes 

- hook_civicrm_pageRun is used to add js and css files that created the nested view on membership tab.
-  The JS file listen to datatables (since most civicrm tables are created using [datatables plugin](https://datatables.net)) [init event](https://datatables.net/reference/event/init) all loops through all visible tables (which are active and inactive membership tables) and add click listener that shows/hides the membership periods nested view.
- The nested periods view is appended to the table using datatables child() method, more info can be found here  : https://datatables.net/examples/api/row_details.html