### PR TITLE
RSE-288: Fix style issue with the periods table on membership types

### DIFF
--- a/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.php
@@ -15,14 +15,53 @@ class CRM_MembershipExtras_Page_MembershipPeriod_PeriodsTable extends CRM_Core_P
 
     $termNumber = 1;
     $membershipPeriods = [];
+
     while ($membershipPeriodEntity->N && $membershipPeriodEntity->fetch()) {
+      $isMembershipPeriodActive = $membershipPeriodEntity->is_active;
+      $links = array(
+        CRM_Core_Action::VIEW => array(
+          'name' => ts('View'),
+          'url' => 'civicrm/membership/period/view',
+          'qs' => 'id=%%id%%',
+          'title' => ts('View Membership'),
+        ),
+        CRM_Core_Action::UPDATE => array(
+          'name' => ts('Edit'),
+          'url' => 'civicrm/membership/period/edit',
+          'qs' => 'id=%%id%%',
+          'title' => ts('Edit Membership Period'),
+        ),
+        CRM_Core_Action::RENEW => array(
+          'name' => ts($isMembershipPeriodActive ? 'Activate' : 'Deactivate'),
+          'url' => 'civicrm/membership/period/' . $isMembershipPeriodActive ? 'activate' : 'deactivate',
+          'qs' => 'id=%%id%%',
+          'title' => ts($isMembershipPeriodActive ? 'Activate' : 'Deactivate' . 'Membership Period'),
+        ),
+        CRM_Core_Action::DELETE => array(
+          'name' => ts('Delete'),
+          'url' => 'civicrm/membership/period/delete',
+          'qs' => 'id=%%id%%',
+          'title' => ts('Delete Membership Period'),
+        ),
+      );
+
       $membershipPeriods[] = [
         'id' => $membershipPeriodEntity->id,
         'term_number' => $termNumber++,
-        'start_date' => $membershipPeriodEntity->start_date,
-        'end_date' => $membershipPeriodEntity->end_date,
-        'is_active' => $membershipPeriodEntity->is_active,
+        'start_date' => CRM_Utils_Date::customFormat($membershipPeriodEntity->start_date, '%Y%m%d'),
+        'end_date' => CRM_Utils_Date::customFormat($membershipPeriodEntity->end_date, '%Y%m%d'),
         'css_class' => $this->getPeriodCSSClass($membershipPeriodEntity),
+        'action' => CRM_Core_Action::formLink($links,
+          null,
+          array(
+            'id' => $membershipPeriodEntity->id,
+          ),
+          ts('more'),
+          FALSE,
+          'period.table.manage',
+          'Period Table',
+          $membershipPeriodEntity->id
+        ),
       ];
     }
 

--- a/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.php
+++ b/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.php
@@ -12,38 +12,37 @@ class CRM_MembershipExtras_Page_MembershipPeriod_PeriodsTable extends CRM_Core_P
   private function getMembershipPeriodsRows() {
     $membershipId = CRM_Utils_Request::retrieve('id', 'Positive');
     $membershipPeriodEntity = MembershipPeriod::getOrderedMembershipPeriods($membershipId);
-
     $termNumber = 1;
     $membershipPeriods = [];
 
     while ($membershipPeriodEntity->N && $membershipPeriodEntity->fetch()) {
       $isMembershipPeriodActive = $membershipPeriodEntity->is_active;
-      $links = array(
-        CRM_Core_Action::VIEW => array(
+      $links = [
+        CRM_Core_Action::VIEW => [
           'name' => ts('View'),
           'url' => 'civicrm/membership/period/view',
           'qs' => 'id=%%id%%',
           'title' => ts('View Membership'),
-        ),
-        CRM_Core_Action::UPDATE => array(
+        ],
+        CRM_Core_Action::UPDATE => [
           'name' => ts('Edit'),
           'url' => 'civicrm/membership/period/edit',
           'qs' => 'id=%%id%%',
           'title' => ts('Edit Membership Period'),
-        ),
-        CRM_Core_Action::RENEW => array(
-          'name' => ts($isMembershipPeriodActive ? 'Activate' : 'Deactivate'),
-          'url' => 'civicrm/membership/period/' . $isMembershipPeriodActive ? 'activate' : 'deactivate',
+        ],
+        CRM_Core_Action::RENEW => [
+          'name' => ts($isMembershipPeriodActive ? 'Deactivate' : 'Activate'),
+          'url' => 'civicrm/membership/period/' . $isMembershipPeriodActive ? 'deactivate' : 'activate',
           'qs' => 'id=%%id%%',
-          'title' => ts($isMembershipPeriodActive ? 'Activate' : 'Deactivate' . 'Membership Period'),
-        ),
-        CRM_Core_Action::DELETE => array(
+          'title' => ts($isMembershipPeriodActive ? 'Deactivate' : 'Activate' . 'Membership Period'),
+        ],
+        CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
           'url' => 'civicrm/membership/period/delete',
           'qs' => 'id=%%id%%',
           'title' => ts('Delete Membership Period'),
-        ),
-      );
+        ],
+      ];
 
       $membershipPeriods[] = [
         'id' => $membershipPeriodEntity->id,
@@ -53,9 +52,9 @@ class CRM_MembershipExtras_Page_MembershipPeriod_PeriodsTable extends CRM_Core_P
         'css_class' => $this->getPeriodCSSClass($membershipPeriodEntity),
         'action' => CRM_Core_Action::formLink($links,
           null,
-          array(
+          [
             'id' => $membershipPeriodEntity->id,
-          ),
+          ],
           ts('more'),
           FALSE,
           'period.table.manage',

--- a/templates/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.tpl
+++ b/templates/CRM/MembershipExtras/Page/MembershipPeriod/PeriodsTable.tpl
@@ -11,29 +11,7 @@
             <td>{$membershipPeriod.start_date|crmDate}</td>
             <td>{$membershipPeriod.end_date|crmDate}</td>
             <td>
-                <span>
-                    <a href='{crmURL p="civicrm/membership/period/view" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='View Membership Period'>View</a>
-                    <a href='{crmURL p="civicrm/membership/period/edit" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='Edit Membership Period'>Edit</a>
-                </span>
-                <span class="btn-slide crm-hover-button">
-                    ...
-                    <ul class="panel" style="display: none;">
-                        {if $membershipPeriod.is_active}
-                            <li>
-                                <a href='{crmURL p="civicrm/membership/period/deactivate" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='Deactivate Membership Period'>Deactivate</a>
-                            </li>
-                        {else}
-                            <li>
-                                <a href='{crmURL p="civicrm/membership/period/activate" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='Activate Membership Period'>Activate</a>
-                            </li>
-                        {/if}
-
-                        <li>
-                            <a href='{crmURL p="civicrm/membership/period/delete" q="id=`$membershipPeriod.id`"}' class='period-action action-item crm-hover-button' title='Delete Membership Period'>Delete</a>
-                        </li>
-                    </ul>
-
-                </span>
+              {$membershipPeriod.action}
             </td>
         </tr>
     {/foreach}


### PR DESCRIPTION
## Overview
This PR fixes the alignment and date format issue on membership types Period tables

## Before
<img width="1463" alt="Screenshot 2019-09-16 at 1 16 28 PM" src="https://user-images.githubusercontent.com/3340537/64955869-ef271f00-d8a6-11e9-8ed4-491b5d1752db.png">


## After
<img width="1467" alt="Screenshot 2019-09-16 at 5 19 19 PM" src="https://user-images.githubusercontent.com/3340537/64955884-f817f080-d8a6-11e9-9bdc-828c88727c40.png">

## Technical Details
Since the action options were added as part of HTML the indentations and newlines were adding some extra white spaces in the `view/edit` link.
So to make sure the HTML is properly sanitised for browser display and to maintain standards the action links are produced using `CRM_Core_Action::formLink`.
This changed approach fixes the extra space and misalignment of action links and dropdown

Also, for fixing date format `CRM_Utils_Date::customFormat` is used and standard date format `'%Y%m%d'` is used.

