### PR TITLE
PSA-212: Remove Duplicate Function 'membershipextras_civicrm_pageRun'…

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -295,22 +295,6 @@ function membershipextras_civicrm_buildForm($formName, &$form) {
 }
 
 /**
- * Implements hrcore_civicrm_pageRun.
- *
- * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_pageRun/
- */
-function membershipextras_civicrm_pageRun($page) {
-  $hooks = [
-    new CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate(),
-    new CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate(),
-    new CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate()
-  ];
-  foreach ($hooks as $hook) {
-    $hook->handle($page);
-  }
-}
-
-/**
  * Implements hook_civicrm_validateForm()
  */
 function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
@@ -384,5 +368,14 @@ function membershipextras_civicrm_pageRun($page) {
       1,
       'page-header'
     );
+  }
+  
+  $hooks = [
+    new CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate(),
+    new CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate(),
+    new CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate()
+  ];
+  foreach ($hooks as $hook) {
+    $hook->handle($page);
   }
 }


### PR DESCRIPTION
… And Merge Logic Into Single Function

## Overview
When membershipextras extension was updated in PSA dev site, the site broke. This PR fixes it.

## Technical Details
In a previous merge (while resolving conflicts probably) 
https://github.com/compucorp/uk.co.compucorp.membershipextras/commit/5e2958c95d67b7259d19e10a9a37beb49ddc319c#diff-8bf97c6a6c1e1c6f1314043ff99f698a
the function 'membershipextras_civicrm_pageRun' was added twice and so this broke PSA site after updating this extension.
In this PR the 2 methods are merged together.