### PR TITLE
BASW-261: Fix Amounts on Multiple Installment Plan Renewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -275,8 +275,8 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
 
     if ($result['count'] > 0) {
       foreach ($result['values'] as $lineItemData) {
-        $totalAmount += $lineItemData['api.LineItem.getsingle']['line_total'];
-        $totalAmount += $lineItemData['api.LineItem.getsingle']['tax_amount'];
+        $totalAmount += floatval($lineItemData['api.LineItem.getsingle']['line_total']);
+        $totalAmount += floatval($lineItemData['api.LineItem.getsingle']['tax_amount']);
       }
     }
 

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -448,8 +448,8 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   private function calculateSingleInstallmentAmount($amount) {
     $resultAmount =  $amount;
 
-    if ($this->newRecurringContribution['installments'] > 1) {
-      $resultAmount = MoneyUtilities::roundToCurrencyPrecision(($amount / $this->newRecurringContribution['installments']));
+    if ($this->currentRecurringContribution['installments'] > 1) {
+      $resultAmount = MoneyUtilities::roundToCurrencyPrecision(($amount / $this->currentRecurringContribution['installments']));
     }
 
     return $resultAmount;

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -148,11 +148,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('financialTypes', $this->financialTypes);
     $this->assign('currencySymbol', $this->getCurrencySymbol());
-    $this->assign('nextPeriodLineItems', $this->getLineItems([
-      'auto_renew' => TRUE,
-      'end_date' => ['IS NULL' => 1],
-      'is_removed' => 0,
-    ]));
+    $this->assign('nextPeriodLineItems', $this->getNextPeriodLineItems());
 
     parent::run();
   }
@@ -166,16 +162,31 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $conditions = [
       'is_removed' => 0,
       'start_date' => ['IS NOT NULL' => 1],
-      'end_date' => ['IS NULL' => 1],
     ];
 
-    if (!$this->contribRecur['installments']) {
+    if (!$this->contribRecur['installments'] || $this->contribRecur['installments'] <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }
 
-    $currentPeriodLineItems = $this->getLineItems($conditions);
+    return $this->getLineItems($conditions);
+  }
 
-    return $currentPeriodLineItems;
+  /**
+   * Obtains list of line items for the next period.
+   *
+   * @return array
+   */
+  private function getNextPeriodLineItems() {
+    $conditions = [
+      'auto_renew' => TRUE,
+      'is_removed' => 0,
+    ];
+
+    if (!$this->contribRecur['installments'] || $this->contribRecur['installments'] <= 1) {
+      $conditions['end_date'] = ['IS NULL' => 1];
+    }
+
+    return $this->getLineItems($conditions);
   }
 
   /**


### PR DESCRIPTION
## Overview
After Auto-Renew job was run, recurring contribution amount was being set as '0.00' in the new recurring contribution entry. On other occasions, the amount was being calculated as the full amount for the membership, instead of the mount per installment.

## Before
Line item amount for the new recurring contribution was being calculated as the full amount for the membership. The calculation for the amount per installment was failing as it required access to the number of installments of the new recurring contribution, but the value was not still set, thus returning the full amount.

Also found a problem displaying the line items of completed recurring contributions with more than one installment, as line items with end date were being filtered out.

## After
Implemented use of number of installments from the current recurring contribution, which is always known.

Also handled by recurring line item list by only filtering out line items with an end date if it is a payment
plan with 1 or less installments.

Also added a cast of calculated amounts to float, to avoid adding in null values.