### PR TITLE
BASW-212: Fix next period start date for payment plans with no installments

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -263,8 +263,11 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @return string
    */
   private function calculateNextPeriodStartDate() {
-    $nextPeriodStartDate = new DateTime(CRM_Utils_Array::value('start_date', $this->contribRecur));
-    $intervalLength = CRM_Utils_Array::value('frequency_interval', $this->contribRecur) * CRM_Utils_Array::value('installments', $this->contribRecur);
+    $numberOfInstallments = 1;
+    if (!empty($this->contribRecur['installments'])) {
+      $numberOfInstallments = $this->contribRecur['installments'];
+    }
+    $intervalLength = CRM_Utils_Array::value('frequency_interval', $this->contribRecur, 0) * $numberOfInstallments;
 
     switch (CRM_Utils_Array::value('frequency_unit', $this->contribRecur)) {
       case 'month':
@@ -278,6 +281,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
         break;
     }
 
+    $nextPeriodStartDate = new DateTime(CRM_Utils_Array::value('start_date', $this->contribRecur));
     $nextPeriodStartDate->add(new DateInterval($interval));
 
     return $nextPeriodStartDate->format('Y-m-d');


### PR DESCRIPTION
## Problem

For payment plans with no installments, the next period start data will always be same as the start date of the current period.

*Before*
![2019-02-05 17_21_06-test323 test323 _ ppphase4](https://user-images.githubusercontent.com/6275540/52283129-d7270e80-2959-11e9-85e5-87c9a8416c50.png)
![2019-02-05 17_21_53-test323 test323 _ ppphase4](https://user-images.githubusercontent.com/6275540/52283139-dd1cef80-2959-11e9-8a03-91a8a22aaf7b.png)



## Solution

The formula to calculate the next period start date used to be : 

N = Payment Plan Number of Installments * Payment Plan Frequency Interval


then the Frequency Unit (year, month, week ..etc) will be used to add the N amount to the current period start date, so if N was 1 and The frequency unit was 'Year', then 1 Year will be added to the start date of current period to calculate the next period start date. But Since the number of installments for payment plan with no installments is 0, I changed the code to convert it to 1 so the correct amount of time will be added, since at the end, a payment plan with no installments is a payment plan with 1 installment.

Though it worth mentioning that the current calculation for next period start time in general and even for payment plans with more than one installments seems to be flawed, because it does not incorporate  the membership type duration and unit, though this subject may a bit tricky since there are many factors might affect the calculation and we decided to delay fixing it for a bit until we further discuss it together and come up with a better solution.

*After*
![2019-02-05 17_21_06-test323 test323 _ ppphase4](https://user-images.githubusercontent.com/6275540/52283143-df7f4980-2959-11e9-8c62-4a9ac33647de.png)
![2019-02-05 17_21_00-test323 test323 _ ppphase4](https://user-images.githubusercontent.com/6275540/52283148-e1490d00-2959-11e9-9acd-6cb95f5b843a.png)
