### PR TITLE
BASW-75: Expose Creating Recur Line Item Subscription Line As API

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -105,7 +105,11 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
    */
   public function createRemainingInstalmentContributionsUpfront() {
     $installmentsCount = (int) $this->currentRecurContribution['installments'];
-    for($contributionNumber = 2; $contributionNumber <= $installmentsCount; $contributionNumber++) {
+    // check number of contributions in  recur contribution and only create remaining
+    $contributionsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => (int) $this->currentRecurContribution['id'],
+    ]);
+    for($contributionNumber = $contributionsCount + 1; $contributionNumber <= $installmentsCount; $contributionNumber++) {
       $this->createContribution($contributionNumber);
     }
   }

--- a/api/v3/ContributionRecurLineItem.php
+++ b/api/v3/ContributionRecurLineItem.php
@@ -6,6 +6,7 @@ use CRM_MembershipExtras_ExtensionUtil as E;
  * This is used for documentation and validation.
  *
  * @param array $spec description of fields supported by this API call
+ *
  * @return void
  * @see http://wiki.civicrm.org/confluence/display/CRMDOC/API+Architecture+Standards
  */
@@ -14,11 +15,11 @@ function _civicrm_api3_contribution_recur_line_item_create_spec(&$spec) {
 }
 
 /**
- * Declare metadata for createsubscriptionline api call.
+ * Declare metadata for createsubscriptionlines api call.
  *
  * @param $spec
  */
-function _civicrm_api3_contribution_recur_line_item_createsubscriptionline_spec(&$spec) {
+function _civicrm_api3_contribution_recur_line_item_createsubscriptionlines_spec(&$spec) {
   $spec['contribution_recur_id'] = array (
     'title' => 'Contribution Recur ID',
     'type' => CRM_Utils_Type::T_INT,
@@ -30,6 +31,7 @@ function _civicrm_api3_contribution_recur_line_item_createsubscriptionline_spec(
  * ContributionRecurLineItem.create API
  *
  * @param array $params
+ *
  * @return array API result descriptor
  * @throws API_Exception
  */
@@ -38,15 +40,17 @@ function civicrm_api3_contribution_recur_line_item_create($params) {
 }
 
 /**
- * ContributionRecurLineItem.createsubscriptionline API
+ * ContributionRecurLineItem.createsubscriptionlines API
  *
  * @param array $params
+ *
  * @return array API result descriptor
  * @throws API_Exception
  */
-function civicrm_api3_contribution_recur_line_item_createsubscriptionline($params) {
+function civicrm_api3_contribution_recur_line_item_createsubscriptionlines($params) {
   $line = new CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator($params['contribution_recur_id']);
   $line->create();
+  
   return civicrm_api3_create_success();
 }
 
@@ -54,6 +58,7 @@ function civicrm_api3_contribution_recur_line_item_createsubscriptionline($param
  * ContributionRecurLineItem.delete API
  *
  * @param array $params
+ *
  * @return array API result descriptor
  * @throws API_Exception
  */
@@ -65,6 +70,7 @@ function civicrm_api3_contribution_recur_line_item_delete($params) {
  * ContributionRecurLineItem.get API
  *
  * @param array $params
+ *
  * @return array API result descriptor
  * @throws API_Exception
  */

--- a/api/v3/ContributionRecurLineItem.php
+++ b/api/v3/ContributionRecurLineItem.php
@@ -14,6 +14,19 @@ function _civicrm_api3_contribution_recur_line_item_create_spec(&$spec) {
 }
 
 /**
+ * Declare metadata for createsubscriptionline api call.
+ *
+ * @param $spec
+ */
+function _civicrm_api3_contribution_recur_line_item_createsubscriptionline_spec(&$spec) {
+  $spec['contribution_recur_id'] = array (
+    'title' => 'Contribution Recur ID',
+    'type' => CRM_Utils_Type::T_INT,
+    'api.required' => 1,
+  );
+}
+
+/**
  * ContributionRecurLineItem.create API
  *
  * @param array $params
@@ -22,6 +35,19 @@ function _civicrm_api3_contribution_recur_line_item_create_spec(&$spec) {
  */
 function civicrm_api3_contribution_recur_line_item_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+}
+
+/**
+ * ContributionRecurLineItem.createsubscriptionline API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_contribution_recur_line_item_createsubscriptionline($params) {
+  $line = new CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator($params['contribution_recur_id']);
+  $line->create();
+  return civicrm_api3_create_success();
 }
 
 /**


### PR DESCRIPTION
** Overview **
This is part of BASW-75. Most of the changes there are done on webform_civicrm. A part of the the requirement is to add a subscription line item. This PR exposes adding a subscription line as an api.
