### PR TITLE
BASW-212:  Several Fixes

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+
 /**
  * Alters UpdateSubscription form.
  */
@@ -48,7 +50,8 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
    * Implements modifications to UpdateSubscription form.
    */
   public function buildForm() {
-    if (!$this->isManualPaymentPlan()) {
+    $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($this->recurringContribution['payment_processor_id']);
+    if (!$isManualPaymentPlan) {
       return;
     }
 
@@ -89,21 +92,6 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
         'name' => ts('Cancel'),
       ],
     ]);
-  }
-
-  /**
-   * Checks if recurring contribution is using manual payment processor.
-   */
-  private function isManualPaymentPlan() {
-    $paymentProcessorID = $this->recurringContribution['payment_processor_id'];
-    $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
-    $isOfflineContribution = in_array($paymentProcessorID, $manualPaymentProcessors);
-
-    if ($isOfflineContribution || empty($paymentProcessorID)) {
-      return true;
-    }
-
-    return false;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+
 /**
  * Alters action links for recurring contributions.
  */
@@ -76,16 +78,9 @@ class CRM_MembershipExtras_Hook_Links_RecurringContribution {
     $recurringContribution = civicrm_api3('ContributionRecur', 'getsingle', [
       'id' => $this->recurringContributionID
     ]);
-
     $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $recurringContribution);
-    $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
-    $isOfflineContribution = in_array($paymentProcessorID, $manualPaymentProcessors);
 
-    if ($isOfflineContribution || empty($paymentProcessorID)) {
-      return TRUE;
-    }
-
-    return FALSE;
+    return ManualPaymentProcessors::isManualPaymentProcessor($paymentProcessorID);
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+
 class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
 
   /**
@@ -34,8 +36,9 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
       return;
     }
 
+    $isManualPaymentPlanTransaction = ManualPaymentProcessors::isManualPaymentProcessor($this->recurContribution['payment_processor_id']);
     $this->setRecurContribution();
-    if (empty($this->recurContribution) || !$this->isManualPaymentPlanTransaction()) {
+    if (empty($this->recurContribution) || !$isManualPaymentPlanTransaction) {
       return;
     }
 
@@ -129,23 +132,6 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     }
 
     $this->recurContribution =  $recurContribution['values'][0];
-  }
-
-  /**
-   * Determines if the transaction is a payment
-   * plan transaction.
-   *
-   * @return bool
-   */
-  private function isManualPaymentPlanTransaction() {
-    $payLaterProcessorID = 0;
-    $manualPaymentProcessorsIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
-
-    if (in_array($this->recurContribution['payment_processor_id'], $manualPaymentProcessorsIDs)) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/Post/LineItem.php
+++ b/CRM/MembershipExtras/Hook/Post/LineItem.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+
 /**
  * Post-processes Line items.
  */
@@ -61,7 +63,8 @@ class CRM_MembershipExtras_Hook_Post_LineItem {
     $processorID = CRM_Utils_Array::value('contribution_id.contribution_recur_id.payment_processor_id', $paymentData, 0);
     $previousPeriod = CRM_Utils_Array::value('contribution_id.contribution_recur_id.previous_period', $paymentData, 0);
 
-    if (!empty($recurringContributionID) && $this->isManualPaymentPlan($processorID) && $previousPeriod == 0) {
+    $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($processorID);
+    if (!empty($recurringContributionID) && $isManualPaymentPlan && $previousPeriod == 0) {
       $contributionCount = civicrm_api3('Contribution', 'getcount', [
         'contribution_recur_id' => $recurringContributionID,
       ]);
@@ -72,24 +75,6 @@ class CRM_MembershipExtras_Hook_Post_LineItem {
     }
 
     return false;
-  }
-
-  /**
-   * Determines if the recurring contribution is offline (pay later) and is for
-   * a payment plan.
-   *
-   * @param int $processorID
-   *
-   * @return bool
-   */
-  private function isManualPaymentPlan($processorID) {
-    $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
-
-    if (empty($processorID) || in_array($processorID, $manualPaymentProcessors)) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator as RecurringContributionLineItemCreator;
+
 class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor{
 
   /**
@@ -43,6 +45,9 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor{
     else {
       $recurContributionID = $this->createAutoRenewRecurContribution();
       $this->updateContributionRecurringContribution($recurContributionID);
+
+      $lineItemCreator = new RecurringContributionLineItemCreator($recurContributionID);
+      $lineItemCreator->create();
     }
 
     $this->setMembershipToAutoRenew($recurContributionID);

--- a/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
@@ -1,0 +1,102 @@
+<?php
+
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+
+class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator {
+
+  private $recurContributionID;
+
+  private $recurContribution;
+
+  private $previousPeriodFieldID;
+
+  public function __construct($recurContributionID){
+    $this->recurContributionID = $recurContributionID;
+    $this->setRecurContribution();
+    $this->previousPeriodFieldID = $this->getCustomFieldID('related_payment_plan_periods', 'previous_period');
+  }
+
+  private function setRecurContribution() {
+    $recurContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'return' => ['start_date', 'payment_processor_id', 'custom_' . $this->previousPeriodFieldID],
+      'id' => $this->recurContributionID,
+    ]);
+    if ($recurContribution['count'] < 1) {
+      $this->recurContribution =  NULL;
+      return;
+    }
+
+    $this->recurContribution =  $recurContribution['values'][0];
+  }
+
+  public function create() {
+    $processorID = CRM_Utils_Array::value('payment_processor_id', $this->recurContribution);
+    $hasPreviousPeriod = CRM_Utils_Array::value('custom_' . $this->previousPeriodFieldID, $this->recurContribution, FALSE);
+    if ($hasPreviousPeriod || !ManualPaymentProcessors::isManualPaymentProcessor($processorID)) {
+      return;
+    }
+
+    $lastContributionLineItems = $this->getLastContributionLineItems();
+    if (empty($lastContributionLineItems)) {
+      return;
+    }
+
+    foreach ($lastContributionLineItems as $lineItemParams) {
+      $this->createRecurLineItem($lineItemParams);
+    }
+  }
+
+  private function getLastContributionLineItems() {
+    try {
+      $lastContributionId = civicrm_api3('Contribution', 'getvalue', [
+        'return' => 'id',
+        'contribution_recur_id' => $this->recurContributionID,
+        'options' => ['limit' => 1, 'sort' => 'id DESC'],
+      ]);
+    } catch (CiviCRM_API3_Exception $exception) {
+      return NULL;
+    }
+
+    $lastContributionLineItems = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'return' => ['entity_table', 'entity_id', 'price_field_id',
+        'label', 'qty', 'unit_price', 'line_total', 'participant_count', 'id',
+        'price_field_value_id', 'financial_type_id', 'non_deductible_amount', 'tax_amount'],
+      'contribution_id' => $lastContributionId,
+      'options' => ['limit' => 0],
+    ]);
+    if ($lastContributionLineItems['count'] < 1) {
+      return NULL;
+    }
+
+    return $lastContributionLineItems['values'];
+  }
+
+  private function createRecurLineItem($lineItemParams) {
+    unset($lineItemParams['id']);
+    $lineItemCopy = civicrm_api3('LineItem', 'create', $lineItemParams);
+
+    CRM_MembershipExtras_BAO_ContributionRecurLineItem::create([
+      'contribution_recur_id' => $this->recurContributionID,
+      'line_item_id' => $lineItemCopy['id'],
+      'start_date' => $this->recurContribution['start_date'],
+      'auto_renew' => TRUE,
+    ]);
+  }
+
+  private function getCustomFieldID($fieldGroup, $fieldName) {
+    $result = civicrm_api3('CustomField', 'get', [
+      'sequential' => 1,
+      'custom_group_id' => $fieldGroup,
+      'name' => $fieldName,
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'][0]['id'];
+    }
+
+    return 0;
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+
 /**
  * Implements pre hook on ContributionRecur entity.
  */
@@ -63,7 +65,8 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
    * contribution.
    */
   public function preProcess() {
-    if ($this->operation == 'edit' && $this->isManualPaymentPlan()) {
+    $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($this->recurringContribution['payment_processor_id']);
+    if ($this->operation == 'edit' && $isManualPaymentPlan) {
       $this->rectifyPaymentPlanStatus();
     }
   }
@@ -137,22 +140,6 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
     }
 
     return $status;
-  }
-
-  /**
-   * Checks if current recurring contribution corresponds to a manual payment
-   * plan.
-   */
-  private function isManualPaymentPlan() {
-    $payLaterProcessorID = 0;
-    $manualPaymentProcessorsIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
-    $isManualPaymentProcessor = in_array($this->recurringContribution['payment_processor_id'], $manualPaymentProcessorsIDs);
-
-    if ($isManualPaymentProcessor) {
-      return TRUE;
-    }
-
-    return FALSE;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_MembershipExtras_Service_MembershipEndDateCalculator as MembershipEndDateCalculator;
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
 
 /**
  * Implements hook to be run before a membership is created/edited.
@@ -99,11 +100,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
     ])['values'][0];
 
     $isPaymentPlanRecurringContribution = !empty($recurringContribution['installments']);
-
-    $manualPaymentProcessors = CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs();
-    $isOfflineContribution = empty($recurringContribution['payment_processor_id']) ||
-      in_array($recurringContribution['payment_processor_id'], $manualPaymentProcessors);
-
+    $isOfflineContribution = ManualPaymentProcessors::isManualPaymentProcessor($recurringContribution['payment_processor_id']);
     if ($isOfflineContribution && $isPaymentPlanRecurringContribution) {
       return TRUE;
     }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -189,7 +189,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   /**
    * Loads list of manual payment processors into an array as a class attribute.
    */
-  private function setManualPaymentProcessorIDs() {
+    private function setManualPaymentProcessorIDs() {
     $payLaterProcessorID = 0;
     $this->manualPaymentProcessorIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
   }

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -131,7 +131,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @inheritdoc
    */
   public function run() {
-    CRM_Utils_System::setTitle(E::ts('Manage Instalment'));
+    CRM_Utils_System::setTitle(E::ts('Manage Installments'));
 
     $this->assign('currentDate', date('Y-m-d'));
     $this->assign('recurringContribution', $this->contribRecur);

--- a/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
+++ b/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
@@ -3,6 +3,25 @@
 class CRM_MembershipExtras_Service_ManualPaymentProcessors {
 
   /**
+   * Checks if the payment processor is a
+   * Manual payment processor. (a Processor that
+   * Implements Payment_Manual class)
+   *
+   * @param $processorID
+   *
+   * @return bool
+   */
+  public static function isManualPaymentProcessor($processorID) {
+    $manualPaymentProcessors = self::getIDs();
+
+    if (empty($processorID) || in_array($processorID, $manualPaymentProcessors)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
    * Gets the list of Payment Processors
    * that use 'Payment_Manual' class.
    *

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.tpl
@@ -19,7 +19,7 @@
 </div>
 
 <p>
-  {ts}Please note the new line will be added to all pending instalments starting from {$newLineItem.start_date|date_format} immediately after clicking "Apply".{/ts}
+  {ts}Please note the new line will be added to all pending instalments starting from {$newLineItem.start_date|crmDate} immediately after clicking "Apply".{/ts}
 </p>
 <div class="crm-section">
   <div>

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -13,9 +13,9 @@
 <div id="confirmLineItemDeletion" style="display: none;"></div>
 
 <div class="right">
-  Period Start Date: {$periodStartDate|date_format}
+  Period Start Date: {$periodStartDate|date_format:"%Y-%m-%d"|crmDate}
   &nbsp;&nbsp;&nbsp;
-  Period End Date: {$periodEndDate|date_format}
+  Period End Date: {$periodEndDate|crmDate}
 </div>
 <form>
   <input name="recurringContributionID" id="recurringContributionID" value="{$recurringContributionID}" type="hidden" />
@@ -43,8 +43,8 @@
 
       <tr id="lineitem-{$currentItem.id}" data-item-data='{$currentItem|@json_encode}' class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
         <td>{$currentItem.label}</td>
-        <td>{$currentItem.start_date|date_format}</td>
-        <td>{$largestMembershipEndDate|date_format}</td>
+        <td>{$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}</td>
+        <td>{$largestMembershipEndDate|crmDate}</td>
         {if $recurringContribution.auto_renew}
           <td>
               <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -5,7 +5,7 @@ var membershipTypes = JSON.parse('{$membershipTypes|@json_encode}');
 var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
 </script>
 <div class="right">
-  Period Start Date: {$nextPeriodStartDate|date_format}
+  Period Start Date: {$nextPeriodStartDate|date_format:"%Y-%m-%d"|crmDate}
 </div>
 <table class="selector row-highlight" id="nextPeriodLineItems">
   <tbody>


### PR DESCRIPTION
Issues fixed in this PR : 

1- Fixing a typo in "Manage Installments' modal header title, it was written as "Manage Instalment".

2- Changing the date format to comply with CiviCRM output date settings, it was previously use smarty **date_format** but I changed it to use **crmDate** modifier which is automatically output the date based on civicrm output settings. For the start date and since the start date also contains time, I had to use **date_format** first to remove the time part before passing it to **crmDate** .

3- If the admin created an autorenwal membership using the "contribution" option : 

![2019-01-14 12_43_28-test50 test50 _ ppphase4](https://user-images.githubusercontent.com/6275540/51108203-44c39d00-17e9-11e9-9d2a-4d9f02bb5c52.png)

then no **membershipextras_subscription_line** records will be created, that's because  we use the **postProcess** hook on the membership forms to create the auto-renwal recurring contribution as well as attaching it to the created contribution  : 
https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/master/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php#L44-L45

but the hook that creates the **membershipextras_subscription_line** records is the  **lineItem** entity **post** hook which runs before the previous hook and require the exsitance of a recurring contribution but because the recurring contribution is not yet created, it won't be able to create its line items. 

I fixed this by creating a new class that accept a recurring contribution ID, then it will get the last contribution of that recurring contribution, then it will get all the line items of the last contribution, and based on these line items, it will create the **membershipextras_subscription_line** records for the recurring contribution. Then I called this class directly after the creation of the recurring contribution inside the **postProcess** hook.


## Other Notes 

There were a repeated logic to check if the payment processor is a manual payment processor or not all over the extension, I moved it to a new public method here https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/39a304dab98e5fdbca8a6dc2d5161b7a12f05611/CRM/MembershipExtras/Service/ManualPaymentProcessors.php#L14-L22

and updated the other classes to use it instead.
