### PR TITLE
RSE-66: Adding/Implementing the (payments that should always activate membership) setting

### DIFF
--- a/CRM/MembershipExtras/BAO/MembershipPeriod.php
+++ b/CRM/MembershipExtras/BAO/MembershipPeriod.php
@@ -237,12 +237,13 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
       $membershipPeriod->find(TRUE);
       self::updateMembershipDatesAndStatus($membershipPeriod);
 
+      $transaction->commit();
+
       return $membershipPeriod;
     } catch (CRM_Core_Exception $exception) {
       $transaction->rollback();
       throw $exception;
     }
-    $transaction->commit();
   }
 
   /**

--- a/CRM/MembershipExtras/Form/PaymentPlanSettings.php
+++ b/CRM/MembershipExtras/Form/PaymentPlanSettings.php
@@ -34,6 +34,9 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
         case 'membershipextras_customgroups_to_exclude_for_autorenew':
           $this->addCustomGroupsToExcludeField($field);
           break;
+        case 'membershipextras_paymentmethods_that_always_activate_memberships':
+          $this->addPaymentMethodsThatActivateMembershipsField($field);
+          break;
         default:
           $this->addSettingField($field);
           break;
@@ -105,6 +108,38 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
     }
 
     return $customGroupsOptions;
+  }
+
+  private function addPaymentMethodsThatActivateMembershipsField($field) {
+    $paymentMethodOptions = ['' => ts('- select -')] + $this->getPaymentMethods();
+
+    $this->add(
+      $field['html_type'],
+      $field['name'],
+      ts($field['title']),
+      $paymentMethodOptions,
+      $field['is_required'],
+      $field['extra_attributes']
+    );
+  }
+
+  private function getPaymentMethods() {
+    $paymentMethods = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'return' => ['label', 'value'],
+      'option_group_id' => 'payment_instrument',
+      'is_active' => 1,
+      'options' => ['limit' => 0],
+    ]);
+
+    $paymentMethodOptions = [];
+    if (!empty($paymentMethods['values'])) {
+      foreach ($paymentMethods['values'] as $paymentMethod) {
+        $paymentMethodOptions[$paymentMethod['value']] =  $paymentMethod['label'];
+      }
+    }
+
+    return $paymentMethodOptions;
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -169,7 +169,6 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    * any pending payment should not extend the membership dates since it should
    * be already extended at the time of creating/renewal.
    * This method ensure that the extending of the membership should not happen.
-   *
    */
   private function preventExtendingAlreadyActiveAndExtendedMembership() {
     $contributionCurrentParams = $this->getContributionCurrentParams();
@@ -178,10 +177,11 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
     $contributionPreviousStatus = $this->paymentContributionPreviousParams['contribution_status'];
 
     $isCompletingPendingContribution = in_array($contributionPreviousStatus, ['Pending', 'Partially paid']) && $contributionCurrentStatus == 'Completed';
+
     $paymentMethodsThatAlwaysActivateMemberships = SettingsManager::getPaymentMethodsThatAlwaysActivateMemberships();
-    if ($isCompletingPendingContribution &&
-      (in_array($this->paymentContributionPreviousParams['payment_instrument_id'],
-        $paymentMethodsThatAlwaysActivateMemberships))) {
+    $isPaymentMethodAlwaysActivate = in_array($this->paymentContributionPreviousParams['payment_instrument_id'], $paymentMethodsThatAlwaysActivateMemberships);
+
+    if ($isCompletingPendingContribution && $isPaymentMethodAlwaysActivate) {
       unset($this->params['end_date']);
     }
 
@@ -191,6 +191,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    * The current details of the completed contribution
    * which is after its status and the other payment details
    * are changed by the payment made.
+   *
    * @return array
    */
   private function getContributionCurrentParams() {

--- a/CRM/MembershipExtras/SettingsManager.php
+++ b/CRM/MembershipExtras/SettingsManager.php
@@ -41,7 +41,7 @@ class CRM_MembershipExtras_SettingsManager {
     if (empty($daysToDisableMP)) {
       return 0;
     }
-    
+
     return $daysToDisableMP;
   }
 
@@ -67,6 +67,15 @@ class CRM_MembershipExtras_SettingsManager {
     }
 
     return $customFieldsIdsToExcludeForAutoRenew;
+  }
+
+  public static function getPaymentMethodsThatAlwaysActivateMemberships() {
+    $paymentMethods = self::getSettingValue('membershipextras_paymentmethods_that_always_activate_memberships');
+    if (empty($paymentMethods)) {
+      return [];
+    }
+
+    return $paymentMethods;
   }
 
   private static function getSettingValue($settingName) {

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -72,5 +72,21 @@ return [
     'is_required' => FALSE,
     'description' => 'Days after a payment is overdue that a membership period should become inactive',
     'help_text' => 'Days after a payment is overdue that a membership period should become inactive',
-  ]
+  ],
+  'membershipextras_paymentmethods_that_always_activate_memberships' => [
+    'name' => 'membershipextras_paymentmethods_that_always_activate_memberships',
+    'group_name' => 'MembershipExtras: Payment Plan',
+    'group' => 'membershipextras_paymentplan',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'add' => '4.7',
+    'title' => 'Payment methods that always activate memberships',
+    'html_type' => 'select',
+    'is_required' => FALSE,
+    'extra_attributes' => [
+      'class' => 'crm-select2',
+      'multiple' => 'multiple',
+      'placeholder' => ts('- select -'),
+    ],
+  ],
 ];

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
@@ -23,7 +23,14 @@
 {/htxt}
 
 {htxt id="membershipextras_customgroups_to_exclude_for_autorenew"}
-{ts}Information in selected custom groups will not be copied over to any new installments 
+{ts}Information in selected custom groups will not be copied over to any new installments
  of an existing payment plan when it auto-renew.{/ts}
 {/htxt}
 
+{htxt id="membershipextras_paymentmethods_that_always_activate_memberships-title"}
+{ts}Payment methods that always activate memberships{/ts}
+{/htxt}
+{htxt id="membershipextras_paymentmethods_that_always_activate_memberships"}
+{ts}When a membership is created using any of the payment methods specified here, Its status will be changed to "Current"
+even if the payment is still pending.{/ts}
+{/htxt}

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.tpl
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.tpl
@@ -1,13 +1,13 @@
 <div class="crm-block crm-form-block">
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
-  </div>  
+  </div>
   <table class="form-layout-compressed">
     <tbody>
       {foreach from=$settingFields item=elementName}
         <tr>
           <td class="label">
-            <label>{$form.$elementName.label} {help id=$elementName file="CRM/MembershipExtras/Form/PaymentPlanSettings.hlp"}</label>
+            {$form.$elementName.label} {help id=$elementName file="CRM/MembershipExtras/Form/PaymentPlanSettings.hlp"}
           </td>
           <td>
             {$form.$elementName.html}


### PR DESCRIPTION
A new setting is added called "**Payment methods that always activate memberships**"

![2019-07-24 19_57_41-Payment Plan Settings _ ppphase3](https://user-images.githubusercontent.com/6275540/61820695-315f5180-ae5e-11e9-8178-a939a23d4ade.png)

which allow users to select one or more payment method.

If any membership is created or renewed with such payment method then it will activate the membership as well as the newly created membership period, and completing the pending payment after that will not result in extending the membership again.

The PR is divided into two parts, the first part add the setting itself and the code that manage its storage and UI: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/180/commits/72cf1e142ed5db63037120e7831b2e72d7d23d88

and the other part implement the business logic around it : https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/180/commits/15a572ebdfb15039f7edbd684f0dab2463f70f78

and the 2nd Part, two classes are mainly affected : 

1- CRM_MembershipExtras_Hook_Post_MembershipPayment : creating a membership with payment will trigger this class, by checking the payment contribution payment_instrument_id field and checking if period attached to this payment is inactive, we can tell if the membership is created in pending status and if it created using a payment method that should activate the membership, and if both conditions apply we activate the inactive period by calling `MembershipPeriod::updatePeriod(['id' => $periodId, 'is_active' => true]);` which will automatically activate the period and the related membership as well as correct its dates and status.

2- CRM_MembershipExtras_Hook_Pre_MembershipEdit : by checking the previous and the current contribution statues we can tell if the membership edit is triggered by completing a pending or partially paid payment, and by checking the payment method and  if it match one of the configured payment methods then prevent CiviCRM from extending its end date.