### PR TITLE
BASW-259: Fix Upgrader.

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -339,7 +339,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   private function updatePaymentPlans() {
     $manualRecurContributions = $this->getManualPaymentPlans();
 
-    foreach ($$manualRecurContributions as $paymentPlan) {
+    foreach ($manualRecurContributions as $paymentPlan) {
       $lastInstalment = $this->getLastInstalmentForPaymentPlan($paymentPlan['id']);
       $lineItems = $this->getLineItemsForContribution($lastInstalment['id']);
 


### PR DESCRIPTION
## Overview
QA reported:
> no records are added in 'membershipextras_subscription_line' table after phase 3 upgrader.
> Table is updated with blank entries though we have records created that match the criteria before upgrading.

## Solution
This problem is caused by the line `foreach ($$manualRecurContributions as $paymentPlan) {`. Removing one `$` solves the problem.