### PR TITLE
RSE-71: Resolve UI issues when opening membership edit page

### DIFF
--- a/templates/CRM/Member/Page/Tab.extra.tpl
+++ b/templates/CRM/Member/Page/Tab.extra.tpl
@@ -1,55 +1,61 @@
 {literal}
 <script type="text/javascript">
-  var membershipTablesContainerIds = ['memberships', 'inactive-memberships'];
-  membershipTablesContainerIds.forEach(function (containerId) {
-    addMembershipPeriodsView(containerId);
-  });
-
-  function addMembershipPeriodsView(containerId) {
-    CRM.$('#' + containerId +' table tr').each(function (rowNumber, row) {
-      if (rowNumber == 0) {
-        // Ignoring the first row that contains the table headers
-        return;
-      }
-
-      var rowMembershipId = (CRM.$(this).attr('id')).replace('crm-membership_', '');
-      var label = CRM.$('td.crm-membership-membership_type', this).text();
-      var url = '{/literal}{crmURL p="civicrm/membership/periods"}{literal}' + '?id=' + rowMembershipId;
-      var expandPeriodsHTML = '<a class="nowrap bold period-expand-row membership-period-collapse-icon" href="' + url + '">' + label + '</a>';
-
-      CRM.$('td.crm-membership-membership_type', this).html(expandPeriodsHTML);
-    });
+  if(!CRM.$('form#Membership').html()) {
+    initializeMembershipPeriodViews();
   }
 
-  /* the code below is copied and slightly altered from CiviCRM core js/crm.expandRow.js
-    It provides the mechanism to view, hide and load the content of the membership periods
-    as a nested table.
-   */
-  CRM.$(function($) {
-    $('body')
-      .off('.periodExpandRow')
-      .on('click.periodExpandRow', 'a.period-expand-row', function(e) {
-        var $row = $(this).closest('tr');
-        if ($(this).hasClass('period-extended')) {
-          $row.next('.crm-child-row').children('td').children('div.crm-ajax-container')
-            .slideUp('fast', function() {$(this).closest('.crm-child-row').remove();});
-        } else {
-          var count = $('td', $row).length,
-            $newRow = $('<tr class="crm-child-row"><td colspan="' + count + '"><div></div></td></tr>')
-              .insertAfter($row);
-          CRM.loadPage(this.href, {target: $('div', $newRow).animate({minHeight: '3em'}, 'fast')});
-        }
-        $(this).toggleClass('period-extended');
-        e.preventDefault();
-      });
-
-    // Refreshes memberships when a period is modified.
-    $('body').on('crmPopupFormSuccess ', function (e, data) {
-      let eventTarget = $(e.target);
-      if (eventTarget.hasClass('period-action')) {
-        CRM.refreshParent(eventTarget.closest('.dataTable'));
-      }
+  function initializeMembershipPeriodViews() {
+    var membershipTablesContainerIds = ['memberships', 'inactive-memberships'];
+    membershipTablesContainerIds.forEach(function (containerId) {
+      addMembershipPeriodsView(containerId);
     });
-  });
+
+    function addMembershipPeriodsView(containerId) {
+      CRM.$('#' + containerId +' table tr').each(function (rowNumber, row) {
+        if (rowNumber == 0) {
+          // Ignoring the first row that contains the table headers
+          return;
+        }
+
+        var rowMembershipId = (CRM.$(this).attr('id')).replace('crm-membership_', '');
+        var label = CRM.$('td.crm-membership-membership_type', this).text();
+        var url = '{/literal}{crmURL p="civicrm/membership/periods"}{literal}' + '?id=' + rowMembershipId;
+        var expandPeriodsHTML = '<a class="nowrap bold period-expand-row membership-period-collapse-icon" href="' + url + '">' + label + '</a>';
+
+        CRM.$('td.crm-membership-membership_type', this).html(expandPeriodsHTML);
+      });
+    }
+
+    /* the code below is copied and slightly altered from CiviCRM core js/crm.expandRow.js
+     It provides the mechanism to view, hide and load the content of the membership periods
+     as a nested table.
+     */
+    CRM.$(function($) {
+      $('body')
+        .off('.periodExpandRow')
+        .on('click.periodExpandRow', 'a.period-expand-row', function(e) {
+          var $row = $(this).closest('tr');
+          if ($(this).hasClass('period-extended')) {
+            $row.next('.crm-child-row').children('td').children('div.crm-ajax-container')
+              .slideUp('fast', function() {$(this).closest('.crm-child-row').remove();});
+          } else {
+            var count = $('td', $row).length,
+              $newRow = $('<tr class="crm-child-row"><td colspan="' + count + '"><div></div></td></tr>')
+                .insertAfter($row);
+            CRM.loadPage(this.href, {target: $('div', $newRow).animate({minHeight: '3em'}, 'fast')});
+          }
+          $(this).toggleClass('period-extended');
+          e.preventDefault();
+        });
+
+      // Refreshes memberships when a period is modified.
+      $('body').on('crmPopupFormSuccess ', function (e, data) {
+        let eventTarget = $(e.target);
+        if (eventTarget.hasClass('period-action')) {
+          CRM.refreshParent(eventTarget.closest('.dataTable'));
+        }
+      });
+    });
+  }
 </script>
 {/literal}


### PR DESCRIPTION
## Before

In the memberships tab, if the membership edit page get open twice or after expanding the periods nested view then the date selector in date fields in the edit page will be broken and the periods view will keep getting duplicated every time the edit page is opened.

![bef](https://user-images.githubusercontent.com/6275540/65282958-e0f33000-db3e-11e9-81bc-2e59dd530ff4.gif)

## After

Because we were using the extra.tpl (https://docs.civicrm.org/dev/en/latest/framework/templates/#appending-jquery-or-other-code-to-a-template) way to add Javascript to the membership tab (to handle the periods nested view), and because the edit page and the tab view page share the same core template, the script were getting executed again and again everytime the edit page is get opened, I resolved the issue by preventing the script from running if the page that triggered it is the edit form page.

![after](https://user-images.githubusercontent.com/6275540/65283103-20218100-db3f-11e9-8f49-fb02e9a94990.gif)

