### PR TITLE
BASW-328: Membership Period Cancellation for Payment Overdue

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -1,5 +1,6 @@
 <?php
 use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
+use CRM_MembershipExtras_Service_ContributionUtilities as ContributionUtilities;
 use CRM_MembershipExtras_Service_MembershipEndDateCalculator as MembershipEndDateCalculator;
 
 /**
@@ -111,6 +112,8 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    * CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan constructor.
    */
   public function __construct() {
+    $this->contributionStatusesNameMap = ContributionUtilities::getStatusesNameMap();
+    
     $this->setUseMembershipLatestPrice();
     $this->setContributionPendingStatusValue();
     $this->setContributionStatusesNameMap();
@@ -156,27 +159,6 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       'option_group_id' => 'contribution_status',
       'name' => 'Pending',
     ]);
-  }
-
-  /**
-   * Gets contribution Statuses Name to value Mapping
-   *
-   * @return array $contributionStatusesNameMap
-   */
-  private function setContributionStatusesNameMap() {
-    $contributionStatuses = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'return' => ['name', 'value'],
-      'option_group_id' => 'contribution_status',
-      'options' => ['limit' => 0],
-    ])['values'];
-
-    $contributionStatusesNameMap = [];
-    foreach ($contributionStatuses as $status) {
-      $contributionStatusesNameMap[$status['name']] = $status['value'];
-    }
-
-    $this->contributionStatusesNameMap = $contributionStatusesNameMap;
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OverdueMembershipPeriodProcessor.php
+++ b/CRM/MembershipExtras/Job/OverdueMembershipPeriodProcessor.php
@@ -1,0 +1,69 @@
+<?php
+
+use CRM_MembershipExtras_Service_ContributionUtilities as ContributionUtilities;
+
+class CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor {
+
+  /**
+   * Starts the scheduled job for disabling overdue membership
+   * periods
+   * 
+   * @return True
+   * 
+   * @throws \Exception
+   */
+  public function run() {
+    $membershipPeriodDao = $this->getMembershipsPeriodsWithOverduePayment();
+    
+    while ($membershipPeriodDao->fetch()) {
+      try {
+        $this->disableMembershipPeriod($membershipPeriodDao->membership_period_id);
+      } catch (Exception $e) {
+        $message = "An error occurred disabling an overdue membership period with id({$membershipPeriodDao->membership_period_id}): " . $e->getMessage();
+
+        throw new Exception($message);
+      }
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * @return CRM_Core_DAO
+   *  Object that point to result set of IDs of overdue membership periods
+   */
+  private function getMembershipsPeriodsWithOverduePayment() {
+    $contributionStatusesNameMap = ContributionUtilities::getContributionStatusesNameMap();
+    $completedContributionStatusID = $contributionStatusesNameMap['Completed'];
+    
+    $daysToDisableMP = CRM_MembershipExtras_SettingsManager::getDaysToDisableMembershipPeriodsWithOverduePayment();
+    $dateNow = (new \DateTime())->format('Y-m-d H:i:s');
+    $daysAgo = date('Y-m-d H:i:s', strtotime("-$daysToDisableMP days", strtotime($dateNow)));
+
+    $query = "
+      SELECT mmp.id as membership_period_id
+        FROM membershipextras_membership_period mmp
+      LEFT JOIN civicrm_membership cm ON mmp.membership_id = cm.id
+      LEFT JOIN civicrm_membership_payment cmp ON mmp.membership_id = cmp.membership_id
+      LEFT JOIN civicrm_contribution cc ON cmp.contribution_id = cc.id
+        WHERE cc.receive_date <= '$daysAgo'
+         AND cc.contribution_status_id != $completedContributionStatusID
+         AND mmp.is_active = 1
+      GROUP BY membership_period_id
+    ";
+
+    return CRM_Core_DAO::executeQuery($query);
+  }
+
+  /**
+   * Disables a membership period
+   * 
+   * @param int $membershipPeriodID 
+   */
+  private function disableMembershipPeriod($membershipPeriodID) {
+    $membershipPeriodBao = new CRM_MembershipExtras_BAO_MembershipPeriod();
+    $membershipPeriodBao->id = $membershipPeriodID;
+    $membershipPeriodBao->is_active = 0;
+    $membershipPeriodBao->save();
+  }
+}

--- a/CRM/MembershipExtras/Job/OverdueMembershipPeriodProcessor.php
+++ b/CRM/MembershipExtras/Job/OverdueMembershipPeriodProcessor.php
@@ -47,7 +47,6 @@ class CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor {
     (
       SELECT mmp.id as membership_period_id
         FROM membershipextras_membership_period mmp
-          INNER JOIN civicrm_membership cm ON mmp.membership_id = cm.id
           INNER JOIN civicrm_contribution cc ON (
             mmp.entity_id = cc.id
             AND mmp.payment_entity_table = 'civicrm_contribution'
@@ -59,7 +58,6 @@ class CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor {
     ) UNION (
       SELECT mmp.id as membership_period_id
         FROM membershipextras_membership_period mmp
-          INNER JOIN civicrm_membership cm ON mmp.membership_id = cm.id
           INNER JOIN civicrm_contribution_recur ccr ON (
             mmp.entity_id = ccr.id
             AND mmp.payment_entity_table = 'civicrm_contribution_recur'

--- a/CRM/MembershipExtras/Job/OverdueMembershipPeriodProcessor.php
+++ b/CRM/MembershipExtras/Job/OverdueMembershipPeriodProcessor.php
@@ -14,14 +14,16 @@ class CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor {
    */
   public function run() {
     $membershipPeriodDao = $this->getMembershipsPeriodsWithOverduePayment();
-    
+    $errors = [];
     while ($membershipPeriodDao->fetch()) {
       try {
         $this->disableMembershipPeriod($membershipPeriodDao->membership_period_id);
       } catch (Exception $e) {
-        $message = "An error occurred disabling an overdue membership period with id({$membershipPeriodDao->membership_period_id}): " . $e->getMessage();
+        $errors[] = "An error occurred disabling an overdue membership period with id({$membershipPeriodDao->membership_period_id}): " . $e->getMessage();
+      }
 
-        throw new Exception($message);
+      if (count($errors) > 0) {
+        throw new Exception("Errors found while processing periods: " . implode('; ', $errors));
       }
     }
 
@@ -37,19 +39,37 @@ class CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor {
     $completedContributionStatusID = $contributionStatusesNameMap['Completed'];
     
     $daysToDisableMP = CRM_MembershipExtras_SettingsManager::getDaysToDisableMembershipPeriodsWithOverduePayment();
-    $dateNow = (new \DateTime())->format('Y-m-d H:i:s');
-    $daysAgo = date('Y-m-d H:i:s', strtotime("-$daysToDisableMP days", strtotime($dateNow)));
+    $date = new DateTime();
+    $date->sub(new DateInterval("P{$daysToDisableMP}D"));
+    $maxReceiveDate = $date->format('Y-m-d H:i:s');
 
     $query = "
+    (
       SELECT mmp.id as membership_period_id
         FROM membershipextras_membership_period mmp
-      LEFT JOIN civicrm_membership cm ON mmp.membership_id = cm.id
-      LEFT JOIN civicrm_membership_payment cmp ON mmp.membership_id = cmp.membership_id
-      LEFT JOIN civicrm_contribution cc ON cmp.contribution_id = cc.id
-        WHERE cc.receive_date <= '$daysAgo'
-         AND cc.contribution_status_id != $completedContributionStatusID
-         AND mmp.is_active = 1
-      GROUP BY membership_period_id
+          INNER JOIN civicrm_membership cm ON mmp.membership_id = cm.id
+          INNER JOIN civicrm_contribution cc ON (
+            mmp.entity_id = cc.id
+            AND mmp.payment_entity_table = 'civicrm_contribution'
+          )
+        WHERE cc.receive_date <= '{$maxReceiveDate}'
+          AND cc.contribution_status_id != {$completedContributionStatusID}
+          AND mmp.is_active = 1
+        GROUP BY membership_period_id
+    ) UNION (
+      SELECT mmp.id as membership_period_id
+        FROM membershipextras_membership_period mmp
+          INNER JOIN civicrm_membership cm ON mmp.membership_id = cm.id
+          INNER JOIN civicrm_contribution_recur ccr ON (
+            mmp.entity_id = ccr.id
+            AND mmp.payment_entity_table = 'civicrm_contribution_recur'
+          )
+          INNER JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id
+        WHERE cc.receive_date <= '{$maxReceiveDate}'
+          AND ccr.contribution_status_id != {$completedContributionStatusID}
+          AND mmp.is_active = 1
+        GROUP BY membership_period_id
+    )
     ";
 
     return CRM_Core_DAO::executeQuery($query);

--- a/CRM/MembershipExtras/Service/ContributionUtilities.php
+++ b/CRM/MembershipExtras/Service/ContributionUtilities.php
@@ -1,0 +1,26 @@
+<?php
+ /**
+ * Generic contribution utilities.
+ */
+class CRM_MembershipExtras_Service_ContributionUtilities {
+  /**
+   * Gets contribution Statuses Name to value Mapping
+   *
+   * @return array $contributionStatusesNameMap
+   */
+  public static function getStatusesNameMap() {
+    $contributionStatuses = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'return' => ['name', 'value'],
+      'option_group_id' => 'contribution_status',
+      'options' => ['limit' => 0],
+    ])['values'];
+    
+    $contributionStatusesNameMap = [];
+    foreach ($contributionStatuses as $status) {
+      $contributionStatusesNameMap[$status['name']] = $status['value'];
+    }
+    
+    return $contributionStatusesNameMap;
+  }
+}

--- a/CRM/MembershipExtras/SettingsManager.php
+++ b/CRM/MembershipExtras/SettingsManager.php
@@ -30,6 +30,21 @@ class CRM_MembershipExtras_SettingsManager {
     return $daysToRenewInAdvance;
   }
 
+  /**
+   * Returns the 'days to disable membership periods with overdue payment'
+   * setting.
+   *
+   * @return int
+   */
+  public static function getDaysToDisableMembershipPeriodsWithOverduePayment() {
+    $daysToDisableMP = self::getSettingValue('membershipextras_paymentplan_days_to_disable_membership_period_with_overdue_payment');
+    if (empty($daysToDisableMP)) {
+      return 0;
+    }
+    
+    return $daysToDisableMP;
+  }
+
   public static function getCustomFieldsIdsToExcludeForAutoRenew() {
     $customGroupsIdsToExcludeForAutoRenew = self::getSettingValue('membershipextras_customgroups_to_exclude_for_autorenew');
     if (empty($customGroupsIdsToExcludeForAutoRenew)) {

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -11,6 +11,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
   public function Install() {
     $this->createOfflineAutoRenewalScheduledJob();
+    $this->createOverdueMembershipPeriodProcessorScheduledJob();
     $this->createPaymentProcessorType();
     $this->createPaymentProcessor();
     $this->createLineItemExternalIDCustomField();
@@ -141,6 +142,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     $paymentProcessorType->remove();
 
     $this->removeOfflineAutoRenewalScheduledJob();
+    $this->removeOverdueMembershipPeriodProcessorScheduledJob();
     $this->removeCustomExternalIDs();
     $this->removeManageInstallmentActivityTypes();
   }
@@ -152,6 +154,35 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   private function removeOfflineAutoRenewalScheduledJob() {
     civicrm_api3('Job', 'get', [
       'name' => 'Renew offline auto-renewal memberships',
+      'api.Job.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  /**
+   * Create 'Update overdue membership/period status' Scheduled Job.
+   */
+  private function createOverdueMembershipPeriodProcessorScheduledJob() {
+    $result = civicrm_api3('Job', 'get', [
+      'name' => 'Update overdue membership period status',
+    ]);
+    if ($result['count'] == 0) {
+      civicrm_api3('Job', 'create', [
+        'run_frequency' => 'Daily',
+        'name' => 'Update overdue membership period status',
+        'description' => ts('Update membership/period status when overdue by amount of days in setting'),
+        'api_entity' => 'OverdueMembershipPeriodProcessor',
+        'api_action' => 'run',
+        'is_active' => 1,
+      ]);
+    }
+  }
+   /**
+   * Removes 'Update overdue membership period status'
+   * Scheduled Job.
+   */
+  private function removeOverdueMembershipPeriodProcessorScheduledJob() {
+    civicrm_api3('Job', 'get', [
+      'name' => 'Update overdue membership period status',
       'api.Job.delete' => ['id' => '$value.id'],
     ]);
   }
@@ -413,6 +444,15 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
   public function upgrade_0002() {
     $this->executeSqlFile('sql/Upgrader/0002_create_membership_period.sql');
 
+    return true;
+  }
+
+  /**
+   * @return bool
+   */
+  public function upgrade_0003() {
+    $this->createOverdueMembershipPeriodProcessorScheduledJob();
+    
     return true;
   }
 

--- a/api/v3/OverdueMembershipPeriodProcessor.php
+++ b/api/v3/OverdueMembershipPeriodProcessor.php
@@ -8,10 +8,10 @@
  * @see civicrm_api3_create_success
  */
 function civicrm_api3_overdue_membership_period_processor_run($params) {
-  $OverdueMembershipPeriodProcessor = new CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor();
+  $overdueMembershipPeriodProcessor = new CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor();
   
   return civicrm_api3_create_success(
-    $OverdueMembershipPeriodProcessor->run(),
+    $overdueMembershipPeriodProcessor->run(),
     $params
   );
 }

--- a/api/v3/OverdueMembershipPeriodProcessor.php
+++ b/api/v3/OverdueMembershipPeriodProcessor.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * OverdueMembershipPeriodProcessor.run API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ */
+function civicrm_api3_overdue_membership_period_processor_run($params) {
+  $OverdueMembershipPeriodProcessor = new CRM_MembershipExtras_Job_OverdueMembershipPeriodProcessor();
+  
+  return civicrm_api3_create_success(
+    $OverdueMembershipPeriodProcessor->run(),
+    $params
+  );
+}

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -60,4 +60,17 @@ return [
       'placeholder' => ts('- select -'),
     ],
   ],
+  'membershipextras_paymentplan_days_to_disable_membership_period_with_overdue_payment' => [
+    'name' => 'membershipextras_paymentplan_days_to_disable_membership_period_with_overdue_payment',
+    'group_name' => 'MembershipExtras: Payment Plan',
+    'group' => 'membershipextras_paymentplan',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'add' => '4.7',
+    'title' => 'Days to disable membership period with overdue payment',
+    'html_type' => 'text',
+    'is_required' => FALSE,
+    'description' => 'Days after a payment is overdue that a membership period should become inactive',
+    'help_text' => 'Days after a payment is overdue that a membership period should become inactive',
+  ]
 ];


### PR DESCRIPTION
## Overview
The PR aims to add a feature to memberships and membership periods up to date by adding:
1. a new setting that allows users of the extension to set the number of days after a payment is overdue that a membership period should become inactive.
2. a scheduled job to update membership/period status when overdue by amount of days in setting

## Before
Action did not exists
![BASW-328-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-328-before-1.png)

## After
Setting has been added.
![basw-328-after-1](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-328-after-1.png)

Scheduled job has been created
![basw-328-after-2](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-328-after-2.png)