### PR TITLE
BASW-222: Fix Duplicate Memberships on Next Period

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -164,7 +164,9 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       'start_date' => ['IS NOT NULL' => 1],
     ];
 
-    if (!$this->contribRecur['installments'] || $this->contribRecur['installments'] <= 1) {
+    $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 0);
+
+    if ($installments <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }
 
@@ -182,7 +184,9 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       'is_removed' => 0,
     ];
 
-    if (!$this->contribRecur['installments'] || $this->contribRecur['installments'] <= 1) {
+    $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 0);
+
+    if ($installments <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }
 

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -165,7 +165,6 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     ];
 
     $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 0);
-
     if ($installments <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }
@@ -185,7 +184,6 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     ];
 
     $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 0);
-
     if ($installments <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }

--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -61,7 +61,8 @@ CRM.$(function () {
     if (selectedId) {
       var membershipType = getMembershipType(selectedId);
       var financialType = getFinancialType(membershipType.financial_type_id);
-      var defaultAmount = Number(membershipType.minimum_fee) / Number(recurringContribution.installments);
+      var installments = getNumberOfInstallments(recurringContribution);
+      var defaultAmount = Number(membershipType.minimum_fee) / Number(installments);
 
       if (!financialType) {
         throw new Error(ts('Invalid financial type id passed'));
@@ -116,6 +117,24 @@ CRM.$(function () {
     CRM.$('#periodsContainer').closest('.ui-dialog-content').data('selectedTab', 'next');
   });
 });
+
+/**
+ * Returns number of installments in given recurring contribution, or 1 if no
+ * installments.
+ *
+ * @param recurringContribution
+ *
+ * @return {number}
+ */
+function getNumberOfInstallments(recurringContribution) {
+  var numberOfInstallments = 1;
+
+  if (typeof recurringContribution.installments !== 'undefined') {
+    numberOfInstallments = parseInt(recurringContribution.installments);
+  }
+
+  return numberOfInstallments > 0 ? numberOfInstallments : 1;
+}
 
 /**
  * Validates the data being used to create a neww membership.
@@ -284,13 +303,13 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
           'id': lineItemData.entity_id,
           'contribution_recur_id': '',
         }).done(function (membershipUnlinkRes) {
-          
+
           if (membershipUnlinkRes.is_error) {
             CRM.alert(ts('Cannot unlink the associated membership'), null, 'alert');
 
             return;
           }
-          
+
           CRM.alert(
             ts(lineItemData.label + ' should no longer be continued in the next period.'),
             null,


### PR DESCRIPTION
## Overview
When clicking the auto-renew checkbox on a line item in current period that is unset, so that it gets added to next period, a notice with warning sign should appear with text "This membership type is already enrolled in next period." when there is another membershipextras_subscription_line in next period with the same membership type.

## Before
A membership type could be added to next period, and then, added to current period without auto-renew. If auto-renew is then set, it resulted line item to be duplicated in next period, as when the auto-renew check-box was set, the line item was added as a donation on next period, instead of a membership. So each time auto-renew check-box was se on, a new line item was added to next period.

## After
Fixed by implementing validation of membership type, so if a line item for that membership type already exists on next period, a waning message is shown and no action is taken. Also, if validation passes ok, current line item is just set to be auto-renewed and recurring contribution - membership relationship is restored.

Also fixed a problem where amount for new membership line items was being calculated by dividing full
price by number of installments, resulting in the NaN amount when dividing by null or 0. Fixed by setting number of installments as 1 if unset or 0.
