### PR TITLE
RSE-80: Add help text

### DIFF
--- a/CRM/MembershipExtras/Form/PeriodRules.php
+++ b/CRM/MembershipExtras/Form/PeriodRules.php
@@ -66,7 +66,8 @@ class CRM_MembershipExtras_Form_PeriodRules extends CRM_Core_Form {
       $options[] = $this->createElement('radio', NULL, NULL, $option, $key, $attributes);
     }
 
-    $group = $this->addGroup($options, $field['name'], $field['title']);
+    $separator = isset($field['separator']) ? $field['separator'] : NULL;
+    $group = $this->addGroup($options, $field['name'], $field['title'], $separator);
     $optionEditKey = 'data-option-edit-path';
     if (!empty($attributes[$optionEditKey])) {
       $group->setAttribute($optionEditKey, $attributes[$optionEditKey]);

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -102,9 +102,12 @@ return [
     'title' => "Automatic action to take when a membership period payment is overdue",
     'html_type' => 'radio',
     'is_required' => FALSE,
-    'description' => "Automatically update a membership period when it's payment is overdue",
-    'help_text' => "Automatically update a membership period when it's payment is overdue",
+    'description' => '',
+    'help_text' => '',
     'options' => ['1' => ts('Deactivate the period'), '2' => ts('Update the period end date')],
+    'separator' => '&nbsp;<a class="helpicon" title=" Help" aria-label=" Help" href="#" onclick="CRM.help(&quot;&quot;, {
+        &quot;id&quot;:&quot;membershipextras_membership_period_rules_action_on_period_with_overdue_payment_1&quot;,&quot;file&quot;:&quot;CRM\/MembershipExtras\/Form\/PeriodRules&quot;
+      }); return false;">&nbsp;</a><br/>',
     'has_children' => TRUE,
     'show_children_only_when_true' => TRUE,
   ],

--- a/templates/CRM/MembershipExtras/Form/PeriodRules.hlp
+++ b/templates/CRM/MembershipExtras/Form/PeriodRules.hlp
@@ -1,0 +1,13 @@
+{htxt id="membershipextras_membership_period_rules_action_on_period_with_overdue_payment_1"}
+  {ts}When a period is deactivated, it is treated as it has not taken effect.
+    A deactivated period is not reflected in memberships duration.{/ts}<br /><br/>
+  {ts}E.g. If a membership has the following periods:{/ts}<br/>
+  {ts}1. 01/01/2018 - 31/12/2018, activated{/ts}<br/>
+  {ts}2. 01/01/2019 - 31/12/2019, deactivated{/ts}<br/>
+  {ts}The membership duration will be 01/01/2018 - 31/12/2018.{/ts}
+{/htxt}
+
+{htxt id="membershipextras_membership_period_rules_update_period_end_date_offset"}
+  {ts}The period end date will be set to the option selected above plus a number of days
+    specified in the offset. This can be a negative number{/ts}
+{/htxt}

--- a/templates/CRM/MembershipExtras/Form/PeriodRules.tpl
+++ b/templates/CRM/MembershipExtras/Form/PeriodRules.tpl
@@ -38,6 +38,7 @@
           <tr>
             <td class="label">
               {$form.membershipextras_membership_period_rules_update_period_end_date_offset.label}
+              {help id=membershipextras_membership_period_rules_update_period_end_date_offset file="CRM/MembershipExtras/Form/PeriodRules.hlp"}
             </td>
             <td>
               {$form.membershipextras_membership_period_rules_update_period_end_date_offset.html}


### PR DESCRIPTION
## Overview
The specs says help texts should be added to two fields on the settings page



## Before
![rse-80-before-2](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-80-before-2.png)

## After
![rse-80-after-3](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-80-after-3.png)
![rse-80-after-4](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-80-after-4.png)