### PR TITLE
BASW-222: Fix Issue Allowing for Creation of Line Items with Duplicate Membership Type

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -70,14 +70,14 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    *
    * @return array
    */
-  private function getAvailableMembershipTypes($currentLineItems) {
+  private function getAvailableMembershipTypes($currentLineItems, $period) {
     $memberhipTypes = civicrm_api3('MembershipType', 'get', [
       'options' => ['limit' => 0],
     ])['values'];
 
     $allowedTypes = [];
     foreach ($memberhipTypes as $type) {
-      if ($this->isAllowedMembershipType($type, $currentLineItems)) {
+      if ($this->isAllowedMembershipType($type, $currentLineItems, $period)) {
         $allowedTypes[] = $type;
       }
     }
@@ -94,9 +94,10 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    *
    * @return bool
    */
-  private function isAllowedMembershipType($membershipType, $currentLineItems) {
+  private function isAllowedMembershipType($membershipType, $currentLineItems, $period) {
     foreach ($currentLineItems as $lineItem) {
-      if ($lineItem['entity_table'] != 'civicrm_membership' || !$lineItem['auto_renew'] ) {
+      $matchAutoRenewLineItems = ($period == 'current_period') ? $lineItem['auto_renew'] : !$lineItem['auto_renew'];
+      if ($lineItem['entity_table'] != 'civicrm_membership' || $matchAutoRenewLineItems ) {
         continue;
       }
 
@@ -146,7 +147,8 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
 
     $currentPeriodLineItems = $this->getCurrentPeriodLineItems();
     $this->assign('largestMembershipEndDate', $this->getLargestMembershipEndDate($currentPeriodLineItems));
-    $this->assign('membershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems));
+    $this->assign('currentPeriodMembershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems, 'current_period'));
+    $this->assign('nextPeriodMembershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems, 'next_period'));
     $this->assign('lineItems', $currentPeriodLineItems);
 
     $nextPeriodLineItems = $this->getNextPeriodLineItems();

--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -275,7 +275,7 @@ function roundUp(num, decimalPlaces) {
  * @returns {Object}
  */
 function getMembershipType(memTypeId) { 
-  var result = CRM.$.grep(membershipTypes, function(membershipType){
+  var result = CRM.$.grep(nextPeriodMembershipTypes, function(membershipType){
     return membershipType.id == memTypeId;
   });
   

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -68,7 +68,7 @@
       <td>
         <select name="newline_membership_type" class="crm-form-select" id="newline_membership_type">
           <option value="">- {ts}select{/ts} -</option>
-          {foreach from=$membershipTypes item="membership"}
+          {foreach from=$currentPeriodMembershipTypes item="membership"}
             <option value="{$membership.id}">{$membership.name}</option>
           {/foreach}
         </select>

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -1,5 +1,5 @@
 <script>
-var membershipTypes = {$membershipTypes|@json_encode};
+var nextPeriodMembershipTypes = {$nextPeriodMembershipTypes|@json_encode};
 </script>
 <div class="right">
   Period Start Date: {$nextPeriodStartDate|date_format:"%Y-%m-%d"|crmDate}
@@ -67,7 +67,7 @@ var membershipTypes = {$membershipTypes|@json_encode};
     <td>
       <select name="newline_membership_type" class="crm-form-select" id="newMembershipItem">
         <option value="">- {ts}select{/ts} -</option>
-        {foreach from=$membershipTypes item="membership"}
+        {foreach from=$nextPeriodMembershipTypes item="membership"}
           <option value="{$membership.id}">{$membership.name}</option>
         {/foreach}
       </select>


### PR DESCRIPTION
## Overview
User is allowed to add the same membership type in Current period again, hence duplicate entries.

## Before
The two period tabs use a generic method to get their membership types which returns pretty much the same membership types irrespective of the tab.

## After
Fix by separating the call the get membership types used to populate the line item creation form of the respective tabs. When on current period, get all membership types whose organisation is not in a membership associated with the recurring contribution (set to auto renew or not).
On the next period, get pretty much the same membership types but include those whose associated recurring contribution to not set to auto renew.