### PR TITLE
RSE-63: Fixing period dates when adding membership with the same type as existing one

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
+++ b/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
@@ -256,13 +256,19 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
     $membershipId = $this->membershipPayment->membership_id;
     $lastActivePeriod = CRM_MembershipExtras_BAO_MembershipPeriod::getLastActivePeriod($membershipId);
     if (!empty($lastActivePeriod) && !empty($lastActivePeriod['end_date'])) {
-      $todayDate = new DateTime();
+      $renewalDate = CRM_Utils_Request::retrieve('renewal_date', 'String');
+      if ($renewalDate) {
+        $renewalDate = (new DateTime($renewalDate))->format('Y-m-d');
+      } else {
+        $renewalDate = (new DateTime())->format('Y-m-d');
+      }
+
       $endOfLastActivePeriod = new DateTime($lastActivePeriod['end_date']);
       $endOfLastActivePeriod->add(new DateInterval('P1D'));
-      if ($endOfLastActivePeriod > $todayDate) {
+      if ($endOfLastActivePeriod->format('Y-m-d') > $renewalDate) {
         $calculatedStartDate =  $endOfLastActivePeriod->format('Y-m-d');
       } else {
-        $calculatedStartDate = $todayDate->format('Y-m-d');
+        $calculatedStartDate = $renewalDate;
       }
     } else {
       $calculatedStartDate = new DateTime($this->membership['join_date']);

--- a/CRM/MembershipExtras/Hook/Pre/MembershipCreate.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipCreate.php
@@ -93,6 +93,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipCreate {
 
     if ($membershipID) {
       $this->params['id'] = $membershipID;
+      $this->createPeriodForTheUpdatedMembershipDates();
     }
   }
 
@@ -112,6 +113,26 @@ class CRM_MembershipExtras_Hook_Pre_MembershipCreate {
     }
 
     return FALSE;
+  }
+
+  private function createPeriodForTheUpdatedMembershipDates() {
+    $newPeriodParams = [
+      'is_active' => FALSE,
+      'membership_id' => $this->params['id'],
+      'start_date' => CRM_Utils_Array::value('start_date', $this->params),
+      'end_date' => CRM_Utils_Array::value('end_date', $this->params),
+    ];
+
+    $completedStatus = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+    $relatedContributionStatus = CRM_Utils_Array::value('contribution_status_id', $this->params);
+    if ($completedStatus == $relatedContributionStatus) {
+      $newPeriodParams['is_active'] = TRUE;
+    } else {
+      unset($this->params['start_date']);
+      unset($this->params['end_date']);
+    }
+
+    CRM_MembershipExtras_BAO_MembershipPeriod::create($newPeriodParams);
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPeriodUpdater.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPeriodUpdater.php
@@ -217,8 +217,12 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPeriodUpdater {
         $periodToUpdate->start_date = $newStartDate;
         $periodToUpdate->end_date = $newEndDate;
         // we also update the membership join date to match the new start date
-        $this->membershipHookParams['join_date'] = date('Y-m-d', strtotime($this->membershipHookParams['start_date']));
-        $this->calculatedMembershipJoinDate = $newStartDate;
+        // if there are no other active periods
+        $isThereActivePeriods = !empty(MembershipPeriod::getFirstActivePeriod($this->membership['id']));
+        if (!$isThereActivePeriods) {
+          $this->membershipHookParams['join_date'] = date('Y-m-d', strtotime($this->membershipHookParams['start_date']));
+          $this->calculatedMembershipJoinDate = $newStartDate;
+        }
       }
     }
   }


### PR DESCRIPTION
## Issues

A- 
1- Create a membership with start and end dates in the past and completed contribution.,
2- Create same membership type again with today date as the new start date but keep the join date the same as the previous one and set the contribution as pending. 
3- As expected,  no new membership will be created, but the previous membership start date and end date will be updated to match the newly created one  dates even though the newly created contribution was set  pending. 

The steps above should only create an inactive membership period with the dates of the membership created at step 2. and only upon completing the contribution the membership dates should be updated as well as the period.


B- 

Doing the same steps above but instead of setting the contribution to "pending" at step 2, set it to completed will result in creating only one period from the first created membership only. there should be two periods instead one that match the first membership dates and the other match the new membership dates.

## Solution

Inside pre-create membership hook implementation, if adding a membership of the same type as existing one is discovered, a new period will be created that match the new membership dates. it will be inactive if the membership payment was set to pending or  active if it was set to completed. in pending case I also unset the end date and start date of the membership so they do not get altered since it is a pending payment,




## Other Notes

I also discovered when renewing a membership with pending contribution, the renewal date is not taken into the consideration and the new period will always be set to either today date or the previous active period end date (depending on the situation) which is not correct, so I updated the code inside MembershipPayment post hook to consider the renewal date during the calculation and use it if its set instead of today date.