### PR TITLE
BASW-262: Improve Exception Handling on Auto-renewals Job

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -11,11 +11,25 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    * @throws \Exception
    */
   public function run() {
-    $multipleInstallmentRenewal = new CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan();
-    $multipleInstallmentRenewal->run();
+    $exceptions = [];
 
-    $singleInstallmentRenewal = new CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan();
-    $singleInstallmentRenewal->run();
+    try {
+      $multipleInstallmentRenewal = new CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan();
+      $multipleInstallmentRenewal->run();
+    } catch (Exception $e) {
+      $exceptions[] = $e->getMessage();
+    }
+
+    try {
+      $singleInstallmentRenewal = new CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan();
+      $singleInstallmentRenewal->run();
+    } catch (Exception $e) {
+      $exceptions[] = $e->getMessage();
+    }
+
+    if (count($exceptions)) {
+      throw new Exception("Errors found on auto-renewals: " . implode("\n", $exceptions));
+    }
 
     return TRUE;
   }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal.php
@@ -8,7 +8,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
    *
    * @return True
    *
-   * @throws \Exception
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     $exceptions = [];
@@ -16,19 +16,19 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal {
     try {
       $multipleInstallmentRenewal = new CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan();
       $multipleInstallmentRenewal->run();
-    } catch (Exception $e) {
+    } catch (CRM_Core_Exception $e) {
       $exceptions[] = $e->getMessage();
     }
 
     try {
       $singleInstallmentRenewal = new CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan();
       $singleInstallmentRenewal->run();
-    } catch (Exception $e) {
+    } catch (CRM_Core_Exception $e) {
       $exceptions[] = $e->getMessage();
     }
 
     if (count($exceptions)) {
-      throw new Exception("Errors found on auto-renewals: " . implode("\n", $exceptions));
+      throw new CRM_Core_Exception("Errors found on auto-renewals: " . implode("\n", $exceptions));
     }
 
     return TRUE;

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -196,6 +196,8 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
 
   /**
    * Renews the given payment plan.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function run() {
     $exceptions = [];
@@ -219,7 +221,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
     }
 
     if (count($exceptions)) {
-      throw new Exception(implode(";\n", $exceptions));
+      throw new CRM_Core_Exception(implode(";\n", $exceptions));
     }
   }
   


### PR DESCRIPTION
## Overview
Renewals seem to have stopped working on payment test server.

## Before
An exception thrown on one of the renewals cause the whole execution to stop, leaving pending auto-renewals after the exception untouched.

## After
Fixed by capturing exceptions in an array and throwing a single exception with the list of problems found when all payment plans have been processed.
