### PR TITLE
CGP-1466: Fix Renewal of Plans with Only One Installment

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
@@ -29,9 +29,13 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
     }
 
     $recurContributionID = $this->getMembershipLastRecurContributionID();
-    $installmentsHandler = new CRM_MembershipExtras_Service_MembershipInstallmentsHandler($recurContributionID);
-    $installmentsHandler->createRemainingInstalmentContributionsUpfront();
     $this->createRecurringSubscriptionLineItems($recurContributionID);
+
+    $installmentsCount = CRM_Utils_Request::retrieve('installments', 'Int');
+    if ($installmentsCount > 1) {
+      $installmentsHandler = new CRM_MembershipExtras_Service_MembershipInstallmentsHandler($recurContributionID);
+      $installmentsHandler->createRemainingInstalmentContributionsUpfront();
+    }
   }
 
   /**
@@ -40,12 +44,11 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
    *
    * @return bool
    */
-  private function isPaymentPlanPayment() {
-    $installmentsCount = CRM_Utils_Request::retrieve('installments', 'Int');
+  private function isPaymentPlan() {
     $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
-    if ($isSavingContribution && $contributionIsPaymentPlan && $installmentsCount > 1) {
+    if ($isSavingContribution && $contributionIsPaymentPlan) {
       return TRUE;
     }
 

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -213,8 +213,6 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       } catch (Exception $e) {
         $transaction->rollback();
         $exceptions[] = "An error occurred renewing a payment plan with id ({$recurContribution['contribution_recur_id']}): " . $e->getMessage();
-
-        continue;
       }
 
       $transaction->commit();
@@ -224,7 +222,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       throw new CRM_Core_Exception(implode(";\n", $exceptions));
     }
   }
-  
+
   /**
    * Retunrs an array of recurring contributions that need to be renewed.
    *


### PR DESCRIPTION
## Overview
Renewal of payment plans with only one installment were failing completely.

## Before
Recurring contribution for payment plans with at least one installment (ie. > 0) were being created on first contribution's pre hook. But line items for the recurring contribution were being created only for payment plans with multiple installments (ie. > 1) on the form's postProcess hook. Payment plans with 0 or null installments had their recurring contribution and its line items created on the form's postProcess hook too. Thus, plans with only one installment never had their line items created.

## After
Refactored creation of line items for payment plans so line items are created both for single and multiple installment plans, only adding subsequent contributions for multiple installment plans.

Also fixed a bug on job renewal so that all transactions opened to renew a payment plan are committed before starting the next one, as an exception thrown on one renewal was causing all sub-sequent transactions to be rolled back.
