### PR TITLE
BASW-415: Fix Membership Line Item Creation on Renewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -583,16 +583,16 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    * @return int
    */
   private function createMembership($lineItem, $priceFieldValue) {
-    $membership = civicrm_api3('Membership', 'create', [
+    $membershipCreateResult = civicrm_api3('Membership', 'create', [
       'contact_id' => $this->currentRecurringContribution['contact_id'],
       'membership_type_id' => $priceFieldValue['membership_type_id'],
       'join_date' => date('YmdHis'),
       'start_date' => $lineItem['start_date'],
       'end_date' => $lineItem['end_date'],
       'contribution_recur_id' => $this->newRecurringContributionID,
-    ])['values'][0];
+    ]);
 
-    return $membership['id'];
+    return $membershipCreateResult['id'];
   }
 
   /**


### PR DESCRIPTION
## Overview
When renewing, line items were being created for new memberships (ie. memberships created on next period only), however, these line items were not being set as related to the new membership.

## Before
The method that was supposed to return the membership's ID on creation failed to do so, causing line items to have an empty entity_id field.

## After
Fixed by returning the ID for the new membership as set by the API create
membership call.