### PR TITLE
BASW-259: Fix Upgrader

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -309,27 +309,14 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     }
   }
 
-  private function getCustomFieldId($customGroupName, $customFieldName) {
-    return civicrm_api3('CustomField', 'getvalue', [
-      'return' => 'id',
-      'custom_group_id' => $customGroupName,
-      'name' => $customFieldName,
-    ]);
-  }
-
   private function createCustomValueForPaymentPlan($paymentPlanId) {
-    $nextPeriodCustomFieldId = $this->getCustomFieldId('related_payment_plan_periods', 'next_period');
-    $prevPeriodCustomFieldId = $this->getCustomFieldId('related_payment_plan_periods', 'previous_period');
+    $custom_fields = array (
+      'previous_period' => 0,
+      'next_period' => 0
+    );
+    $params = array('entityID' => $paymentPlanId, $custom_fields);
 
-    civicrm_api3('ContributionRecur', 'create', [
-      [
-        'id' => $paymentPlanId,
-        'custom_' . $nextPeriodCustomFieldId => 0,
-      ], [
-        'id' => $paymentPlanId,
-        'custom_' . $prevPeriodCustomFieldId => 0,
-      ],
-    ]);
+    CRM_Core_BAO_CustomValueTable::setValues($params);
   }
 
   /**

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -176,51 +176,58 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
    * Add Related Payment Plan Periods' Custom Fields
    */
   private function createPeriodLinkCustomFields() {
-    civicrm_api3('CustomGroup', 'create', [
+    $result = civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
       'name' => 'related_payment_plan_periods',
-      'title' => E::ts('Related Payment Plan Periods'),
-      'extends' => 'ContributionRecur',
-      'style' => 'Inline',
-      'collapse_display' => 1,
-      'weight' => 10,
-      'is_active' => 1,
-      'table_name' => 'civicrm_value_payment_plan_periods',
-      'is_multiple' => 0,
-      'collapse_adv_display' => 0,
-      'is_reserved' => 0,
-      'is_public' => 1,
-      'api.CustomField.create' => [
-        [
-          'custom_group_id' => '$value.id',
-          'name' => 'previous_period',
-          'label' => E::ts('Previous Payment Plan Period'),
-          'data_type' => 'Int',
-          'html_type' => 'Text',
-          'is_required' => 0,
-          'is_searchable' => 0,
-          'weight' => 2,
-          'is_active' => 1,
-          'is_view' => 1,
-          'is_selector' => 0,
-          'custom_group_name' => 'related_payment_plan_periods',
-          'column_name' => 'previous_period',
-        ], [
-          'custom_group_id' => '$value.id',
-          'name' => 'next_period',
-          'label' => E::ts('Next Payment Plan Period'),
-          'data_type' => 'Int',
-          'html_type' => 'Text',
-          'is_required' => 0,
-          'is_searchable' => 0,
-          'weight' => 2,
-          'is_active' => 1,
-          'is_view' => 1,
-          'is_selector' => 0,
-          'custom_group_name' => 'related_payment_plan_periods',
-          'column_name' => 'next_period',
-        ]
-      ],
     ]);
+
+    if ($result['count'] === 0) {
+      civicrm_api3('CustomGroup', 'create', [
+        'name' => 'related_payment_plan_periods',
+        'title' => E::ts('Related Payment Plan Periods'),
+        'extends' => 'ContributionRecur',
+        'style' => 'Inline',
+        'collapse_display' => 1,
+        'weight' => 10,
+        'is_active' => 1,
+        'table_name' => 'civicrm_value_payment_plan_periods',
+        'is_multiple' => 0,
+        'collapse_adv_display' => 0,
+        'is_reserved' => 0,
+        'is_public' => 1,
+        'api.CustomField.create' => [
+          [
+            'custom_group_id' => '$value.id',
+            'name' => 'previous_period',
+            'label' => E::ts('Previous Payment Plan Period'),
+            'data_type' => 'Int',
+            'html_type' => 'Text',
+            'is_required' => 0,
+            'is_searchable' => 0,
+            'weight' => 2,
+            'is_active' => 1,
+            'is_view' => 1,
+            'is_selector' => 0,
+            'custom_group_name' => 'related_payment_plan_periods',
+            'column_name' => 'previous_period',
+          ], [
+            'custom_group_id' => '$value.id',
+            'name' => 'next_period',
+            'label' => E::ts('Next Payment Plan Period'),
+            'data_type' => 'Int',
+            'html_type' => 'Text',
+            'is_required' => 0,
+            'is_searchable' => 0,
+            'weight' => 2,
+            'is_active' => 1,
+            'is_view' => 1,
+            'is_selector' => 0,
+            'custom_group_name' => 'related_payment_plan_periods',
+            'column_name' => 'next_period',
+          ]
+        ],
+      ]);
+    }
   }
 
   /**

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -406,6 +406,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     foreach ($optionValues as $optionValue) {
       $result = civicrm_api3('OptionValue', 'get', [
         'sequential' => 1,
+        'option_group_id' => 'activity_type',
         'name' => $optionValue['name'],
       ]);
 

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -308,11 +308,21 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       civicrm_api3('LineItem', 'create', $params);
     }
   }
+  private function getCustomFieldId($customGroupName, $customFieldName) {
+    return civicrm_api3('CustomField', 'getvalue', [
+      'return' => 'id',
+      'custom_group_id' => $customGroupName,
+      'name' => $customFieldName,
+    ]);
+  }
 
   private function createCustomValueForPaymentPlan($paymentPlanId) {
-    $custom_fields = array (
-      'previous_period' => 0,
-      'next_period' => 0
+    $nextPeriodCustomFieldId = $this->getCustomFieldId('related_payment_plan_periods', 'next_period');
+    $prevPeriodCustomFieldId = $this->getCustomFieldId('related_payment_plan_periods', 'previous_period');
+
+    $custom_fields = array(
+      'custom_' . $prevPeriodCustomFieldId => 0,
+      'custom_' . $nextPeriodCustomFieldId => 0
     );
     $params = array('entityID' => $paymentPlanId, $custom_fields);
 


### PR DESCRIPTION
## Overview
Upgrader fails and exits with the fatal error as reported by QA:
```
Feb 22 14:29:48  [info] $CRM_Queue_Page_AJAX_runNext_error = CiviCRM_API3_Exception: "Mandatory key(s) missing from params array: contact_id, frequency_interval"
#0 C:\MAMP\htdocs\Civi5.6\sites\default\files\civicrm\ext\uk.co.compucorp.membershipextras-master\CRM\MembershipExtras\Upgrader.php(330): civicrm_api3("ContributionRecur", "create", (Array:3))
#1 C:\MAMP\htdocs\Civi5.6\sites\default\files\civicrm\ext\uk.co.compucorp.membershipextras-master\CRM\MembershipExtras\Upgrader.php(353): CRM_MembershipExtras_Upgrader->createCustomValueForPaymentPlan("3")
#2 C:\MAMP\htdocs\Civi5.6\sites\default\files\civicrm\ext\uk.co.compucorp.membershipextras-master\CRM\MembershipExtras\Upgrader.php(402): CRM_MembershipExtras_Upgrader->updatePaymentPlans()
#3 C:\MAMP\htdocs\Civi5.6\sites\default\files\civicrm\ext\uk.co.compucorp.membershipextras-master\CRM\MembershipExtras\Upgrader\Base.php(72): CRM_MembershipExtras_Upgrader->upgrade_0001()
```

The problem is caused by [this method](https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/bc68179688e76229fd62046a62b642778cb6296e/CRM/MembershipExtras/Upgrader.php#L320) which wrongly tries to create a CustomValue for the `next_period` and `previous_period` custom fields.

## Before
Upgrader fails

## After
Bug fixed