### PR TITLE
RSE-62: Adding confirmation popup to period edit form and fixing the membership status update

### DIFF
--- a/CRM/MembershipExtras/BAO/MembershipPeriod.php
+++ b/CRM/MembershipExtras/BAO/MembershipPeriod.php
@@ -226,6 +226,8 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
    *
    * @param $params
    *
+   * @return CRM_MembershipExtras_DAO_MembershipPeriod
+   *
    * @throws CRM_Core_Exception
    */
   public static function updatePeriod($params) {
@@ -234,6 +236,8 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
       $membershipPeriod = self::create($params);
       $membershipPeriod->find(TRUE);
       self::updateMembershipDates($membershipPeriod);
+
+      return $membershipPeriod;
     } catch (CRM_Core_Exception $exception) {
       $transaction->rollback();
       throw $exception;

--- a/CRM/MembershipExtras/BAO/MembershipPeriod.php
+++ b/CRM/MembershipExtras/BAO/MembershipPeriod.php
@@ -235,7 +235,7 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
     try {
       $membershipPeriod = self::create($params);
       $membershipPeriod->find(TRUE);
-      self::updateMembershipDates($membershipPeriod);
+      self::updateMembershipDatesAndStatus($membershipPeriod);
 
       return $membershipPeriod;
     } catch (CRM_Core_Exception $exception) {
@@ -359,7 +359,7 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
     return $endDate >= $evaluatedPeriodStartDate && $endDate <= $evaluatedPeriodEndDate;
   }
 
-  private static function updateMembershipDates($membershipPeriod) {
+  private static function updateMembershipDatesAndStatus($membershipPeriod) {
     $membershipId = $membershipPeriod->membership_id;
     $firstActivePeriod = self::getFirstActivePeriod($membershipId);
     $lastActivePeriod = self::getLastActivePeriod($membershipId);
@@ -381,9 +381,30 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
       $params['end_date'] = $endDate;
     }
 
-    if ($joinDate || $endDate) {
+    $isTheOnlyActivePeriodDeactivated = empty($firstActivePeriod)
+      && $membershipPeriod->is_active == 0 && !self::isMembershipStatusOverridden($membershipId);
+    if ($isTheOnlyActivePeriodDeactivated) {
+      $params['status_id'] = 'Pending';
+      $params['skipStatusCal'] = 1;
+    }
+
+    if ($joinDate || $endDate || $isTheOnlyActivePeriodDeactivated) {
       civicrm_api3('Membership', 'create', $params);
     }
+  }
+
+  private static function isMembershipStatusOverridden($membershipId) {
+    $membership = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'return' => ['is_override'],
+      'id' => $membershipId,
+    ]);
+
+    if (empty($membership['values'][0]['is_override'])) {
+      return FALSE;
+    }
+
+    return TRUE;
   }
 
   public static function deleteById($id) {

--- a/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Activate.php
+++ b/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Activate.php
@@ -17,6 +17,14 @@ class CRM_MembershipExtras_Form_MembershipPeriod_Activation_Activate extends CRM
   /**
    * @inheritdoc
    */
+  public function buildQuickForm() {
+    $this->activationStatus = true;
+    parent::buildQuickForm();
+  }
+
+  /**
+   * @inheritdoc
+   */
   protected function getFormButtons() {
     return [
       [

--- a/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Deactivate.php
+++ b/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Deactivate.php
@@ -34,6 +34,14 @@ class CRM_MembershipExtras_Form_MembershipPeriod_Activation_Deactivate extends C
   /**
    * @inheritdoc
    */
+  public function buildQuickForm() {
+    $this->activationStatus = false;
+    parent::buildQuickForm();
+  }
+
+  /**
+   * @inheritdoc
+   */
   public function postProcess() {
     $transaction = new CRM_Core_Transaction();
     try {

--- a/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
+++ b/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
@@ -1,0 +1,111 @@
+<?php
+
+use CRM_MembershipExtras_Service_ContributionUtilities as ContributionUtilities;
+
+class CRM_MembershipExtras_Form_MembershipPeriod_Activation_PreChangeWarnings {
+
+  public static function checkForQuickAction($period, $newActiveStatus) {
+    return self::getValidationMessage($period, $newActiveStatus);
+  }
+
+  public static function checkForEditForm() {
+    $periodId = CRM_Utils_Request::retrieve('id', 'Integer');
+    $newActiveStatus = CRM_Utils_Request::retrieve('is_active', 'Integer');
+
+    $period = CRM_MembershipExtras_BAO_MembershipPeriod::getMembershipPeriodById($periodId);
+
+    $message['content'] = self::getValidationMessage($period, $newActiveStatus);
+    CRM_Utils_JSON::output($message);
+  }
+
+  private static function getValidationMessage($period, $newActiveStatus) {
+    $message = '';
+    $currentPeriodStatus = $period->is_active;
+
+    if ($newActiveStatus && !$currentPeriodStatus) {
+      $message = self::getActivationMessage($period);
+    }
+
+    if (!$newActiveStatus && $currentPeriodStatus) {
+      $message = self::getDeactivationMessage($period);
+    }
+
+    return $message;
+  }
+
+  public static function getActivationMessage($period) {
+    $startDate = CRM_Utils_Date::customFormat($period->start_date);
+    $endDate = CRM_Utils_Date::customFormat($period->end_date);
+
+    if (self::isPaymentStarted($period)) {
+      return "Would you like to activate membership period {$startDate} to
+        {$endDate} ?";
+    }
+
+    return "Membership period {$startDate} to {$endDate} does not
+        have any fulfilled payment. Would you still like to activate it?";
+  }
+
+  public static function getDeactivationMessage($period) {
+    $startDate = CRM_Utils_Date::customFormat($period->start_date);
+    $endDate = CRM_Utils_Date::customFormat($period->end_date);
+
+    if (self::isPaymentStarted($period)) {
+      return "Membership period {$startDate} to {$endDate}
+        has a payment in progress or is already paid. Would you still like to
+        deactivate it?";
+    }
+
+    return "Would you like to deactivate membership period {$startDate}
+        to {$endDate}? ";
+  }
+
+  /**
+   * Obtains payment entity status.
+   *
+   * @param \CRM_MembershipExtras_BAO_MembershipPeriod $period
+   *
+   * @return string
+   */
+  private static function isPaymentStarted(CRM_MembershipExtras_BAO_MembershipPeriod $period) {
+    $status = self::getPaymentEntityStatus($period->payment_entity_table, $period->entity_id);
+    $contributionStatusesValueMap = ContributionUtilities::getStatusesValueMap();
+    $statusName = CRM_Utils_Array::value($status, $contributionStatusesValueMap, '');
+
+    switch ($statusName) {
+      case 'Completed':
+      case 'In Progress':
+      case 'Partially paid':
+        $isPaymentStarted = TRUE;
+        break;
+
+      default:
+        $isPaymentStarted = FALSE;
+    }
+
+    return $isPaymentStarted;
+  }
+
+  /**
+   * Obtains the status of the payment entity associated to the given period.
+   *
+   * @param string $entityTable
+   * @param int $entityID
+   *
+   * @return string
+   */
+  private static function getPaymentEntityStatus($entityTable, $entityID) {
+    $entity = $entityTable === 'civicrm_contribution_recur' ? 'ContributionRecur' : 'Contribution';
+
+    try {
+      $paymentEntity = civicrm_api3($entity, 'getsingle', [
+        'id' => $entityID,
+      ]);
+    } catch (Exception $e) {
+      return '';
+    }
+
+    return $paymentEntity['contribution_status_id'];
+  }
+
+}

--- a/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.php
+++ b/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.php
@@ -26,6 +26,8 @@ class CRM_MembershipExtras_Form_MembershipPeriod_EditPeriod extends CRM_Core_For
   public function buildQuickForm() {
     $this->assignContactAndMembershipTypeInfoToTemplate();
 
+    $this->add('hidden', 'period_id');
+
     $this->add('datepicker', 'start_date', ts('Start Date'), '', TRUE, ['time' => FALSE]);
 
     $this->add('datepicker', 'end_date', ts('End Date'), '', TRUE, ['time' => FALSE]);
@@ -71,6 +73,7 @@ class CRM_MembershipExtras_Form_MembershipPeriod_EditPeriod extends CRM_Core_For
   }
 
   public function setDefaultValues() {
+    $defaults['period_id'] = $this->membershipPeriod->id;
     $defaults['start_date'] = $this->membershipPeriod->start_date;
     $defaults['end_date'] = $this->membershipPeriod->end_date;
     $defaults['is_active'] = !empty($this->membershipPeriod->is_active) ? TRUE : FALSE ;

--- a/api/v3/MembershipPeriod.php
+++ b/api/v3/MembershipPeriod.php
@@ -26,6 +26,23 @@ function civicrm_api3_membership_period_create($params) {
 }
 
 /**
+ * MembershipPeriod.updateperiod API
+ *
+ * @param array $params
+ * @return array API result descriptor
+ * @throws API_Exception
+ */
+function civicrm_api3_membership_period_updateperiod($params) {
+  try {
+    $updatedPeriod = CRM_MembershipExtras_BAO_MembershipPeriod::updatePeriod($params);
+    return civicrm_api3_create_success($updatedPeriod->toArray());
+  }
+  catch (CRM_Core_Exception $exception) {
+    return civicrm_api3_create_error($exception->getMessage());
+  }
+}
+
+/**
  * MembershipPeriod.delete API
  *
  * @param array $params

--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -243,15 +243,15 @@ function roundUp(num, decimalPlaces) {
 }
 
 /**
- * @param {string} memTypeId 
- * 
+ * @param {string} memTypeId
+ *
  * @returns {Object}
  */
-function getMembershipType(memTypeId) { 
+function getMembershipType(memTypeId) {
   var result = CRM.$.grep(membershipTypes, function(membershipType){
     return membershipType.id == memTypeId;
   });
-  
+
   if (result.length === 0) {
     return {};
   }
@@ -272,7 +272,7 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
       'id': lineItemData.id,
       'auto_renew': 0,
     }).done(function (lineRemovalRes) {
-      
+
       if (lineRemovalRes.is_error) {
         CRM.alert(ts('Cannot remove the last item in an order!'), null, 'error');
 
@@ -284,13 +284,13 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
           'id': lineItemData.entity_id,
           'contribution_recur_id': '',
         }).done(function (membershipUnlinkRes) {
-          
+
           if (membershipUnlinkRes.is_error) {
             CRM.alert(ts('Cannot unlink the associated membership'), null, 'alert');
 
             return;
           }
-          
+
           CRM.alert(
             ts(lineItemData.label + ' should no longer be continued in the next period.'),
             null,
@@ -353,7 +353,6 @@ function createActivity(subject, typeId) {
     'subject': subject,
     'added_by': 'admin',
   }).done(function (res) {
-    console.log(res);
     return;
   });
 }

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Activate.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Activate.tpl
@@ -1,13 +1,7 @@
 <div class="crm-block crm-form-block crm-payment-plan-cancel-form-block">
   <p>
     <strong>
-      {if $isPaymentStarted}
-        Would you like to activate membership period {$period->start_date|crmDate} to
-        {$period->end_date|crmDate}?
-      {else}
-        Membership period {$period->start_date|crmDate} to {$period->end_date|crmDate} does not
-        have any fulfilled payment. Would you still like to activate it?
-      {/if}
+      {$preChangeWarnings}
     </strong>
   </p>
   <div class="crm-submit-buttons">

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Deactivate.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/Activation/Deactivate.tpl
@@ -1,14 +1,7 @@
 <div class="crm-block crm-form-block crm-payment-plan-cancel-form-block">
   <p>
     <strong>
-      {if $isPaymentStarted}
-        Membership period {$period->start_date|crmDate} to {$period->end_date|crmDate}
-        has a payment in progress or is already paid. Would you still like to
-        deactivate it?
-      {else}
-        Would you like to deactivate membership period {$period->start_date|crmDate}
-        to {$period->end_date|crmDate}?
-      {/if}
+      {$preChangeWarnings}
     </strong>
   </p>
   <div class="crm-submit-buttons">

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
@@ -53,7 +53,8 @@
         </tbody>
     </table>
     <div class="crm-submit-buttons">
-        {include file="CRM/common/formButtons.tpl" location="bottom"}
+        {include file=
+        "CRM/common/formButtons.tpl" location="bottom"}
     </div>
 </div>
 <script type="text/javascript">
@@ -62,5 +63,66 @@
     $('#start_date').addClass('dateplugin');
     $('#end_date').addClass('dateplugin');
   });
+
+  var activeNewStatus;
+  var isActiveChanged = false;
+  var activeOriginalState = (CRM.$('#is_active:checked').length > 0) ? 1 : 0;
+  console.log(activeOriginalState);
+  CRM.$('#is_active').change(function () {
+    activeNewStatus = this.checked ? 1 : 0;
+    if (activeOriginalState != activeNewStatus) {
+      isActiveChanged = true;
+    } else {
+      isActiveChanged = false;
+    }
+  });
+
+  CRM.$('input[value="Submit"]').on('click', function(e) {
+    if (isActiveChanged) {
+      e.preventDefault();
+      var periodId = CRM.$("input[name='period_id']").val();
+      var isActive = CRM.$("#is_active").val();
+      CRM.confirm({
+        url: CRM.url("civicrm/membership/period/preactive-validation", {'id' : periodId, 'is_active' : activeNewStatus})
+      }).on('crmConfirm:yes', function() {
+        var updateParams = getUpdateApiParams();
+        CRM.api3('MembershipPeriod', 'updateperiod', updateParams, true).done(function() {
+          var redirectUrl = window.location.href;
+          if (redirectUrl.indexOf("selectedChild=member") < 0) {
+            redirectUrl += '&selectedChild=member';
+          }
+          window.location.href = redirectUrl;
+        });
+
+      });
+    }
+  });
+
+  function getUpdateApiParams() {
+    var formValues = {};
+    CRM.$.each(CRM.$('#EditPeriod').serializeArray(), function(i, field) {
+      formValues[field.name] = field.value;
+    });
+
+    var fieldsToUpdate = {
+      'start_date' : '',
+      'end_date' : '',
+      'is_active' : 0,
+      'is_historic' : 0
+    };
+
+    var apiParams = {};
+    CRM.$.each(fieldsToUpdate, function(key, value) {
+      if (!formValues[key]) {
+        apiParams[key] = fieldsToUpdate[key];
+      } else {
+        apiParams[key] = formValues[key];
+      }
+    });
+
+    apiParams['id'] = CRM.$("input[name='period_id']").val();
+
+    return apiParams;
+  }
   {/literal}
 </script>

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
@@ -53,8 +53,7 @@
         </tbody>
     </table>
     <div class="crm-submit-buttons">
-        {include file=
-        "CRM/common/formButtons.tpl" location="bottom"}
+        {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
 </div>
 <script type="text/javascript">
@@ -67,7 +66,6 @@
   var activeNewStatus;
   var isActiveChanged = false;
   var activeOriginalState = (CRM.$('#is_active:checked').length > 0) ? 1 : 0;
-  console.log(activeOriginalState);
   CRM.$('#is_active').change(function () {
     activeNewStatus = this.checked ? 1 : 0;
     if (activeOriginalState != activeNewStatus) {

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -73,6 +73,11 @@
     <access_arguments>edit memberships</access_arguments>
   </item>
   <item>
+    <path>civicrm/membership/period/preactive-validation</path>
+    <page_callback>CRM_MembershipExtras_Form_MembershipPeriod_Activation_PreChangeWarnings::checkForEditForm</page_callback>
+    <access_arguments>edit memberships</access_arguments>
+  </item>
+  <item>
     <path>civicrm/membership/period/related-contributions</path>
     <page_callback>CRM_MembershipExtras_Page_MembershipPeriod_ContributionList</page_callback>
     <title>Membership Period Contributions</title>


### PR DESCRIPTION
## Problem

1- We added a confirmation popup when activating or deactivating periods through the quick action menu, but this confirmation popup does not appear when activating or deactivating periods from the period edit form.

2- if there is only one period, then deactivating that period should set the membership status to pending if the status is not overridden.

## Solution

Both issues are fixed in this PR : 

![dsdsdsds](https://user-images.githubusercontent.com/6275540/61475452-b809bf80-a982-11e9-9692-44ea059c6cff.gif)

## Technical notes 

I added a listener to the "is active" field so it prevent the edit form submission when submit button is clicked (with preventDefault()) and show the confirmation popup using CRM.confirm().

I also added a new url "civicrm/membership/period/preactive-validation" that takes the period id and the new activation status and return the confirmation message  that is needed to be shown to the user.

I also added a new API end point to the MembershipPeriod entity called `updateperiod`, this method calls the BAO method that update both the period and the related membership dates/status.

The logic that determine the confirmation message is moved from the CRM_MembershipExtras_Form_MembershipPeriod_Activation_Base  class to a new one called CRM_MembershipExtras_Form_MembershipPeriod_Activation_PreChangeWarnings 
 