### PR TITLE
RSE-155: Fix multiple icon issue on ajax edit form for edit membership option

### DIFF
--- a/templates/CRM/Member/Page/Tab.extra.tpl
+++ b/templates/CRM/Member/Page/Tab.extra.tpl
@@ -13,7 +13,7 @@
       }
 
       var rowMembershipId = (CRM.$(this).attr('id')).replace('crm-membership_', '');
-      var label = CRM.$('td.crm-membership-membership_type', this).html();
+      var label = CRM.$('td.crm-membership-membership_type', this).text();
       var url = '{/literal}{crmURL p="civicrm/membership/periods"}{literal}' + '?id=' + rowMembershipId;
       var expandPeriodsHTML = '<a class="nowrap bold period-expand-row membership-period-collapse-icon" href="' + url + '">' + label + '</a>';
 
@@ -42,7 +42,7 @@
         $(this).toggleClass('period-extended');
         e.preventDefault();
       });
-    
+
     // Refreshes memberships when a period is modified.
     $('body').on('crmPopupFormSuccess ', function (e, data) {
       let eventTarget = $(e.target);


### PR DESCRIPTION
## Overview
This PR fix the multiple accordion icon issue on contact membership page while clicking on edit membership link

## Before
![RSE-155-before](https://user-images.githubusercontent.com/3340537/64938595-0e5c8700-d87c-11e9-9571-681218bccec3.gif)

## After
![RSE-155-after](https://user-images.githubusercontent.com/3340537/64938601-16b4c200-d87c-11e9-9fe3-097fdd90479d.gif)

## Technical Details
For `templates/CRM/Member/Page/Tab.extra.tpl` file inside `addMembershipPeriodsView` function (which is responsible for adding icon to the membership label) while fetching **label** variable in n [this commit](https://github.com/compucorp/uk.co.compucorp.membershipextras/commit/72a4b27b#diff-849d196c322e495073d55e5ea8d3bc9aR16) the value was fetched using `.html()` function. This in return was fetching the whole HTML (including the HTML for the icons which was adding new icons for it) . 
Changing the `.html` with `.text` fixed the issue as using this only fetched the label string and not the whole HTML.
