### PR TITLE
CGP-1470: Disabling the ability to modify payment plan line items for the upcoming release

### DIFF
--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -59,14 +59,14 @@ class CRM_MembershipExtras_Hook_Links_RecurringContribution {
       }
     }
 
-    if ($this->isManualPaymentPlan()) {
+    /**if ($this->isManualPaymentPlan()) {
       $this->links[] = [
         'name' => 'View/Modify Future Instalments',
         'url' => 'civicrm/recurring-contribution/edit-lineitems',
         'qs' => 'reset=1&crid=%%crid%%&cid=%%cid%%&context=contribution',
         'title' => 'View/Modify Future Instalments',
       ];
-    }
+    }**/
   }
 
   /**


### PR DESCRIPTION
since there are still some issues with it and it is not important for the next release we are hiding the ability to allow users to modify payment plan line items (by commenting out the hook that add the menu). 

## Before

![2019-10-02 18_49_14-r rteertter _ ppphase3](https://user-images.githubusercontent.com/6275540/66059853-9efdbd00-e534-11e9-9cd8-79d3da019e21.png)


## After

![2019-10-02 18_48_47-r rteertter _ ppphase3](https://user-images.githubusercontent.com/6275540/66059861-a3c27100-e534-11e9-9e4b-65d96b7bc2da.png)
