### PR TITLE
BASW-332: Upgrader

### DIFF
--- a/CRM/MembershipExtras/SettingsManager.php
+++ b/CRM/MembershipExtras/SettingsManager.php
@@ -61,4 +61,26 @@ class CRM_MembershipExtras_SettingsManager {
     ])['values'][0][$settingName];
   }
 
+  /**
+   * Gets the extension configuration fields
+   *
+   * @return array
+   */
+  public static function getConfigFields() {
+    $allowedConfigFields = self::fetchSettingFields();
+    if (!isset($allowedConfigFields) || empty($allowedConfigFields)) {
+      $result = civicrm_api3('System', 'flush');
+      if ($result['is_error'] == 0){
+        $allowedConfigFields =  self::fetchSettingFields();
+      }
+    }
+    return $allowedConfigFields;
+  }
+
+  private static function fetchSettingFields() {
+    return civicrm_api3('Setting', 'getfields',[
+      'filters' =>[ 'group' => 'membershipextras_paymentplan'],
+    ])['values'];
+  }
+
 }


### PR DESCRIPTION
This PR adds an upgrader for phase 4 that:
1. Create periods table
2. Create settings
3. Create periods for existing memberships

Periods table is already created by `sql/auto_install.sql` which runs automatically.

## Before
Upgrader did not exists
![BASW-332-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-332-before-3.png)
![BASW-332-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-332-before-2.png)
![BASW-332-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-332-before-1.png)

## After
![BASW-332-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-332-after-1.png)
![BASW-332-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-332-after-2.png)
![BASW-332-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-332-after-3.png)