### PR TITLE
CGP-1450: Fix Bug on Upgrader Causing Multiplication of All Line Items

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -296,6 +296,8 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       'options' => ['sort' => 'id DESC', 'limit' => 1],
       'contribution_recur_id' => $paymentPlanId,
     ]);
+
+    return $result;
   }
 
   /**


### PR DESCRIPTION
## Overview
Running upgrader on a site with many existing payment plans (over 3000) took an inordinate amount of time (over 20 min) and resulted in hundreds of thousands of line itmes to be created, all associated to a single payment plan.

## Before
Method that obtained the last installment of a payment plan, in order to fetch its line items and duplicate them for the recurring contribution, failed to return the installment's information. This caused a NULL value to be used to obtain line items by searching by contribution ID, which caused ALL line items in the system to be used for every payment plan.

## After
Fixed by returning the contribution's data so it is available to obtain line items.