### PR TITLE
RSE-66: Fix Message After Updating Pending Contributions

### DIFF
--- a/CRM/MembershipExtras/BAO/MembershipPeriod.php
+++ b/CRM/MembershipExtras/BAO/MembershipPeriod.php
@@ -279,6 +279,9 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
 
     $errors = [];
     $membershipPeriods = self::getOrderedMembershipPeriods($membershipID);
+    if (!isset($membershipPeriods)) {
+      return;
+    }
 
     $term = 0;
     while ($membershipPeriods->N && $membershipPeriods->fetch()) {

--- a/CRM/MembershipExtras/Hook/PostProcess/ContributionForm.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/ContributionForm.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_PostProcess_ContributionForm.
+ *
+ * Post-processes contribution form used to create, update and delete
+ * contributions.
+ */
+class CRM_MembershipExtras_Hook_PostProcess_ContributionForm {
+
+  /**
+   * Form object that is being processed.
+   *
+   * @var \CRM_Contribute_Form_Contribution
+   */
+  private $form;
+
+  /**
+   * CRM_MembershipExtras_Hook_PostProcess_ContributionForm constructor.
+   *
+   * @param \CRM_Contribute_Form_Contribution $form
+   *   Form object that is being processed.
+   */
+  public function __construct(CRM_Contribute_Form_Contribution &$form) {
+    $this->form = $form;
+  }
+
+  /**
+   * Post-processes the form.
+   */
+  public function postProcess() {
+    $isEditAction = $this->form->getAction() & CRM_Core_Action::UPDATE;
+    if (!$isEditAction) {
+      return;
+    }
+
+    $session = CRM_Core_Session::singleton();
+    $statusMessages = $session->getStatus(TRUE);
+
+    foreach ($statusMessages as $message) {
+      $message['text'] = preg_replace('/The membership End Date is [^.]+./', '', $message['text']);
+      CRM_Core_Session::setStatus(
+        $message['text'],
+        $message['title'],
+        $message['type'],
+        $message['options'] ?: []
+      );
+    }
+  }
+}

--- a/CRM/MembershipExtras/Hook/PostProcess/ContributionForm.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/ContributionForm.php
@@ -29,6 +29,13 @@ class CRM_MembershipExtras_Hook_PostProcess_ContributionForm {
    * Post-processes the form.
    */
   public function postProcess() {
+    $this->fixMembershipEndDateInRenewalNotificaiton();
+  }
+
+  /**
+   * Fixes the status message built by CiviCRM with the wrong end date.
+   */
+  private function fixMembershipEndDateInRenewalNotificaiton() {
     $isEditAction = $this->form->getAction() & CRM_Core_Action::UPDATE;
     if (!$isEditAction) {
       return;
@@ -47,4 +54,5 @@ class CRM_MembershipExtras_Hook_PostProcess_ContributionForm {
       );
     }
   }
+
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -126,7 +126,9 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
     ])['values'][0];
 
     $isPaymentPlanRecurringContribution = !empty($recurringContribution['installments']);
-    $isOfflineContribution = ManualPaymentProcessors::isManualPaymentProcessor($recurringContribution['payment_processor_id']);
+    $isOfflineContribution = ManualPaymentProcessors::isManualPaymentProcessor(
+      CRM_Utils_Array::value('payment_processor_id', $recurringContribution, NULL)
+    );
     $pendingContributionStatusId = array_search('Pending', CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name'));
     $isNonPending = !($recurringContribution['contribution_status_id'] == $pendingContributionStatusId);
     if (!empty($this->recurContributionPreviousStatus)) {
@@ -136,6 +138,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
     if ($isOfflineContribution && $isPaymentPlanRecurringContribution && $isNonPending) {
       return TRUE;
     }
+
     return FALSE;
   }
 

--- a/CRM/MembershipExtras/SettingsManager.php
+++ b/CRM/MembershipExtras/SettingsManager.php
@@ -130,7 +130,7 @@ class CRM_MembershipExtras_SettingsManager {
         'sequential' => 1,
         'return' => [$settingName],
       ]);
-      if ($result['count'] > 1) {
+      if ($result['count'] > 0) {
         return $result['values'][0][$settingName];
       }
     } catch (Exception $e) {

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -322,6 +322,11 @@ function membershipextras_civicrm_postProcess($formName, &$form) {
     $membershipTypeHook = new CRM_MembershipExtras_Hook_PostProcess_UpdateMembershipTypeColour($form);
     $membershipTypeHook->process();
   }
+
+  if ($formName === 'CRM_Contribute_Form_Contribution') {
+    $contributionFormHook = new CRM_MembershipExtras_Hook_PostProcess_ContributionForm($form);
+    $contributionFormHook->postProcess();
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview
Message shown when updating a pending contribution for a payment method set to auto-complete was erroneously informing the user that the end date of the membership was changed, by a whole period.

## Before
The message was being generated deep within CiviCRM Core when processing the Contribution Form. It erronously took the updating of the contribution as an intent to renew the memberhip, and thus calculated a new end date by extending it for a full period. Periods remained unchanged, as they should, but the message still showed the wrong date.

The new end date is calculated here:
https://github.com/MiyaNoctem/civicrm-core/blob/master///CRM/Contribute/BAO/Contribution.php#L1908-L1912

The message is built here:
https://github.com/MiyaNoctem/civicrm-core/blob/master/CRM/Contribute/Form/Contribution.php#L1736
https://github.com/MiyaNoctem/civicrm-core/blob/master//CRM/Contribute/BAO/Contribution.php#L5248-L5253

And it is added to status on session here:
https://github.com/MiyaNoctem/civicrm-core/blob/master/CRM/Contribute/Form/Contribution.php#L1777

## After
The building of the erroneous message and its addition to status in session happens all before postProcess hooks are called, so the solution uses a postProcess hoook on the Contribution form to process status messages and filter out the date.
