### PR TITLE
RSE-76: Fixing issues around membership and periods deletion

### DIFF
--- a/CRM/MembershipExtras/BAO/MembershipPeriod.php
+++ b/CRM/MembershipExtras/BAO/MembershipPeriod.php
@@ -411,6 +411,28 @@ class CRM_MembershipExtras_BAO_MembershipPeriod extends CRM_MembershipExtras_DAO
     return TRUE;
   }
 
+  /**
+   * Unlink periods linked to the specified
+   * payment entity.
+   *
+   * @param int $entityID
+   * @param int $entityTable
+   */
+  public static function unlinkPaymentEntity($entityID, $entityTable) {
+    $membershipPeriod = new self();
+    $membershipPeriod->entity_id = $entityID;
+    $membershipPeriod->payment_entity_table = $entityTable;
+    $membershipPeriod->find();
+    while ($membershipPeriod->fetch()) {
+      $processedPeriod = new self();
+      $processedPeriod->id = $membershipPeriod->id;
+      $processedPeriod->entity_id = 'NULL';
+      $processedPeriod->payment_entity_table = 'NULL';
+      $processedPeriod->save();
+    }
+
+  }
+
   public static function deleteById($id) {
     $membershipPeriod = self::getMembershipPeriodById($id);
     $membershipId = $membershipPeriod->membership_id;

--- a/CRM/MembershipExtras/Hook/Post/ContributionDelete.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionDelete.php
@@ -1,0 +1,23 @@
+<?php
+use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+
+/**
+ * Implements post-process hooks on ContributionRecur entity.
+ */
+class CRM_MembershipExtras_Hook_Post_ContributionDelete {
+
+  /**
+   * @var int
+   */
+  private $contributionId;
+
+
+  public function __construct($contributionBAO) {
+    $this->contributionId = $contributionBAO->id;
+  }
+
+  public function process() {
+    CRM_MembershipExtras_BAO_MembershipPeriod::unlinkPaymentEntity($this->contributionId, 'civicrm_contribution');
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Post/MembershipPaymentCreate.php
+++ b/CRM/MembershipExtras/Hook/Post/MembershipPaymentCreate.php
@@ -4,16 +4,9 @@ use CRM_MembershipExtras_BAO_MembershipPeriod as MembershipPeriod;
 use CRM_MembershipExtras_SettingsManager as SettingsManager;
 
 /**
- * Post processes membership payments after creation or update.
+ * Post processes membership payments after creation
  */
-class CRM_MembershipExtras_Hook_Post_MembershipPayment {
-
-  /**
-   * Operation being done on the line item
-   *
-   * @var string
-   */
-  private $operation;
+class CRM_MembershipExtras_Hook_Post_MembershipPaymentCreate {
 
   /**
    * ID of the record.
@@ -68,14 +61,10 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
   private static $paymentIds = [];
 
   /**
-   * CRM_MembershipExtras_Hook_Post_MembershipPayment constructor.
-   *
-   * @param $operation
    * @param $objectId
    * @param \CRM_Member_DAO_MembershipPayment $objectRef
    */
-  public function __construct($operation, $objectId, CRM_Member_DAO_MembershipPayment $objectRef, $periodId) {
-    $this->operation = $operation;
+  public function __construct($objectId, CRM_Member_DAO_MembershipPayment $objectRef, $periodId) {
     $this->id = $objectId;
     self::$paymentIds[] = $objectId;
     $this->membershipPayment = $objectRef;
@@ -99,15 +88,13 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
   }
 
   /**
-   * Post-processes a membership payment on creation and update.
+   * Post-processes a membership payment on creation.
    */
   public function postProcess() {
-    if ($this->operation == 'create') {
-      $this->fixRecurringLineItemMembershipReferences();
-      $this->createMissingMembershipPeriod();
-      $this->linkPaymentToMembershipPeriod();
-      $this->updateMembershipStatusBasedOnPaymentMethod();
-    }
+    $this->fixRecurringLineItemMembershipReferences();
+    $this->createMissingMembershipPeriod();
+    $this->linkPaymentToMembershipPeriod();
+    $this->updateMembershipStatusBasedOnPaymentMethod();
   }
 
   /**

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -283,8 +283,8 @@ function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef)
     $periodId = $objectId;
   }
 
-  if ($objectName == 'MembershipPayment') {
-    $membershipPaymentPostHook = new CRM_MembershipExtras_Hook_Post_MembershipPayment($op, $objectId, $objectRef, $periodId);
+  if ($objectName == 'MembershipPayment' && $op == 'create') {
+    $membershipPaymentPostHook = new CRM_MembershipExtras_Hook_Post_MembershipPaymentCreate($objectId, $objectRef, $periodId);
     $membershipPaymentPostHook->postProcess();
   }
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -292,6 +292,11 @@ function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef)
     $membershipPaymentPostHook = new CRM_MembershipExtras_Hook_Post_ContributionEdit($objectRef);
     $membershipPaymentPostHook->process();
   }
+
+  if ($objectName == 'Contribution' && $op == 'delete') {
+    $membershipPaymentPostHook = new CRM_MembershipExtras_Hook_Post_ContributionDelete($objectRef);
+    $membershipPaymentPostHook->process();
+  }
 }
 
 /**


### PR DESCRIPTION
This PR is two parts : 

1- paymentshttps://github.com/compucorp/uk.co.compucorp.membershipextras/commit/0f0f1af6fb311c6263d755caed9d02e3c028d744


In this I un-link the payment (contribution) linked to a membership period(s) in case the contribution get deleted.

2- https://github.com/compucorp/uk.co.compucorp.membershipextras/commit/a24f975b9aae92a6db5c38e78c0b79cd343ed00b

There were an issue that prevent deleting memberships when linked to a contribution caused by the MembershipPeriod hook since it get invoked on the delete operation though it is only designed to work  for the create operation, so I changed it so it only get invoked for the create operation.