### PR TITLE
BASW-223: (Next Period) tab UI Improvment

### DIFF
--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -53,7 +53,7 @@ var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
         {/foreach}
       </select>
     </td>
-    <td id="financialTypeTaxRate" nowrap>{if !empty($financialTypes[0].tax_rate)}{$financialTypes[0].tax_rate}{else}N/A{/if}</td>
+    <td id="financialTypeTaxRate" nowrap>{if !empty($financialTypes[0].tax_rate)}{$financialTypes[0].tax_rate} %{else}N/A{/if}</td>
     <td>
       {$currencySymbol}&nbsp; <input type="text" class="four crm-form-text" size="4" id="amount" />
     </td>


### PR DESCRIPTION
## Before

on (next period) tab and when clicking on "adding another amount" button, if the by default selected financial type has a tax, then the tax amount percentage sign will not appear, though this is only happen for the one selected by default, but if it get changed then the percentage sign will appear normally : 

![1b](https://user-images.githubusercontent.com/6275540/52138676-c585f400-2645-11e9-9947-b734ffd8561c.gif)


## After

![1f](https://user-images.githubusercontent.com/6275540/52138680-c880e480-2645-11e9-89f4-abe514f03ec9.gif)
