### PR TITLE
BASW-222: Fix Issues Adding Lines to Next Period

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -96,7 +96,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    */
   private function isAllowedMembershipType($membershipType, $currentLineItems) {
     foreach ($currentLineItems as $lineItem) {
-      if ($lineItem['entity_table'] != 'civicrm_membership') {
+      if ($lineItem['entity_table'] != 'civicrm_membership' || !$lineItem['auto_renew'] ) {
         continue;
       }
 
@@ -117,14 +117,18 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @return array
    */
   private function getMembershipTypeFromMembershipID($membershipID) {
-    $result = civicrm_api3('Membership', 'getsingle', [
-      'id' => $membershipID,
-      'api.MembershipType.getsingle' => [
-        'id' => '$value.membership_type_id',
-      ],
-    ]);
+    try {
+      $result = civicrm_api3('Membership', 'getsingle', [
+        'id' => $membershipID,
+        'api.MembershipType.getsingle' => [
+          'id' => '$value.membership_type_id',
+        ],
+      ]);
 
-    return $result['api.MembershipType.getsingle'];
+      return $result['api.MembershipType.getsingle'];
+    } catch (Exception $e) {
+      return [];
+    }
   }
 
   /**

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -104,6 +104,7 @@
 
         $('.totaltaxAmount').html(taxMessage);
         $('#amount_summary').html(`${membershipextrasCurrency} ${amountPerPeriod.toFixed(2)} <br/> ${taxPerPeriodMessage}`);
+        toggleStatusOfPaymentAndAutoRenewCheckboxes($('#record_contribution'));
       });
     }
 

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -33,6 +33,7 @@
     function initializeMembershipForm () {
       $('#invoice_date_summary').html($('#receive_date').val());
       selectPaymentPlanTab(togglerValue);
+      toggleStatusOfPaymentAndAutoRenewCheckboxes($('#record_contribution'));
     }
 
     /**
@@ -116,6 +117,8 @@
 
     /**
      * Adds events that enable toggling contribution/payment plan selection:
+     * - Enables/disables auto-renew checkbox if payment is going to be recorded
+     *   or not.
      * - Reloads original total amount if payment plan is selected.
      * - Changes total_amount field to readonly if payment plan is selected.
      * - Shows installments, frequency and frequency unit fields if payment plan
@@ -124,11 +127,27 @@
      * - Resets form to original state if contribution is selected.
      */
     function setupPayPlanTogglingEvents () {
+      $('#record_contribution').change(function () {
+        toggleStatusOfPaymentAndAutoRenewCheckboxes($(this));
+      });
+
       $('#payment_plan_fields_tabs li').click(function () {
         const tabOptionId = $(this).attr('data-selector');
 
         selectPaymentPlanTab(tabOptionId);
       });
+    }
+
+    /**
+     * Checks status of given checkbox and enables/disables auto-renew
+     * checkbox if checked/unchecked, respectively.
+     */
+    function toggleStatusOfPaymentAndAutoRenewCheckboxes(recordContributionCheckbox) {
+      if (recordContributionCheckbox.prop('checked')) {
+        $('#offline_auto_renew').prop('disabled', false);
+      } else {
+        $('#offline_auto_renew').prop('disabled', true);
+      }
     }
 
     /**


### PR DESCRIPTION
## Overview
Several issues were found testing the addition of line items to next period:
- Current period membership types should not be excluded in the next period, unless they are set to auto-renew.
- User should not be allowed to check "Auto-renew offline" option if "Record Membership Payment?" option is not checked, so an offline Auto-Renew should only work with "Record membership payment" checkbox
- Membership's start date gets changed to contribution's receive date for payment plans with more than one installment when recording payments.

## Before
- Do not exclude membership types not set to auto-renew: membership types used in current period were being filtered out of next period.
- Don't allow checking auto-renew if no payment is being made: Record membership payment box and auto-renew box were not linked in behaviour.
- Recording payments caused membership start date to be changed: on recording payment, CiviCRM core was updating membership's start date to the contribution's receive date.

## After
- Do not exclude membership types not set to auto-renew: added logic on back-end to include membership types that are not set to auto-renew in membership type selection combo of next period.
- Don't allow checking auto-renew if no payment is being made: added front-end logic to enable/disable auto-renew checkbox when payment plan checkbox is clicked.
- Recording payments caused membership start date to be changed: added logic to membership's Pre hook so membership start date cannot be altered unless changed in a form by a user.