### PR TITLE
CGP-1466: Fix isPaymentPlanPayment Method Name

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
@@ -44,7 +44,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
    *
    * @return bool
    */
-  private function isPaymentPlan() {
+  private function isPaymentPlanPayment() {
     $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 


### PR DESCRIPTION
## Overview
Injected error by changing the method's name, but failing to do so on method calls.

## Before
Call to method and method names were different.

## After
Changed method name to original name.