### PR TITLE
CGP-1466: Fix Taxes Applied Twice to Renewal Contributions

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/Contribution.php
+++ b/CRM/MembershipExtras/Hook/Pre/Contribution.php
@@ -69,15 +69,15 @@ class CRM_MembershipExtras_Hook_Pre_Contribution {
     $calculatedTotalAmount = 0;
     $calculatedTaxAmount = 0;
     $lineItems = $this->getContributionLineItems();
+
     foreach ($lineItems as $line) {
       $lineTax = CRM_Utils_Array::value('tax_amount', $line, 0);
       $calculatedTotalAmount += $line['line_total'] + $lineTax;
       $calculatedTaxAmount += $lineTax;
     }
-    if ($calculatedTotalAmount != $givenTotalAmount || $calculatedTaxAmount != $givenTaxAmount) {
-      $this->params['total_amount'] = $calculatedTotalAmount;
-      $this->params['tax_amount'] = $calculatedTaxAmount;
-    }
+
+    $this->params['total_amount'] = $calculatedTotalAmount;
+    $this->params['tax_amount'] = $calculatedTaxAmount;
   }
 
   /**


### PR DESCRIPTION
## Overview
Renewal of payment plans resulted in the new contributions having wrong amounts, as if taxes had been applied twice.

## Before
Problem was caused by a pre hook on the Contribution entity to fix contribution amount from all line items associated to the contribution. We implemented this on this PR #157 to fix contribution's amount when adding new line items to the payment plan. 

However, adding amounts when they were not being updated caused line items to be re-calculated by CiviCRM core, using the total amount of the contribution (ie. with tax) as the total for the line item, and calculating tax again from it.

## After
Fixed by only fixing contribution totals if set.