### PR TITLE
BASW-212: remove the 'time' part from the period end data view

### DIFF
--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -15,7 +15,7 @@
 <div class="right">
   Period Start Date: {$periodStartDate|date_format:"%Y-%m-%d"|crmDate}
   &nbsp;&nbsp;&nbsp;
-  Period End Date: {$periodEndDate|crmDate}
+  Period End Date: {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
 </div>
 <form>
   <input name="recurringContributionID" id="recurringContributionID" value="{$recurringContributionID}" type="hidden" />


### PR DESCRIPTION
The  period end date in "current period" tab still show the time part of the date 

![image](https://user-images.githubusercontent.com/6275540/51252583-19c97c80-1994-11e9-8c6e-7c6c8ae86a45.png)

I changed the template to show only the date part.