### PR TITLE
BASW-222: Validate Membership Types When Adding Line Item

### DIFF
--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -76,16 +76,16 @@ var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
       </select>
     </td>
     <td id="newMembershipFinancialType">{ts}select a membership type{/ts}</td>
-    <td id="newMembershipFinTypeTaxRate">N/A</td>
+    <td id="newMembershipFinTypeTaxRate">-</td>
     <td>
       {$currencySymbol}&nbsp; <input type="text" class="four crm-form-text" size="4" id="newMembershipAmount" />
     </td>
     <td nowrap class="confirmation-icons">
-      <a href="#" class="cancel-add-next-period-membership-button">
-        <span><i class="crm-i fa-times"></i></span>
-      </a>
       <a href="#" class="confirm-add-next-period-membership-button">
         <span><i class="crm-i fa-check"></i></span>
+      </a>
+      <a href="#" class="cancel-add-next-period-membership-button">
+        <span><i class="crm-i fa-times"></i></span>
       </a>
     </td>
   </tr>


### PR DESCRIPTION
## Overview
Although existing membership type validation when checking auto-renew box was implemented, you could still add a new membership and set it to auto-renew while the same type was present on a line item on next period.

## Before
There was no validation of membership type being done when adding a new membership line item.

## After
Fixed by adding membership type validation when clicking on button to add new membership line item.