### PR TITLE
BASW-219: Fix Issues With Line Item Auto-renew and Removal

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -93,6 +93,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
     civicrm_api3('ContributionRecurLineItem', 'get', [
       'sequential' => 1,
       'contribution_recur_id' => $this->recurringContribution['id'],
+      'is_removed' => 0,
       'options' => ['limit' => 0],
       'api.ContributionRecurLineItem.create' => [
         'id' => '$value.id',

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -60,6 +60,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
     $this->updateMembership();
     $this->updateRelatedInstallments();
     $this->updateRecurringContribution();
+    $this->updateSubscriptionLineItems();
   }
 
   /**
@@ -79,6 +80,27 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
     civicrm_api3('ContributionRecur', 'create', $params);
   }
 
+  /**
+   * Updates recurring line items associated to the recurring contribution.
+   */
+  private function updateSubscriptionLineItems() {
+    $autoRenew = $this->form->getElementValue('auto_renew');
+    
+    if (!$autoRenew) {
+      return;
+    }
+
+    civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'options' => ['limit' => 0],
+      'api.ContributionRecurLineItem.create' => [
+        'id' => '$value.id',
+        'auto_renew' => $autoRenew,
+      ]
+    ]);
+  }
+  
   /**
    * Updates membership if necessary.
    */

--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -123,8 +123,9 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
       'contribution_status_id' => 'Partially paid',
     ]);
 
-    $allPaid = $paidInstallmentsCount >= $this->recurringContribution['installments'];
-    $moreThanOneInstallment = $this->recurringContribution['installments'] > 1;
+    $installments = CRM_Utils_Array::value('installments', $this->recurringContribution, 0);
+    $allPaid = $paidInstallmentsCount >= $installments;
+    $moreThanOneInstallment = $installments > 1;
 
     switch (true) {
       case $moreThanOneInstallment && $allPaid:

--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -223,7 +223,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
   };
 
   /**
-   * Adds events tht handle new membership addition to the recurring
+   * Adds events that handle new membership addition to the recurring
    * contribution.
    */
   CurrentPeriodLineItemHandler.prototype.setNewMembershipEvents = function () {
@@ -436,11 +436,11 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     CRM.api3('Contribution', 'getcount', {
       'contribution_recur_id': that.recurringContributionID,
       'contribution_status_id': 'Pending',
-      'end_date': {'>=': startDate},
+      'receive_date': {'>=': startDate},
     }).done(function (result) {
       that.currentTab.unblock();
 
-      if (that.recurringContribution.installments > 1 && result.result < 1) {
+      if (result.result < 1) {
         CRM.alert(
           'There are no instalments left for this period. Suggest to follow the steps below:' +
           '<ul>' +

--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -295,11 +295,17 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
       yes: ts('Apply')
     }
   }).on('crmConfirm:yes', function() {
-    CRM.api3('ContributionRecurLineItem', 'create', {
+    var params = {
       'id': lineItemData.id,
-      'auto_renew': 0,
-    }).done(function (lineRemovalRes) {
-      
+      'auto_renew': 0
+    };
+
+    if (typeof lineItemData.start_date === 'undefined' || lineItemData.start_date === '') {
+      params.is_removed = 1;
+    }
+
+    CRM.api3('ContributionRecurLineItem', 'create', params)
+    .done(function (lineRemovalRes) {
       if (lineRemovalRes.is_error) {
         CRM.alert(ts('Cannot remove the last item in an order!'), null, 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
 
@@ -340,7 +346,6 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
 
         return;
       }
-
     });
   }).on('crmConfirm:no', function() {
     return;


### PR DESCRIPTION
## Overview
There were several issues present when removing line items from next period, both by using the trash icon on next period or the auto-renew checkbox on current period:

1. ‘is_removed’ in ‘membershipextras_subscription_line’ for the corresponding item should set to True but its still set as ‘0' after removing the line item. 
1. If a payment plan is created without the auto-renew, but is later edited to be auto-renew, all line items that are not removed should also be set to auto-renew.
1. For Recurring Contribution with Null Installment- While trying to select 'Renew-Automatically' checkbox (Auto-Renew was set 'False' before) , the original line item entry is deleted from UI as well as from DB.
1. Below error message is thrown in Current Period always while trying to replicate issue#7 for Null Installment scenarios

![image](https://user-images.githubusercontent.com/21999940/52074701-77df8d80-2558-11e9-8376-f7813653f5e2.png)

## Before
### is_removed Flag on Next Period Removals
When removing line items from next period, is_removed was not being set to true, as that was also removing them from next period. Still, if a line item has only been added to next period, then the is_removed flag should be set.

### Updating a Recurring Contribution to Auto-renew
When editing a recurring contribution that is not set to auto-renew, if the auto-renew checkbox is checked and saved, all subscription lines should be set to renew too. This was not happenning.

### Disappearing Line Items When Setting Them to Auto-renew
When a membership line item was added not to auto-renew, and then was set to auto-renew for a payment plan with 0 installments, the line item got deleted from the database. This happened because although the line item was created, since all contributions were in the past and/or completed, there were no payments associated to the new membership.

Now, when setting the line item to auto-renew, the membership needs to be updated to store the recurring contribution's ID in the contribution_recur_id field of the Membership entity. On CiviCRM core, the create() method of the membership's BAO checks if the membership has any payments. If it doesn't, it assumes the membership type has changed, and thus DELETES ALL LINE ITEMS
ASSOCIATED TO THE MEMBERSHIP!

The thing is, the line item should not have been allowed to be created in the first place, as there is a validation in the Manage Future Installments form that checks if there are pending contributions in the future to add and pay for the new membership. This validation was failing because it was erronously
checking the contributions' end_date (which doesn't even exist), instead of the receive_date.

Fixed by using receive_date to validate if there are any pending contributions in the future.

## After
### is_removed Flag on Next Period Removals
Added a check to see if the line item was only added to next period. If so, it sets is_removed to true.

### Updating a Recurring Contribution to Auto-renew
Implemented logic on UpdateSubscription form's postProcess hook to set subscription lines to auto-renew.

### Disappearing Line Items When Setting Them to Auto-renew
Fixed by using receive_date to validate if there are any pending contributions in the future. This will prevent the creation of memberships without payments.