### PR TITLE
BASW-220: Fix Calculation of Contribution Amount on Creation

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/Contribution.php
+++ b/CRM/MembershipExtras/Hook/Pre/Contribution.php
@@ -45,7 +45,9 @@ class CRM_MembershipExtras_Hook_Pre_Contribution {
    * contribution.
    */
   public function preProcess() {
-    $this->rectifyAmountsBasedOnLineItems();
+    if ($this->operation == 'edit' && $this->contributionID) {
+      $this->rectifyAmountsBasedOnLineItems();
+    }
   }
 
   /**
@@ -57,8 +59,9 @@ class CRM_MembershipExtras_Hook_Pre_Contribution {
     $taxAmount = 0;
 
     foreach ($lineItems as $line) {
-      $totalAmount += $line['line_total'] + $line['tax_amount'];
-      $taxAmount += $line['tax_amount'];
+      $lineTax = CRM_Utils_Array::value('tax_amount', $line, 0);
+      $totalAmount += $line['line_total'] + $lineTax;
+      $taxAmount += $lineTax;
     }
 
     if ($totalAmount != $this->params['total_amount'] || $taxAmount != $this->params['tax_amount']) {


### PR DESCRIPTION
## Overview
Creating memberships now caused contributions to be created with huge amounts.

## Before
When creating contributions, calculation of amount on pre-hook was using empty ID to look for line items. This caused all line items to be used to calculate amounts, causing contributions to be created with huge amounts.

## After
Fixed by only doing calculation on contribution update and if ID is not empty.