### PR TITLE
BASW-220: Fix Issues When Adding Membership to Current Period

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
@@ -171,14 +171,11 @@ abstract class CRM_MembershipExtras_Form_RecurringContribution_AddLineItem exten
         $firstAmountTotal = $this->getElementValue('first_installment_amount');
         $taxRates = CRM_Core_PseudoConstant::getTaxRates();
         $rate = CRM_Utils_Array::value($recurringLineItem['financial_type_id'], $taxRates, 0);
+        $subTotal = $firstAmountTotal * $lineItemParams['qty'];
 
-        $lineItemParams['tax_amount'] = MoneyUtilities::roundToCurrencyPrecision(
-          ($firstAmountTotal * ($rate / 100)) / (1 + ($rate / 100))
-        );
-        $lineItemParams['unit_price'] = MoneyUtilities::roundToCurrencyPrecision(
-          $firstAmountTotal - $lineItemParams['tax_amount']
-        );
-        $lineItemParams['line_total'] = $lineItemParams['unit_price'];
+        $lineItemParams['unit_price'] = MoneyUtilities::roundToCurrencyPrecision($firstAmountTotal);
+        $lineItemParams['tax_amount'] = MoneyUtilities::roundToCurrencyPrecision($subTotal * ($rate / 100));
+        $lineItemParams['line_total'] = $subTotal + $lineItemParams['tax_amount'];
 
         $firstContribution = FALSE;
       }

--- a/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
@@ -171,11 +171,10 @@ abstract class CRM_MembershipExtras_Form_RecurringContribution_AddLineItem exten
         $firstAmountTotal = $this->getElementValue('first_installment_amount');
         $taxRates = CRM_Core_PseudoConstant::getTaxRates();
         $rate = CRM_Utils_Array::value($recurringLineItem['financial_type_id'], $taxRates, 0);
-        $subTotal = $firstAmountTotal * $lineItemParams['qty'];
 
         $lineItemParams['unit_price'] = MoneyUtilities::roundToCurrencyPrecision($firstAmountTotal);
-        $lineItemParams['tax_amount'] = MoneyUtilities::roundToCurrencyPrecision($subTotal * ($rate / 100));
-        $lineItemParams['line_total'] = $subTotal + $lineItemParams['tax_amount'];
+        $lineItemParams['line_total'] = MoneyUtilities::roundToCurrencyPrecision($lineItemParams['unit_price'] * $lineItemParams['qty']);
+        $lineItemParams['tax_amount'] = MoneyUtilities::roundToCurrencyPrecision($lineItemParams['line_total'] * ($rate / 100));
 
         $firstContribution = FALSE;
       }

--- a/CRM/MembershipExtras/Hook/Pre/Contribution.php
+++ b/CRM/MembershipExtras/Hook/Pre/Contribution.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Implements pre hook on Contribution entity.
+ */
+class CRM_MembershipExtras_Hook_Pre_Contribution {
+
+  /**
+   * Operation being performed.
+   *
+   * @var string
+   */
+  private $operation;
+
+  /**
+   * Current data for the contribution, if it's being updated.
+   *
+   * @var int
+   */
+  private $contributionID;
+
+  /**
+   * List of parameters that are being used to create/update the recurring
+   * contribution.
+   *
+   * @var array
+   */
+  private $params;
+
+  /**
+   * CRM_MembershipExtras_Hook_Pre_ContributionRecur constructor.
+   *
+   * @param string $op
+   * @param int $id
+   * @param array $params
+   */
+  public function __construct($op, $id, &$params) {
+    $this->operation = $op;
+    $this->contributionID = $id;
+    $this->params = &$params;
+  }
+
+  /**
+   * Pre-processes the parameters being used to create or update the recurring
+   * contribution.
+   */
+  public function preProcess() {
+    $this->rectifyAmountsBasedOnLineItems();
+  }
+
+  /**
+   * Checks if total amount is ok vs sum of line items.
+   */
+  private function rectifyAmountsBasedOnLineItems() {
+    $lineItems = $this->getContributionLineItems();
+    $totalAmount = 0;
+    $taxAmount = 0;
+
+    foreach ($lineItems as $line) {
+      $totalAmount += $line['line_total'] + $line['tax_amount'];
+      $taxAmount += $line['tax_amount'];
+    }
+
+    if ($totalAmount != $this->params['total_amount'] || $taxAmount != $this->params['tax_amount']) {
+      $this->params['total_amount'] = $totalAmount;
+      $this->params['tax_amount'] = $taxAmount;
+    }
+  }
+
+  /**
+   * Obtains list of line items for contribution.
+   */
+  private function getContributionLineItems() {
+    $result = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'contribution_id' => $this->contributionID,
+      'options' => ['limit' => 0],
+    ]);
+
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+    return [];
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -65,9 +65,8 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
    * contribution.
    */
   public function preProcess() {
-    $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor(
-      $this->recurringContribution['payment_processor_id']
-    );
+    $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $this->recurringContribution, 0);
+    $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($paymentProcessorID);
 
     if ($this->operation == 'edit' && $isManualPaymentPlan) {
       $this->rectifyPaymentPlanStatus();

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -193,6 +193,11 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
     $contributionRecurPreHook = new CRM_MembershipExtras_Hook_Pre_ContributionRecur($op, $id, $params);
     $contributionRecurPreHook->preProcess();
   }
+
+  if ($objectName === 'Contribution') {
+    $contributionPreHook = new CRM_MembershipExtras_Hook_Pre_Contribution($op, $id, $params);
+    $contributionPreHook->preProcess();
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview
Several issues were found when testing line item addition to current period of a payment plan:

1.  Tax amount is not added to the adjusted first installment amount.
![image](https://user-images.githubusercontent.com/21999940/53958080-2a51c580-40ae-11e9-9cfe-2198df633fce.png)
![image](https://user-images.githubusercontent.com/21999940/53958119-389fe180-40ae-11e9-98ac-170802e43be2.png)

2. Contribution amount gets changed to old value when it is paid/Completed. Updated amount values based on the newly added line items are not displayed.

## Before
### Tax Amount not Set When Adjusting First Installment
The amount set by the user was being used as the line item's complete total, calculating total_amount and tax_amount from it. This caused the total of the contribution to change only by the amount given by the user, as the it was assumed the value given was total + tax.

### Contribution Amount Resets to Old Value When Recording Payment
When a membership line item is added to a payment plan, this membership is added to pending contributions using default memberships price set. This price set is marked as quick_config. When recording a payment, this flag makes CiviCRM asssume a contribution only has one line item and uses the first one it finds to calculate contribution amount and tax.

## After
### Tax Amount not Set When Adjusting First Installment
Fixed by using given amount as line item total and using tax rate to calculate tax amount.

### Contribution Amount Resets to Old Value When Recording Payment
Fixed by recalculating contribution amount on Contribution's pre hook from all line items associated to the contribution.
