### PR TITLE
BASW-222: Disable Auto-renew Checkbox and Re-use Lines Among Periods

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
@@ -185,6 +185,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
       'contribution_recur_id' => $this->recurringContribution['id'],
       'auto_renew' => TRUE,
       'is_removed' => 0,
+      'options' => ['limit' => 0],
       'api.LineItem.getsingle' => [
         'id' => '$value.line_item_id',
         'entity_table' => ['IS NOT NULL' => 1],

--- a/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
@@ -103,7 +103,9 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
   }
 
   /**
-   * Creates new line item associaated to the rcurring contribution.
+   * Checks if recurring line item exists for membership type in next period,
+   * and updates it if finds one. Otherwise, creates new line item associated to
+   * the recurring contribution.
    *
    * @return array
    */
@@ -116,7 +118,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
       $this->lineItemParams['amount'] * $taxRate / 100
     );
 
-    $lineItem = civicrm_api3('LineItem', 'create', [
+    $params = [
       'sequential' => 1,
       'entity_table' => 'civicrm_membership',
       'entity_id' => $membership['id'],
@@ -128,7 +130,14 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
       'price_field_value_id' => $priceFieldValue['id'],
       'financial_type_id' => $priceFieldValue['financial_type_id'],
       'tax_amount' => $taxAmount,
-    ]);
+    ];
+
+    $existingLineItem = $this->getExistingLineItemForMembershipType($membership['membership_type_id']);
+    if (CRM_Utils_Array::value('id', $existingLineItem, false)) {
+      $params['id'] = $existingLineItem['id'];
+    }
+
+    $lineItem = civicrm_api3('LineItem', 'create', $params);
 
     CRM_MembershipExtras_BAO_ContributionRecurLineItem::create([
       'contribution_recur_id' => $this->recurringContribution['id'],
@@ -138,6 +147,68 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
     ]);
 
     return array_shift($lineItem['values']);
+  }
+
+  /**
+   * Loops through line items on next period and returns the first line item
+   * with the same membership type as the given one.
+   *
+   * @param int $membershipTypeID
+   *
+   * @return array
+   */
+  private function getExistingLineItemForMembershipType($membershipTypeID) {
+    $nextPeriodLines = $this->getNextPeriodLineItems();
+
+    foreach ($nextPeriodLines as $lineItem) {
+      $priceFieldValue = $lineItem['price_field_value'];
+      $lineMembershipType = $priceFieldValue['membership_type_id'];
+
+      if ($membershipTypeID == $lineMembershipType) {
+        return $lineItem;
+      }
+    }
+
+    return [];
+  }
+
+  /**
+   * Obtains list of line items for the next period.
+   *
+   * @return array
+   */
+  private function getNextPeriodLineItems() {
+    $lineItems = array();
+
+    $params = [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'auto_renew' => TRUE,
+      'is_removed' => 0,
+      'api.LineItem.getsingle' => [
+        'id' => '$value.line_item_id',
+        'entity_table' => ['IS NOT NULL' => 1],
+        'entity_id' => ['IS NOT NULL' => 1],
+        'api.PriceFieldValue.getsingle' => [
+          'id' => '$value.price_field_value_id',
+        ],
+      ],
+    ];
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', $params);
+
+    if ($result['count'] > 0) {
+      foreach ($result['values'] as $lineItemData) {
+        $lineDetails = $lineItemData['api.LineItem.getsingle'];
+        $lineDetails['price_field_value'] = $lineDetails['api.PriceFieldValue.getsingle'];
+
+        unset($lineDetails['id']);
+        unset($lineDetails['api.PriceFieldValue.getsingle']);
+        unset($lineItemData['api.LineItem.getsingle']);
+        $lineItems[] = array_merge($lineItemData, $lineDetails);
+      }
+    }
+
+    return $lineItems;
   }
 
   /**

--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -613,6 +613,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
       'contribution_recur_id': this.recurringContribution.id,
       'auto_renew': true,
       'is_removed': 0,
+      'options': {'limit': 0},
       'api.LineItem.get': {
         'sequential': 1,
         'id': '$value.line_item_id',


### PR DESCRIPTION
## Overview
If a user tries to add a membership line item to the current period and that membership type is already on next period, the auto-renew checkbox should be disabled and forcibly set to true, before applying changes. Also, when the data is saved, instead of creating a new line item for the membership and disallowing setting it to auto-renew (as the membership type is already on next period), we should use the existing line item and update it so it appears both on current and next periods.

## Before
When adding a membership to current period with auto-renew, the system checked if the membership type was on next period and if so, issued a warning and disallowed the creation of the membership unless the auto-renew checkbox was unset.

## After
System checks if membership type is already on next period when selecting membership type, and if so, disables auto-renew checkbox and forcibly sets it to true.

When creating a membership line item for the current period of a payment plan we check if it exists for next period. If it does, we use that existing line, instead of creating a new one.