### PR TITLE
BASW-289: Do not save end date for lifetime meberships.

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
@@ -269,11 +269,24 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
       'sequential' => 1,
       'id' => $membership['id'],
       'start_date' => $this->lineItemParams['start_date'],
-      'end_date' => $this->lineItemParams['end_date'],
+      'end_date' => $this->calculateEndDateFromMembershipType(),
       'contribution_recur_id' => $this->recurringContribution['auto_renew'] ? $this->recurringContribution['id'] : '',
     ]);
 
     return array_shift($result['values']);
+  }
+
+  /**
+   * Returns NULL for lifetime membership types
+   * 
+   * @return string|NULL
+   */
+  private function calculateEndDateFromMembershipType() {
+    if ($this->membershipType['duration_unit'] == 'lifetime') {
+      return NULL;
+    }
+
+    return $this->lineItemParams['end_date'];
   }
 
   /**
@@ -314,7 +327,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
       'membership_type_id' => $this->membershipType['id'],
       'join_date' => date('YmdHis'),
       'start_date' => $this->lineItemParams['start_date'],
-      'end_date' => $this->lineItemParams['end_date'],
+      'end_date' => $this->calculateEndDateFromMembershipType(),
       'contribution_recur_id' => $autoRenew ? $this->recurringContribution['id'] : '',
     ]);
 

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -146,10 +146,12 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('periodEndDate', CRM_Utils_Array::value('end_date', $this->contribRecur));
 
     $currentPeriodLineItems = $this->getCurrentPeriodLineItems();
-    $this->assign('largestMembershipEndDate', $this->getLargestMembershipEndDate($currentPeriodLineItems));
+    $largestMembershipEndDate = $this->getLargestMembershipEndDate($currentPeriodLineItems);
+    $this->setCurrentPeriodPresentationalData($currentPeriodLineItems, $largestMembershipEndDate);
+    $this->assign('largestMembershipEndDate', $largestMembershipEndDate);
     $this->assign('currentPeriodMembershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems, 'current_period'));
     $this->assign('nextPeriodMembershipTypes', $this->getAvailableMembershipTypes($currentPeriodLineItems, 'next_period'));
-    $this->assign('lineItems', $currentPeriodLineItems);
+    $this->assign('currentPeriodLineItems', $currentPeriodLineItems);
 
     $nextPeriodLineItems = $this->getNextPeriodLineItems();
     $this->assign('showNextPeriodTab', $this->showNextPeriodTab());
@@ -328,6 +330,31 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     }
 
     return $lineItems;
+  }
+
+  /**
+   * Sets data for a line item for presentational purpose only
+   *
+   * @param array $lineItem
+   * @param string $largestMembershipEndDate
+   */
+  private function setCurrentPeriodPresentationalData(&$lineItems, $largestMembershipEndDate) {
+    foreach($lineItems as &$lineItem) {
+      if ($lineItem['entity_table'] == 'civicrm_membership') {
+        $membership = $this->getMembership($lineItem['entity_id']);
+
+        if (!isset($membership['end_date'])) {
+          $lineItem['end_date'] = NULL;
+          continue;
+        }
+
+        $membershipEndDate = new DateTime($membership['end_date']);
+        $lineItem['end_date'] = $membershipEndDate->format('Y-m-d');
+        continue;
+      }
+
+      $lineItem['end_date'] = $largestMembershipEndDate;
+    }
   }
 
   /**

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -39,14 +39,20 @@
     {assign var='taxTotal' value=0}
     {assign var='installmentTotal' value=0}
 
-    {foreach from=$lineItems item='currentItem'}
+    {foreach from=$currentPeriodLineItems item='currentItem'}
       {assign var='subTotal' value=$subTotal+$currentItem.line_total}
       {assign var='taxTotal' value=$taxTotal+$currentItem.tax_amount}
 
       <tr id="lineitem-{$currentItem.id}" data-item-data='{$currentItem|@json_encode}' class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
         <td>{$currentItem.label}</td>
         <td>{$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}</td>
-        <td>{$largestMembershipEndDate|crmDate}</td>
+        <td>
+          {if $currentItem.end_date eq NULL}
+            {ts}N/A{/ts}
+          {else}
+            {$currentItem.end_date|crmDate}
+          {/if}
+        </td>
         {if $recurringContribution.auto_renew}
           <td>
               <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />
@@ -77,7 +83,7 @@
         <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="Start Date" name="newline_start_date" type="text" value="{$currentDate}" id="newline_start_date" class="crm-form-text crm-hidden-date">
       </td>
       <td nowrap>
-        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="End Date" name="newline_end_date" type="text" value="{$largestMembershipEndDate}" id="newline_end_date" class="crm-form-text crm-hidden-date">
+        <input data-crm-datepicker="{ldelim}&quot;time&quot;:false, &quot;allowClear&quot;:false{rdelim}" aria-label="End Date" name="newline_end_date" type="text" value="{$currentItem.end_date}" id="newline_end_date" class="crm-form-text crm-hidden-date">
       </td>
       {if $recurringContribution.auto_renew}
         <td>


### PR DESCRIPTION
## Overview
On our instalment management screen, we are able to specify start date and end date when adding a membership line. The start date and end date will control two things:
1. narrowing down the instalments that the new membership line should apply to
2. setting the start date and end date of the membership

We want to avoid setting the end date of life memberships but also not taking away the ability to perform point 1 and 2 for other memberships.

## Before
![basw-289-before-1](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-289-before-1.png)

## After
![basw-289-after](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-289-after.png)
![basw-289-after-2](https://raw.githubusercontent.com/16kilobyte/screenshots/master/BASW-289-after-2.png)