### PR TITLE
BASW-256: Fix Line Item End Date Calculation on Payments Completion

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
@@ -1,4 +1,5 @@
 <?php
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
 
 /**
  * Implements post-process hooks on ContributionRecur entity.
@@ -25,7 +26,10 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
    * Post processes recurring contribution entity.
    */
   public function postProcess() {
-    $this->updateLineItemEndDates();
+    $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($this->contributionRecurBAO->payment_processor_id);
+    if ($isManualPaymentPlan) {
+      $this->updateLineItemEndDates();
+    }
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Implements post-process hooks on ContributionRecur entity.
+ */
+class CRM_MembershipExtras_Hook_Post_ContributionRecur {
+
+  /**
+   * Reference to the recurring contribution's BAO that was stored.
+   *
+   * @var \CRM_Contribute_BAO_ContributionRecur
+   */
+  private $contributionRecurBAO;
+
+  /**
+   * CRM_MembershipExtras_Hook_Post_ContributionRecur constructor.
+   *
+   * @param \CRM_Contribute_BAO_ContributionRecur $contributionBAO
+   */
+  public function __construct(CRM_Contribute_BAO_ContributionRecur $contributionBAO) {
+    $this->contributionRecurBAO = $contributionBAO;
+  }
+
+  /**
+   * Post processes recurring contribution entity.
+   */
+  public function postProcess() {
+    $this->updateLineItemEndDates();
+  }
+
+  /**
+   * Updates end dates for line items associated to the recurring contribution.
+   */
+  private function updateLineItemEndDates() {
+    $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus($this->contributionRecurBAO->contribution_status_id, 'name');
+
+    if ($contributionStatus === 'Completed' && $this->contributionRecurBAO->installments > 1) {
+      $subscriptionLines = $this->getSubscriptionLines();
+
+      foreach($subscriptionLines as $line) {
+        if (!empty($line['start_date']) && empty($line['end_date'])) {
+          civicrm_api3('ContributionRecurLineItem', 'create', [
+            'id' => $line['id'],
+            'end_date' => $this->contributionRecurBAO->end_date,
+          ]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns LineItems associated to a recurring contribution
+   *
+   * @return array
+   */
+  private function getSubscriptionLines() {
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->contributionRecurBAO['id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count']) {
+      return $result['values'];
+    }
+
+    return [];
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
@@ -19,7 +19,7 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
    * @param \CRM_Contribute_BAO_ContributionRecur $contributionBAO
    */
   public function __construct(CRM_Contribute_BAO_ContributionRecur $contributionBAO) {
-    $this->contributionRecurBAO = $contributionBAO;
+    $this->contributionRecurBAO = CRM_Contribute_BAO_ContributionRecur::findById($contributionBAO->id);
   }
 
   /**
@@ -60,7 +60,7 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
   private function getSubscriptionLines() {
     $result = civicrm_api3('ContributionRecurLineItem', 'get', [
       'sequential' => 1,
-      'contribution_recur_id' => $this->contributionRecurBAO['id'],
+      'contribution_recur_id' => $this->contributionRecurBAO->id,
       'options' => ['limit' => 0],
     ]);
 

--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -54,48 +54,9 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
 
     if ($newStatus == 'Completed') {
       $updateParams['end_date'] = $this->generateNewPaymentPlanEndDate();
-      $this->updateSubscriptionLinesEndDate($updateParams['end_date']);
     }
 
     civicrm_api3('ContributionRecur', 'create', $updateParams);
-  }
-
-  /**
-   * Updates subscription line items end date.
-   *
-   * @param string $date
-   */
-  private function updateSubscriptionLinesEndDate($date) {
-    $subscriptionLines = $this->getSubscriptionLines();
-
-    foreach($subscriptionLines as $line) {
-      if (!empty($line['start_date']) && empty($line['end_date'])) {
-        civicrm_api3('ContributionRecurLineItem', 'create', [
-          'id' => $line['id'],
-          'end_date' => $date,
-        ]);
-      }
-    }
-  }
-
-  /**
-   * Returns LineItems associated to a recurring contribution
-   * 
-   * @return array
-   */
-  private function getSubscriptionLines() {
-    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
-      'sequential' => 1,
-      'contribution_recur_id' => $this->recurContribution['id'],
-      'options' => ['limit' => 0],
-    ]);
-
-    $subscriptionLines = [];
-    if ($result['count']) {
-      $subscriptionLines = $result['values'];
-    }
-    
-    return $subscriptionLines;
   }
 
   /**

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -222,6 +222,11 @@ function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef)
     $entityFinancialTrxnHook->updatePaymentPlanStatus();
   }
 
+  if ($objectName === 'ContributionRecur') {
+    $contributionRecurPostHook = new CRM_MembershipExtras_Hook_Post_ContributionRecur($objectRef);
+    $contributionRecurPostHook->postProcess();
+  }
+
   if ($objectName == 'LineItem') {
     $lineItemPostHook = new CRM_MembershipExtras_Hook_Post_LineItem($op, $objectId, $objectRef);
     $lineItemPostHook->postProcess();


### PR DESCRIPTION
## Overview
A problem was found when renewing a payment plan, as the end dates for the recurring line items where not set. Currently, these end dates are set by a post hook on the Financial Transaction entity. For some reason, under certain circumstances, this hook is not dispatched, as the flow to update info in CiviCRM core is different.

## Before
Editing a contribution and changing its status to completed takes a different path to recording a payment in CiviCRM. This caused that when the Financial Transaction Hook was called, the conditions for it to run were not being met, in order to calculate the recurring contribution's end date and status, as also the end date for the recurring line items.

## After
Fixed by moving setting of line item end date to ContributionRecur post hook.