### PR TITLE
RSE-75: Fix Issues on View and Edit Period Forms

### DIFF
--- a/CRM/MembershipExtras/BAO/MembershipPeriod.php
+++ b/CRM/MembershipExtras/BAO/MembershipPeriod.php
@@ -352,7 +352,7 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
 
     $evaluatedPeriodEndDate = new DateTime($evaluatedPeriod->end_date);
 
-    return $endDate >= $evaluatedPeriodStartDate && $endDate < $evaluatedPeriodEndDate;
+    return $endDate >= $evaluatedPeriodStartDate && $endDate <= $evaluatedPeriodEndDate;
   }
 
   private static function updateMembershipDates($membershipPeriod) {

--- a/CRM/MembershipExtras/Page/MembershipPeriod/ContributionList.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/ContributionList.php
@@ -1,0 +1,221 @@
+<?php
+
+use CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriodDataGenerator as ViewPeriodDataGenerator;
+
+class CRM_MembershipExtras_Page_MembershipPeriod_ContributionList extends CRM_Core_Page {
+  
+  /**
+   * ID of payment entity.
+   *
+   * @var int
+   */
+  private $periodID = NULL;
+  
+  /**
+   * ID of currenty logged contact.
+   * 
+   * @var int
+   */
+  private $contactID = NULL;
+
+  /**
+   * Builds list of contributions related to the given payment entity.
+   *CRM/MembershipExtras/Page/MembershipPeriod/ContributionList.tpl
+   * @return null
+   */
+  public function run() {
+    $this->periodID = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+    $this->contactID = $this->getLoggedContactId();
+
+    $this->loadRelatedContributions();
+
+    return parent::run();
+  }
+  
+  /**
+   * Gets logged contact's id
+   *
+   * @return int
+   */
+  private function getLoggedContactId() {
+    return CRM_Core_Session::singleton()->getLoggedInContactID();
+  }  
+
+  /**
+   * Loads contributions associated to the current recurring contribution being
+   * viewed.
+   */
+  private function loadRelatedContributions() {
+    $viewPeriodDataGenerator = new ViewPeriodDataGenerator($this->periodID);
+    $relatedContributions = $viewPeriodDataGenerator->getContributions();
+
+    foreach ($relatedContributions as &$contribution) {
+      $this->insertAmountExpandingPaymentsControl($contribution);
+      $this->fixDateFormats($contribution);
+      $this->insertStatusLabels($contribution);
+      $this->insertContributionActions($contribution);
+    }
+
+    if (count($relatedContributions) > 0) {
+      $this->assign('contributionsCount', count($relatedContributions));
+      $this->assign('relatedContributions', json_encode($relatedContributions));
+    }
+  }
+
+  /**
+   * Inserts a string into the array with the html used to show the expanding
+   * payments control, which loads when user clicks on the amount.
+   *
+   * @param array $contribution
+   *   Reference to the array holding the contribution's data and where the
+   *   control will be inserted into
+   */
+  private function insertAmountExpandingPaymentsControl(&$contribution) {
+    $amount = CRM_Utils_Money::format($contribution['total_amount'], $contribution['currency']);
+
+    $expandPaymentsUrl = CRM_Utils_System::url('civicrm/payment',
+      array(
+        'view' => 'transaction',
+        'component' => 'contribution',
+        'action' => 'browse',
+        'cid' => $this->contactID,
+        'id' => $contribution['contribution_id'],
+        'selector' => 1,
+      ),
+      FALSE, NULL, TRUE
+    );
+
+    $contribution['amount_control'] = '
+      <a class="nowrap bold crm-expand-row" title="view payments" href="' . $expandPaymentsUrl . '">
+        &nbsp; ' . $amount . '
+      </a>
+    ';
+  }
+
+  /**
+   * Fixes date fields present in the given contribution.
+   *
+   * @param array $contribution
+   *   Reference to the array holding the contribution's data
+   */
+  private function fixDateFormats(&$contribution) {
+    $config = CRM_Core_Config::singleton();
+
+    $contribution['formatted_receive_date'] = CRM_Utils_Date::customFormat($contribution['receive_date'], $config->dateformatDatetime);
+    $contribution['formatted_thankyou_date'] = CRM_Utils_Date::customFormat($contribution['thankyou_date'], $config->dateformatDatetime);
+  }
+
+  /**
+   * Inserts a contribution_status_label key into the array, with the value
+   * showing the current status plus observations on the current status.
+   *
+   * @param array $contribution
+   *   Reference to the array holding the contribution's data and where the new
+   *   position will be inserted
+   */
+  private function insertStatusLabels(&$contribution) {
+    $contribution['contribution_status_label'] = $contribution['contribution_status'];
+
+    if ($contribution['is_pay_later'] && CRM_Utils_Array::value('contribution_status', $contribution) == 'Pending') {
+      $contribution['contribution_status_label'] .= ' (' . ts('Pay Later') . ')';
+    }
+    elseif (CRM_Utils_Array::value('contribution_status', $contribution) == 'Pending') {
+      $contribution['contribution_status_label'] .= ' (' . ts('Incomplete Transaction') . ')';
+    }
+  }
+
+  /**
+   * Inserts into the given array a string with the 'action' key, holding the
+   * html to be used to show available actions for the contribution.
+   *
+   * @param $contribution
+   *   Reference to the array holding the contribution's data. It is also the
+   *   array where the new 'action' key will be inserted.
+   */
+  private function insertContributionActions(&$contribution) {
+    $contribution['action'] = CRM_Core_Action::formLink(
+      $this->buildContributionLinks($contribution),
+      $this->getContributionPermissionsMask(),
+      array(
+        'id' => $contribution['contribution_id'],
+        'cid' => $contribution['contact_id'],
+        'cxt' => 'contribution',
+      ),
+      ts('more'),
+      FALSE,
+      'contribution.selector.row',
+      'Contribution',
+      $contribution['contribution_id']
+    );
+  }
+
+  /**
+   * Builds list of links for authorized actions that can be done on given
+   * contribution.
+   *
+   * @param array $contribution
+   *
+   * @return array
+   */
+  private function buildContributionLinks($contribution) {
+    $links = CRM_Contribute_Selector_Search::links($contribution['contribution_id'],
+      CRM_Utils_Request::retrieve('action', 'String'),
+      NULL,
+      NULL
+    );
+
+    $isPayLater = FALSE;
+    if ($contribution['is_pay_later'] && CRM_Utils_Array::value('contribution_status', $contribution) == 'Pending') {
+      $isPayLater = TRUE;
+
+      $links[CRM_Core_Action::ADD] = array(
+        'name' => ts('Pay with Credit Card'),
+        'url' => 'civicrm/contact/view/contribution',
+        'qs' => 'reset=1&action=update&id=%%id%%&cid=%%cid%%&context=%%cxt%%&mode=live',
+        'title' => ts('Pay with Credit Card'),
+      );
+    }
+
+    if (in_array($contribution['contribution_status'], array('Partially paid', 'Pending refund')) || $isPayLater) {
+      $buttonName = ts('Record Payment');
+
+      if ($contribution['contribution_status'] == 'Pending refund') {
+        $buttonName = ts('Record Refund');
+      }
+      elseif (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
+        $links[CRM_Core_Action::BASIC] = array(
+          'name' => ts('Submit Credit Card payment'),
+          'url' => 'civicrm/payment/add',
+          'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution&mode=live',
+          'title' => ts('Submit Credit Card payment'),
+        );
+      }
+      $links[CRM_Core_Action::ADD] = array(
+        'name' => $buttonName,
+        'url' => 'civicrm/payment',
+        'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution',
+        'title' => $buttonName,
+      );
+    }
+
+    return $links;
+  }
+
+  /**
+   * Builds a mask with allowed contribution related permissions.
+   *
+   * @return int
+   */
+  private function getContributionPermissionsMask() {
+    $permissions = array(CRM_Core_Permission::VIEW);
+    if (CRM_Core_Permission::check('edit contributions')) {
+      $permissions[] = CRM_Core_Permission::EDIT;
+    }
+    if (CRM_Core_Permission::check('delete in CiviContribute')) {
+      $permissions[] = CRM_Core_Permission::DELETE;
+    }
+
+    return CRM_Core_Action::mask($permissions);
+  }
+  
+}

--- a/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriod.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriod.php
@@ -1,17 +1,25 @@
 <?php
 
+use CRM_MembershipExtras_ExtensionUtil as E;
 use CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriodDataGenerator as ViewPeriodDataGenerator;
 
 class CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriod extends CRM_Core_Page {
 
+  /**
+   * Period ID.
+   * 
+   * @var int
+   */
   private $periodId;
 
   public function run() {
     $this->periodId = CRM_Utils_Request::retrieve('id', 'String', $this, TRUE);
-
+    
     $viewPeriodDataGenerator = new ViewPeriodDataGenerator($this->periodId);
-    $this->assign('membershipPeriod', $viewPeriodDataGenerator->getMembershipPeriodData());
-    $this->assign('contributions', $viewPeriodDataGenerator->getContributions());
+    $periodData = $viewPeriodDataGenerator->getMembershipPeriodData();
+    
+    $this->setPageTitle($periodData);
+    $this->assign('membershipPeriod', $periodData);
     $this->assign('recurContribution', $viewPeriodDataGenerator->getRecurContributionData());
 
     $this->buildCustomGroupsView();
@@ -19,6 +27,55 @@ class CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriod extends CRM_Core_Pag
     parent::run();
   }
 
+  /**
+   * Builds the title for the page.
+   * 
+   * @param array $periodData
+   */
+  private function setPageTitle($periodData) {
+    $periodMembershipType = $periodData['membership_type_name'];
+    $periodTermNumber = $this->getPeriodTermNumber($periodData['membership_id']);
+    $pageTitle = "View $periodMembershipType - Period $periodTermNumber";
+    
+    CRM_Utils_System::setTitle(E::ts($pageTitle));
+  }
+  
+  /**
+   * Obtains term number for the current period.
+   */
+  private function getPeriodTermNumber($membershipID) {
+    $membershipPeriods = $this->getSortedMembershipPeriods($membershipID);
+    
+    $term = 1;
+    foreach ($membershipPeriods as $period) {
+      if ($period['id'] === $this->periodId) {
+        return $term;
+      }
+      
+      $term++;
+    }
+  }
+
+  /**
+   * Builds array of periods for the given membership, sorted by start date.
+   * 
+   * @param int $membershipID
+   * 
+   * @return array
+   */
+  private function getSortedMembershipPeriods($membershipID) {
+    $membershipPeriodsResult = CRM_MembershipExtras_BAO_MembershipPeriod::getOrderedMembershipPeriods($membershipID);
+
+    $membershipPeriods = [];
+    while ($membershipPeriodsResult->N && $membershipPeriodsResult->fetch()) {
+      $membershipPeriods[] = [
+        'id' => $membershipPeriodsResult->id,
+      ];
+    }
+
+    return $membershipPeriods;    
+  }
+  
   private function buildCustomGroupsView() {
     $groupTree = CRM_Core_BAO_CustomGroup::getTree('MembershipPeriod', NULL, $this->periodId);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree);

--- a/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriod.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriod.php
@@ -34,48 +34,12 @@ class CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriod extends CRM_Core_Pag
    */
   private function setPageTitle($periodData) {
     $periodMembershipType = $periodData['membership_type_name'];
-    $periodTermNumber = $this->getPeriodTermNumber($periodData['membership_id']);
+    $periodTermNumber = $periodData['term_number'];
     $pageTitle = "View $periodMembershipType - Period $periodTermNumber";
     
     CRM_Utils_System::setTitle(E::ts($pageTitle));
   }
-  
-  /**
-   * Obtains term number for the current period.
-   */
-  private function getPeriodTermNumber($membershipID) {
-    $membershipPeriods = $this->getSortedMembershipPeriods($membershipID);
-    
-    $term = 1;
-    foreach ($membershipPeriods as $period) {
-      if ($period['id'] === $this->periodId) {
-        return $term;
-      }
-      
-      $term++;
-    }
-  }
 
-  /**
-   * Builds array of periods for the given membership, sorted by start date.
-   * 
-   * @param int $membershipID
-   * 
-   * @return array
-   */
-  private function getSortedMembershipPeriods($membershipID) {
-    $membershipPeriodsResult = CRM_MembershipExtras_BAO_MembershipPeriod::getOrderedMembershipPeriods($membershipID);
-
-    $membershipPeriods = [];
-    while ($membershipPeriodsResult->N && $membershipPeriodsResult->fetch()) {
-      $membershipPeriods[] = [
-        'id' => $membershipPeriodsResult->id,
-      ];
-    }
-
-    return $membershipPeriods;    
-  }
-  
   private function buildCustomGroupsView() {
     $groupTree = CRM_Core_BAO_CustomGroup::getTree('MembershipPeriod', NULL, $this->periodId);
     CRM_Core_BAO_CustomGroup::buildCustomDataView($this, $groupTree);

--- a/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriodDataGenerator.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriodDataGenerator.php
@@ -5,6 +5,9 @@ class CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriodDataGenerator {
 
   private $periodId;
 
+  /**
+   * @var MembershipPeriod
+   */
   private $membershipPeriod;
 
   public function __construct($periodId) {
@@ -48,12 +51,14 @@ class CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriodDataGenerator {
     $membershipPeriod['membership_type_name'] = $membershipType;
     $membershipPeriod['is_active'] = $membershipPeriod['is_active'] ? ts('Yes') : ts('No');
     $membershipPeriod['is_historic'] = $membershipPeriod['is_historic'] ? ts('Yes') : ts('No');
-    
+
     $startDate = new DateTime($membershipPeriod['start_date']);
     $membershipPeriod['start_date'] = $startDate->format('Y-m-d');
 
     $endDate = new DateTime($membershipPeriod['end_date']);
     $membershipPeriod['end_date'] = $endDate->format('Y-m-d');
+
+    $membershipPeriod['term_number'] = $this->membershipPeriod->calculateTermNumber();
 
     return $membershipPeriod;
   }

--- a/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriodDataGenerator.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriodDataGenerator.php
@@ -48,6 +48,12 @@ class CRM_MembershipExtras_Page_MembershipPeriod_ViewPeriodDataGenerator {
     $membershipPeriod['membership_type_name'] = $membershipType;
     $membershipPeriod['is_active'] = $membershipPeriod['is_active'] ? ts('Yes') : ts('No');
     $membershipPeriod['is_historic'] = $membershipPeriod['is_historic'] ? ts('Yes') : ts('No');
+    
+    $startDate = new DateTime($membershipPeriod['start_date']);
+    $membershipPeriod['start_date'] = $startDate->format('Y-m-d');
+
+    $endDate = new DateTime($membershipPeriod['end_date']);
+    $membershipPeriod['end_date'] = $endDate->format('Y-m-d');
 
     return $membershipPeriod;
   }

--- a/templates/CRM/Member/Page/Tab.extra.tpl
+++ b/templates/CRM/Member/Page/Tab.extra.tpl
@@ -42,6 +42,14 @@
         $(this).toggleClass('period-extended');
         e.preventDefault();
       });
+    
+    // Refreshes memberships when a period is modified.
+    $('body').on('crmPopupFormSuccess ', function (e, data) {
+      let eventTarget = $(e.target);
+      if (eventTarget.hasClass('period-action')) {
+        CRM.refreshParent(eventTarget.closest('.dataTable'));
+      }
+    });
   });
 </script>
 {/literal}

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.hlp
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.hlp
@@ -2,8 +2,8 @@
 {ts}
 CiviCRM originally does not keep track of membership periods information.
 <br><br>
-If a period is an estimated legacy period, it means it is a membership period
-with and estimated length that covers the start date and end date of the membership
-when the membership extras extension is installed.
+If a period is an estimated legacy period, it means it is a membership period 
+with an estimated length that covers the start date and end date of the 
+membership when the membership extras extension is installed.
 {/ts}
 {/htxt}

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
@@ -1,9 +1,10 @@
 <div class="crm-block crm-form-block">
+  <input/>
     <table class="form-layout-compressed">
         <tbody>
         <tr>
             <td class="label">
-                <label>Contact</label>
+                <label id="contact_label">Contact</label>
             </td>
             <td>
                 {$contactName}
@@ -43,7 +44,8 @@
         </tr>
         <tr>
             <td class="label">
-                <label>{$form.is_historic.label} {help id="membershipextras_membershipperiod_is_historic" file="CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.hlp"}</label>
+                <label>{$form.is_historic.label}</label>
+                {help id="membershipextras_membershipperiod_is_historic" file="CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.hlp"}
             </td>
             <td>
                 {$form.is_historic.html}
@@ -55,3 +57,11 @@
         {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
 </div>
+<script type="text/javascript">
+  {literal}
+  CRM.$(function($) {
+    $('#start_date').addClass('dateplugin');
+    $('#end_date').addClass('dateplugin');
+  });
+  {/literal}
+</script>

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
@@ -1,5 +1,4 @@
 <div class="crm-block crm-form-block">
-  <input/>
     <table class="form-layout-compressed">
         <tbody>
         <tr>

--- a/templates/CRM/MembershipExtras/Page/MembershipPeriod/ContributionList.tpl
+++ b/templates/CRM/MembershipExtras/Page/MembershipPeriod/ContributionList.tpl
@@ -1,0 +1,43 @@
+<div class="crm-accordion-wrapper">
+  <div class="crm-accordion-header">{ts}Contributions{/ts}</div>
+  <div class="crm-accordion-body">
+
+  {if $contributionsCount > 0}
+    <table class="crm-contact-contributions">
+      <thead>
+      <tr>
+        <th class='crm-contact-total_amount'>{ts}Amount{/ts}</th>
+        <th class='crm-contact-financial_type_id'>{ts}Type{/ts}</th>
+        <th class='crm-contact-contribution_source'>{ts}Source{/ts}</th>
+        <th class='crm-contact-receive_date'>{ts}Recieved{/ts}</th>
+        <th class='crm-contact-thankyou_date'>{ts}Thank-you Sent{/ts}</th>
+        <th class='crm-contact-contribution_status'>{ts}Status{/ts}</th>
+        <th>&nbsp;</th>
+      </tr>
+      </thead>
+    </table>
+    <script type="text/javascript">
+      var tableData = {$relatedContributions};
+      {literal}
+      cj('table.crm-contact-contributions').DataTable({
+        data : tableData,
+        columns: [
+          { data: 'amount_control' },
+          { data: 'financial_type' },
+          { data: 'contribution_source' },
+          { data: 'formatted_receive_date' },
+          { data: 'formatted_thankyou_date' },
+          { data: 'contribution_status_label' },
+          { data: 'action' }
+        ]
+      });
+      {/literal}
+    </script>
+  {else}
+    <div class="messages status no-popup">
+      <div class="icon inform-icon"></div>
+      {ts}No contributions have been recorded for this period.{/ts}
+    </div>
+  {/if}
+  </div>
+</div>

--- a/templates/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.tpl
+++ b/templates/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.tpl
@@ -12,19 +12,19 @@
             <td>{$membershipPeriod.end_date|crmDate}</td>
             <td>
                 <span>
-                    <a href='{crmURL p="civicrm/membership/period/view" q="id=`$membershipPeriod.id`"}' class='action-item crm-hover-button' title='View Membership Period'>View</a>
-                    <a href='{crmURL p="civicrm/membership/period/edit" q="id=`$membershipPeriod.id`"}' class='action-item crm-hover-button' title='Edit Membership Period'>Edit</a>
+                    <a href='{crmURL p="civicrm/membership/period/view" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='View Membership Period'>View</a>
+                    <a href='{crmURL p="civicrm/membership/period/edit" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='Edit Membership Period'>Edit</a>
                 </span>
                 <span class="btn-slide crm-hover-button">
                     ...
                     <ul class="panel" style="display: none;">
                         {if $membershipPeriod.is_active}
                             <li>
-                                <a href='{crmURL p="civicrm/membership/period/deactivate" q="id=`$membershipPeriod.id`"}' class='action-item crm-hover-button' class="action-item crm-hover-button" title='Deactivate Membership Period'>Deactivate</a>
+                                <a href='{crmURL p="civicrm/membership/period/deactivate" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='Deactivate Membership Period'>Deactivate</a>
                             </li>
                         {else}
                             <li>
-                                <a href='{crmURL p="civicrm/membership/period/activate" q="id=`$membershipPeriod.id`"}' class='action-item crm-hover-button' class="action-item crm-hover-button" title='Activate Membership Period'>Activate</a>
+                                <a href='{crmURL p="civicrm/membership/period/activate" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='Activate Membership Period'>Activate</a>
                             </li>
                         {/if}
 

--- a/templates/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriod.tpl
+++ b/templates/CRM/MembershipExtras/Page/MembershipPeriod/ViewPeriod.tpl
@@ -43,7 +43,8 @@
         </tr>
         <tr>
             <td class="label">
-                <label>Estimated Legacy Period {help id="membershipextras_membershipperiod_is_historic" file="CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.hlp"}</label>
+                <label>Estimated Legacy Period?</label>
+                {help id="membershipextras_membershipperiod_is_historic" file="CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.hlp"}
             </td>
             <td>
                 {$membershipPeriod.is_historic}
@@ -53,108 +54,74 @@
     </table>
 
     <div id="custom-fieldset">
-        <table class="no-border">
-            <tbody>
-            <tr>
-                <td  class="section-shown form-item">
-                    <div class="crm-accordion-wrapper collapsed">
-                        <div class="crm-accordion-header">
-                            Custom Fieldset
-                        </div>
-                        <div class="crm-accordion-body" style="display: none;">
-                            {include file="CRM/Custom/Page/CustomDataView.tpl"}
-                        </div>
-                        <div class="clear"></div>
-                    </div>
-                </td>
-            </tr>
-            </tbody>
-        </table>
+        <div class="crm-accordion-wrapper collapsed">
+            <div class="crm-accordion-header">
+                Custom Fieldset
+            </div>
+            <div class="crm-accordion-body" style="display: none;">
+                {include file="CRM/Custom/Page/CustomDataView.tpl"}
+            </div>
+            <div class="clear"></div>
+        </div>
     </div>
-
-    {if !empty($contributions)}
+    
     <div id="contributions">
-        <table class="no-border">
-            <tbody>
-            <tr>
-                <td  class="section-shown form-item">
-                    <div class="crm-accordion-wrapper">
-                        <div class="crm-accordion-header">
-                            Contributions
-                        </div>
-                        <div class="crm-accordion-body" style="display: block;">
-                            <table class="crm-info-panel">
-                                <thead>
-                                <tr>
-                                    <th>Amount</th>
-                                    <th>Source</th>
-                                    <th>Received</th>
-                                    <th>Status</th>
-                                    <th></th>
-                                </tr>
-                                </thead>
-                                {foreach from=$contributions item="contribution"}
-                                    <tr>
-                                        <td>{$contribution.total_amount|crmMoney:$contribution.currency}</td>
-                                        <td>{$contribution.contribution_source}</td>
-                                        <td>{$contribution.receive_date|crmDate}</td>
-                                        <td>{$contribution.contribution_status}</td>
-                                        <td>
-                                            <a href='{crmURL p="civicrm/contact/view/contribution" q="id=`$contribution.id`&action=view"}' class='action-item crm-hover-button' title='View Contribution'>View</a>
-                                            <a href='{crmURL p="civicrm/contact/view/contribution" q="id=`$contribution.id`&action=update"}' class='action-item crm-hover-button' title='Edit Contribution'>Edit</a>
-                                        </td>
-                                    </tr>
-                                {/foreach}
-                            </table>
-                        </div>
-                        <div class="clear"></div>
-                    </div>
-                </td>
-            </tr>
-            </tbody>
-        </table>
+        <script type="text/javascript">
+          var periodID = {$membershipPeriod.id};
+
+          {literal}
+            CRM.$(function($) {
+              CRM.loadPage(
+                CRM.url(
+                  'civicrm/membership/period/related-contributions',
+                  {
+                    reset: 1,
+                    id: periodID,
+                  },
+                  'back'
+                ),
+                {
+                  target : '#contributions',
+                  dialog : false
+                }
+              );
+            });
+          {/literal}
+        </script>        
     </div>
-    {/if}
+    
 
     {if !empty($recurContribution)}
     <div id="recur-contribution">
-        <table class="no-border">
-            <tbody>
-            <tr>
-                <td  class="section-shown form-item">
-                    <div class="crm-accordion-wrapper">
-                        <div class="crm-accordion-header">
-                            Recurring Contribution
-                        </div>
-                        <div class="crm-accordion-body" style="display: block;">
-                            <table class="crm-info-panel">
-                                <thead>
-                                <tr>
-                                    <th>Amount</th>
-                                    <th>Frequency</th>
-                                    <th>Start Date</th>
-                                    <th>Installments</th>
-                                    <th></th>
-                                </tr>
-                                </thead>
-                                <tr>
-                                    <td>{$recurContribution.amount|crmMoney:$recurContribution.currency}</td>
-                                    <td>Every {$recurContribution.frequency_interval} {$recurContribution.frequency_unit|ucfirst}(s)</td>
-                                    <td>{$recurContribution.start_date|crmDate}</td>
-                                    <td>{$recurContribution.installments}</td>
-                                    <td>
-                                        <a href='{crmURL p="civicrm/contact/view/contributionrecur" q="id=`$recurContribution.id`&cid=`$recurContribution.contact_id`"}' class='action-item crm-hover-button' title='View Recur Contribution'>View</a>
-                                        <a href='{crmURL p="civicrm/contribute/updaterecur" q="crid=`$recurContribution.id`&action=update&cid=`$recurContribution.contact_id`"}' class='action-item crm-hover-button' title='Edit Recur Contribution'>Edit</a>
-                                    </td>
-                                </tr>
-                            </table>
-                        </div>
-                        <div class="clear"></div>
-                    </div>
-                </td>
-            </tr>
-            </tbody>
-        </table>
+        <div class="crm-accordion-wrapper">
+            <div class="crm-accordion-header">
+                Recurring Contributions
+            </div>
+            <div class="crm-accordion-body" style="display: block;">
+                <table class="crm-info-panel">
+                    <thead>
+                    <tr>
+                        <th>Amount</th>
+                        <th>Frequency</th>
+                        <th>Start Date</th>
+                        <th>Installments</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tr>
+                        <td>{$recurContribution.amount|crmMoney:$recurContribution.currency}</td>
+                        <td>Every {$recurContribution.frequency_interval} {$recurContribution.frequency_unit|ucfirst}(s)</td>
+                        <td>{$recurContribution.start_date|crmDate}</td>
+                        <td>{$recurContribution.installments}</td>
+                        <td>
+                            <a href='{crmURL p="civicrm/contact/view/contributionrecur" q="id=`$recurContribution.id`&cid=`$recurContribution.contact_id`"}' class='action-item crm-hover-button' title='View Recur Contribution'>View</a>
+                            <a href='{crmURL p="civicrm/contribute/updaterecur" q="crid=`$recurContribution.id`&action=update&cid=`$recurContribution.contact_id`"}' class='action-item crm-hover-button' title='Edit Recur Contribution'>Edit</a>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="clear"></div>
+        </div>
     </div>
     {/if}
 

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -72,4 +72,10 @@
     <title>Membership Period Deactivation</title>
     <access_arguments>edit memberships</access_arguments>
   </item>
+  <item>
+    <path>civicrm/membership/period/related-contributions</path>
+    <page_callback>CRM_MembershipExtras_Page_MembershipPeriod_ContributionList</page_callback>
+    <title>Membership Period Contributions</title>
+    <access_arguments>access CiviMember</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
Some problems were found when working with view/edit forms on the new membership periods entity.

## Before
View Membership: 
1. 'Estimated Legacy Period' should have a '?' in the field label. Should be 'Estimated Legacy Period ?'
2. Time value should not be displayed in Start Date & End Date fields.
3. Info message for 'Estimated Legacy Period' should be corrected as below.
4. 'Recurring Contribution' subheading should be 'Recurring Contributions'. Letter 's' is missing.
5. Can each Contribution have a tag as '(Recurring)' under each as displayed in Contribution tab view if its a recurring.
6. 'Delete' is missing for Completed contribution . Also 'More' or 3 dots option is missing for Pending contribution.
7. View Membership period heading should have 'Membership Type' & Term Details (Period 1, Period 2..) as given in mockup.
8. Updated Membership dates are reflected only after refreshing the page. Auto -refresh is not happening after Editing Membership dates.
9. Error message message content should be corrected to 
   "The new start date of this membership period overlaps with another activated membership period. please review your changes"
   instead of 
   "The new end date of this membership period overlaps with another activated membership period. please review your changes"
10. Whenever Edit is clicked, Edit Membership Period window is displayed with Calendar box of Start Date opened by default

## After
1. 'Estimated Legacy Period' now has a '?' in the field label.
1. Time value is not be displayed in Start Date & End Date fields.
1. Info message for 'Estimated Legacy Period' is corrected as per spec.
1. 'Recurring Contribution' was changed to 'Recurring Contributions'.
1. Replicated use of CiviCRM's functionality to load contributions in recurring contributions detail view, so now the "Recurring" label is added as normal.
1. Replicated use of CiviCRM's functionality to load contributions in recurring contributions detail view, so now the all actions are the same as on the contributions view.
1. View Membership period View title now has the format "[Membership Type] - Period [Term Number]".
1. Implemented auto-refresh when updating a period.
1. Error message message content was corrected to show if it is the start date or the end date which causes an overlap.
1. Whenever Edit is clicked, calendar for start date is not opened.