### PR TITLE
BASW-212: Fix JS Errors Adding/Renewing Lines On Current Period

### DIFF
--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -409,7 +409,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
    * @return (object)
    */
   CurrentPeriodLineItemHandler.prototype.getFinancialType = function(id) {
-    return financialTypes.filter(function(financialType) {
+    return this.financialTypes.filter(function(financialType) {
       return financialType.id === id;
     })[0];
   };

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -1,5 +1,6 @@
 <script>
   var currentFinancialTypes = JSON.parse('{$financialTypes|@json_encode}');
+  var recurringContributionID = {$recurringContributionID};
 
   {literal}
   CRM.$(function () {

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -1,12 +1,12 @@
 <script>
-  var currentFinancialTypes = JSON.parse('{$financialTypes|@json_encode}');
   var recurringContributionID = {$recurringContributionID};
+  var financialTypes = {$financialTypes|@json_encode};
 
   {literal}
   CRM.$(function () {
     var formHandler = new CRM.RecurringContribution.CurrentPeriodLineItemHandler(CRM.$('#recurringContributionID').val());
     formHandler.initializeForm(CRM.$('#current-subtab'));
-    formHandler.set('financialTypes', currentFinancialTypes);
+    formHandler.set('financialTypes', financialTypes);
     formHandler.addEventHandlers();
   });
   {/literal}

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -1,7 +1,6 @@
 <script>
-var financialTypes = JSON.parse('{$financialTypes|@json_encode}');
-var membershipTypes = JSON.parse('{$membershipTypes|@json_encode}');
-var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');
+var membershipTypes = {$membershipTypes|@json_encode};
+var recurringContribution = {$recurringContribution|@json_encode};
 </script>
 <div class="right">
   Period Start Date: {$nextPeriodStartDate|date_format:"%Y-%m-%d"|crmDate}

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -1,5 +1,4 @@
 <script>
-var recurringContributionID = {$recurringContributionID};
 var financialTypes = JSON.parse('{$financialTypes|@json_encode}');
 var membershipTypes = JSON.parse('{$membershipTypes|@json_encode}');
 var recurringContribution = JSON.parse('{$recurringContribution|@json_encode}');


### PR DESCRIPTION
## Overview
When adding  new donation to a payment plan not set to auto renew, tax rate was not being shown.

## Before
Some variables that were defined on next period tab were needed for some events happening on current tab, like renewing and adding a new donation. 

## After
Fixed by adding the variables to current tab and using them within the current period handler class.
