### PR TITLE
BASW-212: Create Subscription Lines for Plans not Set to Auto-Renew

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
@@ -45,10 +45,10 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor{
     else {
       $recurContributionID = $this->createAutoRenewRecurContribution();
       $this->updateContributionRecurringContribution($recurContributionID);
+      $this->createRecurringSubscriptionLineItems($recurContributionID);
     }
 
     $this->setMembershipToAutoRenew($recurContributionID);
-    $this->createRecurringSubscriptionLineItems($recurContributionID);
 
     if ($isPaymentPlanWithAtLeastOneInstallment) {
       $this->setRecurContributionAutoRenew($recurContributionID);

--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator as RecurringContributionLineItemCreator;
+
 class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
 
   /***
@@ -29,6 +31,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
     $recurContributionID = $this->getMembershipLastRecurContributionID();
     $installmentsHandler = new CRM_MembershipExtras_Service_MembershipInstallmentsHandler($recurContributionID);
     $installmentsHandler->createRemainingInstalmentContributionsUpfront();
+    $this->createRecurringSubscriptionLineItems($recurContributionID);
   }
 
   /**
@@ -65,6 +68,17 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
     ])['values'][0]['contribution_id.contribution_recur_id'];
 
     return $recurContributionID;
+  }
+
+  /**
+   * Creates recurring contribution's line items to set up current and next
+   * periods.
+   *
+   * @param $recurContributionID
+   */
+  private function createRecurringSubscriptionLineItems($recurContributionID ) {
+    $lineItemCreator = new RecurringContributionLineItemCreator($recurContributionID);
+    $lineItemCreator->create();
   }
 
 }


### PR DESCRIPTION
## Overview
Membership with Auto-Renew as 'False' is not showing up in Manage Installment popup. No line items are displayed in the popup.

## Before
Plans that were not auto-renew didn't go into auto-renew setup psto hook, which is where line items were being created for the payment plan.

## After
Move line item creation to where recurring contributions were created, both when adding a membership and renewing.