### PR TITLE
BASW-338: Allow users to view membership periods in membership tab

### DIFF
--- a/CRM/MembershipExtras/BAO/MembershipPeriod.php
+++ b/CRM/MembershipExtras/BAO/MembershipPeriod.php
@@ -1,5 +1,4 @@
 <?php
-use CRM_MembershipExtras_ExtensionUtil as E;
 
 class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO_MembershipPeriod {
 
@@ -20,6 +19,17 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
     CRM_Utils_Hook::post($hook, 'MembershipPeriod', $instance->id, $instance);
 
     return $instance;
+  }
+
+  public static function getOrderedMembershipPeriods($membershipId) {
+    $membershipPeriod = new self();
+    $membershipPeriod->membership_id = $membershipId;
+    $membershipPeriod->orderBy('start_date ASC');
+    if ($membershipPeriod->find() > 0) {
+      return $membershipPeriod;
+    }
+
+    return NULL;
   }
 
 }

--- a/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.php
@@ -1,0 +1,46 @@
+<?php
+use CRM_MembershipExtras_BAO_MembershipPeriod as MembershipPeriod;
+
+class CRM_MembershipExtras_Page_MembershipPeriod_PeriodsTable extends CRM_Core_Page {
+
+  public function run() {
+    $this->assign('membershipPeriods', $this->getMembershipPeriodsRows());
+
+    parent::run();
+  }
+
+  private function getMembershipPeriodsRows() {
+    $membershipId = CRM_Utils_Request::retrieve('id', 'Positive');
+    $membershipPeriodEntity = MembershipPeriod::getOrderedMembershipPeriods($membershipId);
+
+    $termNumber = 1;
+    $membershipPeriods = [];
+    while ($membershipPeriodEntity->N && $membershipPeriodEntity->fetch()) {
+      $membershipPeriods[] = [
+        'id' => $membershipPeriodEntity->id,
+        'term_number' => $termNumber++,
+        'start_date' => $membershipPeriodEntity->start_date,
+        'end_date' => $membershipPeriodEntity->end_date,
+        'is_active' => $membershipPeriodEntity->is_active,
+        'css_class' => $this->getPeriodCSSClass($membershipPeriodEntity),
+      ];
+    }
+
+    return $membershipPeriods;
+  }
+
+  private function getPeriodCSSClass($membershipPeriodEntity) {
+    $periodEndDate = (new DateTime($membershipPeriodEntity->end_date))->format('Ymd');
+    $currentDate = (new DateTime())->format('Ymd');
+    if ($currentDate > $periodEndDate) {
+      return 'membership-period-in-past';
+    }
+
+    if ($membershipPeriodEntity->is_active == 0) {
+      return 'membership-period-inactive';
+    }
+
+    return '';
+  }
+
+}

--- a/css/membershipPeriodsNestedView.css
+++ b/css/membershipPeriodsNestedView.css
@@ -1,0 +1,39 @@
+.membership-period-collapse-icon:before {
+  font-family: 'FontAwesome';
+  font-style: normal;
+  text-rendering: auto;
+  font-size: 13px;
+  margin-right: 13px;
+  content: '\f054';
+  color: #4d4d69;
+}
+
+.membership-period-collapse-icon.period-extended:before {
+  font-family: 'FontAwesome';
+  font-style: normal;
+  text-rendering: auto;
+  font-size: 13px;
+  margin-right: 13px;
+  content: '\f078';
+  color: #4d4d69;
+}
+
+#memberships .periods-nested-view-table th,#inactive-memberships .periods-nested-view-table th {
+  background:#f3f6f7 !important;
+}
+
+#memberships .periods-nested-view-table td,#inactive-memberships .periods-nested-view-table td {
+  text-align: left;
+}
+
+#memberships .crm-child-row td:first-child,#inactive-memberships .crm-child-row td:first-child{
+  padding-top: 0 !important;
+}
+
+.membership-period-inactive td{
+  color: #cf3458 !important;
+}
+
+.membership-period-in-past td{
+  color: #c2c2c2 !important;
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -359,4 +359,9 @@ function membershipextras_civicrm_pageRun($page) {
       'page-header'
     );
   }
+
+  if (get_class($page) === 'CRM_Member_Page_Tab') {
+    Civi::resources()->addStyleFile('uk.co.compucorp.membershipextras', 'css/membershipPeriodsNestedView.css');
+  }
 }
+

--- a/templates/CRM/Member/Page/Tab.extra.tpl
+++ b/templates/CRM/Member/Page/Tab.extra.tpl
@@ -1,0 +1,47 @@
+{literal}
+<script type="text/javascript">
+  var membershipTablesContainerIds = ['memberships', 'inactive-memberships'];
+  membershipTablesContainerIds.forEach(function (containerId) {
+    addMembershipPeriodsView(containerId);
+  });
+
+  function addMembershipPeriodsView(containerId) {
+    CRM.$('#' + containerId +' table tr').each(function (rowNumber, row) {
+      if (rowNumber == 0) {
+        // Ignoring the first row that contains the table headers
+        return;
+      }
+
+      var rowMembershipId = (CRM.$(this).attr('id')).replace('crm-membership_', '');
+      var label = CRM.$('td.crm-membership-membership_type', this).html();
+      var url = '{/literal}{crmURL p="civicrm/membership/periods"}{literal}' + '?id=' + rowMembershipId;
+      var expandPeriodsHTML = '<a class="nowrap bold period-expand-row membership-period-collapse-icon" href="' + url + '">' + label + '</a>';
+
+      CRM.$('td.crm-membership-membership_type', this).html(expandPeriodsHTML);
+    });
+  }
+
+  /* the code below is copied and slightly altered from CiviCRM core js/crm.expandRow.js
+    It provides the mechanism to view, hide and load the content of the membership periods
+    as a nested table.
+   */
+  CRM.$(function($) {
+    $('body')
+      .off('.periodExpandRow')
+      .on('click.periodExpandRow', 'a.period-expand-row', function(e) {
+        var $row = $(this).closest('tr');
+        if ($(this).hasClass('period-extended')) {
+          $row.next('.crm-child-row').children('td').children('div.crm-ajax-container')
+            .slideUp('fast', function() {$(this).closest('.crm-child-row').remove();});
+        } else {
+          var count = $('td', $row).length,
+            $newRow = $('<tr class="crm-child-row"><td colspan="' + count + '"><div></div></td></tr>')
+              .insertAfter($row);
+          CRM.loadPage(this.href, {target: $('div', $newRow).animate({minHeight: '3em'}, 'fast')});
+        }
+        $(this).toggleClass('period-extended');
+        e.preventDefault();
+      });
+  });
+</script>
+{/literal}

--- a/templates/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.tpl
+++ b/templates/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.tpl
@@ -1,0 +1,19 @@
+<table class="periods-nested-view-table">
+    <tr>
+        <th>Term</th>
+        <th>Start Date</th>
+        <th>End Date</th>
+        <th>Actions</th>
+    </tr>
+    {foreach from=$membershipPeriods item='membershipPeriod'}
+        <tr class="{$membershipPeriod.css_class}">
+            <td>Term {$membershipPeriod.term_number}</td>
+            <td>{$membershipPeriod.start_date|crmDate}</td>
+            <td>{$membershipPeriod.end_date|crmDate}</td>
+            <td>
+                <a href='{crmURL p="civicrm/membership/period/view" q="id=`$membershipPeriod.id`"}' class='action-item crm-hover-button' title='View Membership Period'>View</a>
+                <a href='{crmURL p="civicrm/membership/period/edit" q="id=`$membershipPeriod.id`"}' class='action-item crm-hover-button' title='Edit Membership Period'>Edit</a>
+            </td>
+        </tr>
+    {/foreach}
+</table>

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -36,4 +36,11 @@
     <title>RecurringContribution_AddDonationLineItem</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+
+  <item>
+    <path>civicrm/membership/periods</path>
+    <page_callback>CRM_MembershipExtras_Page_MembershipPeriod_PeriodsTable</page_callback>
+    <title>Membership Periods</title>
+    <access_arguments>access CiviMember</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Note

This PR is to replace https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/114 by following an approach that is more closer to how civicrm core handles nested rows.

## User Story

As a staff member, I want to see the period of each membership signup and renewal so that I can know the complete membership history of this contact. 
 Membership periods should be nested under each membership type where active periods are in black color, past periods are in gray color and inactive periods are in red, the periods should also be ordered by start date in Ascending order.

## Before

There is no place to view the current membership periods.

## After

Membership periods can be viewed by expanding the membership type field : 

+ On Legacy screen
![with-shorr](https://user-images.githubusercontent.com/6275540/49440147-cd96f400-f7ba-11e8-978e-81260ef07061.gif)

+ On Shoreditch screen
![with-shorrrr](https://user-images.githubusercontent.com/6275540/49440165-d8518900-f7ba-11e8-96f3-7265a904a452.gif)


## Technical Notes 

- A new getOrderedMembershipPeriods() method is added to MembershipPeriod BAO which accepts a membership ID and return the a DAO object that contains all the membership periods ordered by start date.

- A new page is added (CRM_MembershipExtras_Page_MembershipPeriod_PeriodsTable ) that show the list of  membership periods in a table given the membership id as a GET parameter.

- a new template at **templates/CRM/Member/Page/Tab.extra.tpl** is added, the template basicly extends the core CRM/Members/Page/Tab.tpl which is responsible for rendering the membership tab page, but hence that this new template does not override the core one since I use the .extra.tpl which basicly appened the content of the template to the core one as explained here : https://docs.civicrm.org/dev/en/latest/framework/templates/#appending-jquery-or-other-code-to-a-template

- The new extra template add JQuery code that adds the nested periods view to the membership tab, the lines here https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/72a4b27b07f1327343882317870af907462a07b0/templates/CRM/Member/Page/Tab.extra.tpl#L28-L47
is copied from js/crm.expandRow.js which is the civicrm core way to handle such nested views, it basically load the (CRM_MembershipExtras_Page_MembershipPeriod_PeriodsTable ) page and appends it to the memberships table as a nested row instead.

- membershipextras_civicrm_pageRun hooks is used to add a CSS file that styles the membership periods nested view.