### PR TITLE
RSE-62: Fix Activation Modal

### DIFF
--- a/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
+++ b/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
@@ -14,9 +14,9 @@ class CRM_MembershipExtras_Form_MembershipPeriod_Activation_PreChangeWarnings {
 
     $period = CRM_MembershipExtras_BAO_MembershipPeriod::getMembershipPeriodById($periodId);
 
-    $message['content'] = '<div class="crm-form-block"><p><strong>';
+    $message['content'] = '<p><strong>';
     $message['content'] .= self::getValidationMessage($period, $newActiveStatus);
-    $message['content'] .= '</p></strong></div>';
+    $message['content'] .= '</strong></p>';
     CRM_Utils_JSON::output($message);
   }
 

--- a/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
+++ b/CRM/MembershipExtras/Form/MembershipPeriod/Activation/PreChangeWarnings.php
@@ -36,8 +36,9 @@ class CRM_MembershipExtras_Form_MembershipPeriod_Activation_PreChangeWarnings {
   }
 
   public static function getActivationMessage($period) {
-    $startDate = CRM_Utils_Date::customFormat($period->start_date);
-    $endDate = CRM_Utils_Date::customFormat($period->end_date);
+    $config = CRM_Core_Config::singleton();
+    $startDate = CRM_Utils_Date::customFormat($period->start_date, $config->dateformatFull);
+    $endDate = CRM_Utils_Date::customFormat($period->end_date, $config->dateformatFull);
 
     if (self::isPaymentStarted($period)) {
       return "Would you like to activate membership period {$startDate} to

--- a/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
+++ b/templates/CRM/MembershipExtras/Form/MembershipPeriod/EditPeriod.tpl
@@ -134,3 +134,11 @@
   }
   {/literal}
 </script>
+<style type="text/css">
+{literal}
+  .crm-container.ui-dialog .ui-dialog-buttonset [data-op='no'] {
+    float: left;
+    margin-left: 0 !important;
+  }
+{/literal}
+</style>


### PR DESCRIPTION
## Overview
As per QA report:
1. Time value is displayed on the popup still while Activating Membership period. It looks good while doing deactivation. Please check below
2. Can you also Left align 'Cancel' button.

## Before
![rse-62-before](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-62-before.png)

## After
![rse-62-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/RSE-62-after.png)