### PR TITLE
RSE-80: Fix help text typo

### DIFF
--- a/templates/CRM/MembershipExtras/Form/PeriodRules.hlp
+++ b/templates/CRM/MembershipExtras/Form/PeriodRules.hlp
@@ -1,5 +1,5 @@
 {htxt id="membershipextras_membership_period_rules_action_on_period_with_overdue_payment_1"}
-  {ts}When a period is deactivated, it is treated as it has not taken effect.
+  {ts}When a period is deactivated, it will be treated as if it has not taken effect.
     A deactivated period is not reflected in memberships duration.{/ts}<br /><br/>
   {ts}E.g. If a membership has the following periods:{/ts}<br/>
   {ts}1. 01/01/2018 - 31/12/2018, activated{/ts}<br/>
@@ -9,5 +9,5 @@
 
 {htxt id="membershipextras_membership_period_rules_update_period_end_date_offset"}
   {ts}The period end date will be set to the option selected above plus a number of days
-    specified in the offset. This can be a negative number{/ts}
+    specified in the offset. This can be a negative number.{/ts}
 {/htxt}


### PR DESCRIPTION
## Overview
This PR fixes a typo issue created on #183 

Pointed out by the comments:
https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/183#issuecomment-527201924
https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/183#issuecomment-527202585

## Before
![rse-80-after-3](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-80-after-3.png)
![rse-80-after-4](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-80-after-4.png)

## After
![rse-80-after-5](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-80-after-5.png)
![rse-80-after-6](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-80-after-6.png)