### PR TITLE
BASW-321: Different Membership Types of a Contact Should Appear as Different Membership Lines

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipCreate.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipCreate.php
@@ -78,8 +78,40 @@ class CRM_MembershipExtras_Hook_Pre_MembershipCreate {
     }
   }
 
+  /**
+   * Checks if a membership of the same type already exists for the contact and
+   * if it does, retrieves the ID so that the membership gets updated instead.
+   */
   private function updateOrCreateMembership() {
-    
+    $contactID = $this->params['contact_id'];
+    $membershipTypeID = $this->params['membership_type_id'];
+
+    $membershipID = $this->getLastMembershipID([
+      'contact_id' => $contactID,
+      'membership_type_id' => $membershipTypeID,
+    ]);
+
+    if ($membershipID) {
+      $this->params['id'] = $membershipID;
+    }
+  }
+
+  /**
+   * Returns the last membership based on the conditions passed
+   * 
+   * @param mixed[] $conditions
+   */
+  private function getLastMembershipID($conditions) {
+    $result = civicrm_api3('Membership', 'get', array_merge($conditions, [
+      'sequential' => 1,
+    ]));
+
+    if (!empty($result['values'])) {
+      $largestIndex = count($result['values']) - 1;
+      return $result['values'][$largestIndex]['id'];
+    }
+
+    return FALSE;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipCreate.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipCreate.php
@@ -24,6 +24,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipCreate {
   public function preProcess() {
     $this->recalculateTaxAmount();
     $this->recalculateLineItemsAmounts();
+    $this->updateOrCreateMembership();
   }
 
   /**
@@ -75,6 +76,10 @@ class CRM_MembershipExtras_Hook_Pre_MembershipCreate {
         );
       }
     }
+  }
+
+  private function updateOrCreateMembership() {
+    
   }
 
 }


### PR DESCRIPTION
## Overview
When a membership is added to a contact, if the contact does not hold any membership of the same type, a new membership should be created. Otherwise the membership with the same type should be extended/updated.

## Before
Action did not exists

## After
Creating a new membership for a contact will now create update existing membership (last added membership) of the same membership type or create a new membership.
![basw-219-after](https://raw.githubusercontent.com/katorjames-compucorp/screenshots/master/DiffMembersipTypes.gif)