### PR TITLE
CGP-1450: Fix Call to Obtain Last Installment of PP on Upgrader

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -293,12 +293,13 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     }
 
     $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
       'options' => ['sort' => 'id DESC', 'limit' => 1],
       'contribution_recur_id' => $paymentPlanId,
     ]);
 
     if ($result['count'] > 0) {
-      return $result['values'][0];
+      return array_shift($result['values']);
     }
 
     return [];


### PR DESCRIPTION
## Overview
When running upgrade, none of the payment were processed to create their recurring line items.

## Before
Call to obtain last installment was not using the 'sequential' flag, so array with results was indexed with the contribution's ID, but the method was returning the unexisting '0' index of the array.

## After
Fixed by adding the sequential flag. Also used array_shift() to obtain the first element, instead of relying on array keys.