### PR TITLE
RSE-62: Unify the activation/deactivation dialogs UI

### DIFF
--- a/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
+++ b/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
@@ -14,7 +14,9 @@ class CRM_MembershipExtras_Form_MembershipPeriod_Activation_PreChangeWarnings {
 
     $period = CRM_MembershipExtras_BAO_MembershipPeriod::getMembershipPeriodById($periodId);
 
-    $message['content'] = self::getValidationMessage($period, $newActiveStatus);
+    $message['content'] = '<div class="crm-form-block"><p><strong>';
+    $message['content'] .= self::getValidationMessage($period, $newActiveStatus);
+    $message['content'] .= '</p></strong></div>';
     CRM_Utils_JSON::output($message);
   }
 
@@ -47,8 +49,9 @@ class CRM_MembershipExtras_Form_MembershipPeriod_Activation_PreChangeWarnings {
   }
 
   public static function getDeactivationMessage($period) {
-    $startDate = CRM_Utils_Date::customFormat($period->start_date);
-    $endDate = CRM_Utils_Date::customFormat($period->end_date);
+    $config = CRM_Core_Config::singleton();
+    $startDate = CRM_Utils_Date::customFormat($period->start_date, $config->dateformatFull);
+    $endDate = CRM_Utils_Date::customFormat($period->end_date, $config->dateformatFull);
 
     if (self::isPaymentStarted($period)) {
       return "Membership period {$startDate} to {$endDate}

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
@@ -80,8 +80,18 @@
       e.preventDefault();
       var periodId = CRM.$("input[name='period_id']").val();
       var isActive = CRM.$("#is_active").val();
+
+      var confirmationTitle = 'Deactivate Membership Period?';
+      var confirmationButtonLabel = 'Deactivate';
+      if (activeNewStatus) {
+        confirmationTitle = 'Activate Membership Period?';
+        confirmationButtonLabel = 'Activate';
+      }
+
       CRM.confirm({
-        url: CRM.url("civicrm/membership/period/preactive-validation", {'id' : periodId, 'is_active' : activeNewStatus})
+        title : confirmationTitle,
+        url: CRM.url("civicrm/membership/period/preactive-validation", {'id' : periodId, 'is_active' : activeNewStatus}),
+        options: {no: 'Cancel', yes: confirmationButtonLabel}
       }).on('crmConfirm:yes', function() {
         var updateParams = getUpdateApiParams();
         CRM.api3('MembershipPeriod', 'updateperiod', updateParams, true).done(function() {


### PR DESCRIPTION
## Before

The activation/deactivation dialog looks different when doing it through the period edit form versus using the activation/deactivation quick-action buttons.

*Quick action button dialog*
![screenshot-5](https://user-images.githubusercontent.com/6275540/62720723-8379a880-ba02-11e9-9261-11008ecfae83.png)

*edit form dialog*
![screenshot-6](https://user-images.githubusercontent.com/6275540/62720729-85dc0280-ba02-11e9-9af3-d0a6d4ca8dee.png)


## After

UI on both dialogs look the same

![ddddd](https://user-images.githubusercontent.com/6275540/62720773-a4da9480-ba02-11e9-9d79-c984647cfddf.gif)

