### PR TITLE
BASW-223: UI Improvements to "manage installments" next and current tabs

### DIFF
--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -1,5 +1,7 @@
 CRM.RecurringContribution = CRM.RecurringContribution || {};
 
+var NOTIFICATION_EXPIRE_TIME_IN_MS = 5000;
+
 /**
  * This class handles front-end events and logic associated to managing line
  * items for a recurring contribution.
@@ -149,7 +151,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
 
       that.currentTab.unblock();
       if (itemData.entity_table === 'civicrm_membership' && isMembershipTypeOnNextPeriod) {
-        CRM.alert(ts('This membership type is already enrolled in next period.'), 'Duplicate Membership Type in Next Period', 'alert');
+        CRM.alert(ts('This membership type is already enrolled in next period.'), 'Duplicate Membership Type in Next Period', 'alert', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
         CRM.refreshParent('#periodsContainer');
       } else {
         that.showLineItemAutoRenewConfirmation(itemData);
@@ -285,7 +287,8 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
         CRM.alert(
           ts('This membership type is already enrolled in next period. If you want to create it, please unset the check-box to auto-renew. Otherwise, delete the line item on next period tab and try again.'),
           ts('Duplicate Membership Type Found on Next Period'),
-          'alert'
+          'alert',
+          {expires: NOTIFICATION_EXPIRE_TIME_IN_MS}
         );
 
         return;
@@ -445,7 +448,8 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
           '<li>(optional) Create the membership or contribution outside the recurring order.</li>' +
           '</ul>',
           null,
-          'alert'
+          'alert',
+          {expires: NOTIFICATION_EXPIRE_TIME_IN_MS}
         );
 
         return;
@@ -493,7 +497,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     }
 
     if (errors.length > 0) {
-      CRM.alert('<p>Required fields are missing:</p> <ul>' + errors + '</ul>', 'Missing Fields', 'error');
+      CRM.alert('<p>Required fields are missing:</p> <ul>' + errors + '</ul>', 'Missing Fields', 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
       return false;
     }
@@ -533,7 +537,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     }
 
     if (errors.length > 0) {
-      CRM.alert('<p>Required fields are missing:</p> <ul>' + errors + '</ul>', 'Missing Fields', 'error');
+      CRM.alert('<p>Required fields are missing:</p> <ul>' + errors + '</ul>', 'Missing Fields', 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
       return false;
     }
@@ -558,7 +562,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
       that.currentTab.unblock();
 
       if (result.result < 2) {
-        CRM.alert('Cannot remove the last item in an order!', null, 'alert');
+        CRM.alert('Cannot remove the last item in an order!', null, 'alert', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
         return;
       }

--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -52,7 +52,12 @@ CRM.$(function () {
       throw new Error(ts('Invalid financial type id passed'));
     }
 
-    CRM.$('#financialTypeTaxRate').text(financialType.tax_rate || 'N/A');
+    var taxRate = financialType.tax_rate || 'N/A';
+    if (taxRate != 'N/A') {
+      taxRate += ' %';
+    }
+
+    CRM.$('#financialTypeTaxRate').text(taxRate);
   });
 
   CRM.$('#newMembershipItem').on('change', function() {

--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -1,3 +1,5 @@
+var NOTIFICATION_EXPIRE_TIME_IN_MS = 5000;
+
 CRM.$(function () {
 
   CRM.$('.remove-next-period-line-button').each(function () {
@@ -89,20 +91,20 @@ CRM.$(function () {
         financial_type_id = CRM.$('#financialType').val();
 
     if (!label.length) {
-      CRM.alert(ts('Item label is required'), null, 'error');
+      CRM.alert(ts('Item label is required'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
       return;
     }
 
     if (!amount.length) {
-      CRM.alert(ts('Item amount is required'), null, 'error');
+      CRM.alert(ts('Item amount is required'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
       return;
     } else {
       try {
         amount = parseInt(amount);
       } catch(error) {
-        CRM.alert(ts('Amount you entered is not valid'), null, 'error');
+        CRM.alert(ts('Amount you entered is not valid'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
         return;
       }
@@ -151,20 +153,20 @@ function validateNewMembershipLineItem() {
     newMembershipAmount = CRM.$('#newMembershipAmount').val();
 
   if (!membershipTypeId || !membershipTypeId.length) {
-    CRM.alert(ts('Item label is required'), null, 'error');
+    CRM.alert(ts('Item label is required'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
     return false;
   }
 
   if (!newMembershipAmount.length) {
-    CRM.alert(ts('Item amount is required'), null, 'error');
+    CRM.alert(ts('Item amount is required'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
     return false;
   } else {
     try {
       newMembershipAmount = parseInt(newMembershipAmount);
     } catch(error) {
-      CRM.alert(ts('Amount you entered is not valid'), null, 'error');
+      CRM.alert(ts('Amount you entered is not valid'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
       return false;
     }
@@ -213,7 +215,7 @@ function showMembershipAddLineItemConfirmation() {
           entity_table: 'civicrm_contribution_recur',
         });
       } else {
-        CRM.alert('Could not determine price field value for the select membership type.', null, 'error');
+        CRM.alert('Could not determine price field value for the select membership type.', null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
       }
     });
   }).on('crmConfirm:no', function() {
@@ -224,7 +226,7 @@ function showMembershipAddLineItemConfirmation() {
 function createLineItem(params) {
   CRM.api3('LineItem', 'create', params).done(function(lineItemResult) {
     if (lineItemResult.is_error) {
-      CRM.alert(lineItemResult.error_message, null, 'error');
+      CRM.alert(lineItemResult.error_message, null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
       return;
     }
@@ -236,7 +238,7 @@ function createLineItem(params) {
       auto_renew: true,
     }).done(function(contribRecurResult) {
       if (contribRecurResult.is_error) {
-        CRM.alert(contribRecurResult.error_message, null, 'error');
+        CRM.alert(contribRecurResult.error_message, null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
         return;
       }
@@ -244,7 +246,8 @@ function createLineItem(params) {
       CRM.alert(
         ts(params.label + ' will now be continued in the next period.'),
         null,
-        'success'
+        'success',
+        {expires: NOTIFICATION_EXPIRE_TIME_IN_MS}
       );
       createActivity('Update Payment Plan Next Period', 'update_payment_plan_next_period');
       CRM.refreshParent('#periodsContainer');
@@ -298,7 +301,7 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
     }).done(function (lineRemovalRes) {
       
       if (lineRemovalRes.is_error) {
-        CRM.alert(ts('Cannot remove the last item in an order!'), null, 'error');
+        CRM.alert(ts('Cannot remove the last item in an order!'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
         return;
       }
@@ -310,7 +313,7 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
         }).done(function (membershipUnlinkRes) {
 
           if (membershipUnlinkRes.is_error) {
-            CRM.alert(ts('Cannot unlink the associated membership'), null, 'alert');
+            CRM.alert(ts('Cannot unlink the associated membership'), null, 'alert', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
             return;
           }
@@ -318,7 +321,8 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
           CRM.alert(
             ts(lineItemData.label + ' should no longer be continued in the next period.'),
             null,
-            'success'
+            'success',
+            {expires: NOTIFICATION_EXPIRE_TIME_IN_MS}
           );
           createActivity('Update Payment Plan Next Period', 'update_payment_plan_next_period');
           CRM.refreshParent('#periodsContainer');
@@ -330,7 +334,8 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
         CRM.alert(
           ts(lineItemData.label + ' should no longer be continued in the next period.'),
           null,
-          'success'
+          'success',
+          {expires: NOTIFICATION_EXPIRE_TIME_IN_MS}
         );
 
         return;

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -57,12 +57,12 @@ var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
     <td>
       {$currencySymbol}&nbsp; <input type="text" class="four crm-form-text" size="4" id="amount" />
     </td>
-    <td>
-      <a href="#" class="cancel-add-next-period-line-button">
-        <span><i class="crm-i fa-times crm-i-red"></i></span>
-      </a>
+    <td nowrap class="confirmation-icons">
       <a href="#" class="confirm-add-next-period-line-button">
         <span><i class="crm-i fa-check crm-i-green"></i></span>
+      </a>
+      <a href="#" class="cancel-add-next-period-line-button">
+        <span><i class="crm-i fa-times crm-i-red"></i></span>
       </a>
     </td>
   </tr>


### PR DESCRIPTION
Several UI improvements are done to "manage installments" next and current tabs : 

1- When adding a new amount and selecting a financial type that include tax, the tax percentage does not appear on "next period" tab which is now fixed : 

**Before**
![1b](https://user-images.githubusercontent.com/6275540/51707581-49c6ee80-202a-11e9-9719-d27d5f2ef487.gif)


**After**
![1a](https://user-images.githubusercontent.com/6275540/51707548-3025a700-202a-11e9-8ad6-848d3edef194.gif)


2- A bit of improvement to the layout of confirmation icons when adding an amount in "next period" tab is done so it match the other places : 

**Before**
![2b](https://user-images.githubusercontent.com/6275540/51707596-521f2980-202a-11e9-8d38-78b838b83b81.png)


**After**
![2a](https://user-images.githubusercontent.com/6275540/51707602-551a1a00-202a-11e9-80b4-dca9c0ddff25.png)


3- A **5** seconds expiration is added to all kind of notifications on next and current period tabs : 

**Before**
![3b](https://user-images.githubusercontent.com/6275540/51707619-5b0ffb00-202a-11e9-9594-8296d613f88f.gif)


**After**
![3a](https://user-images.githubusercontent.com/6275540/51707630-5f3c1880-202a-11e9-8f0d-65b4cb915c7c.gif)
