### PR TITLE
CGP-1450: Fix Renewal of Old Plans With Multiple Installments

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -46,7 +46,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
           ccr.contribution_status_id != {$cancelledStatusID} 
           AND ccr.contribution_status_id != {$refundedStatusID}
          )
-         AND ppp.next_period IS NULL
+         AND (ppp.next_period IS NULL OR ppp.next_period = 0)
          AND msl.auto_renew = 1
          AND msl.is_removed = 0
          AND msl.end_date IS NOT NULL

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -761,11 +761,11 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    */
   private function isDuplicateLineItem($lineItem) {
     $result = civicrm_api3('LineItem', 'get', [
-      'entity_table' => $lineItem['entity_table'],
-      'entity_id' => $lineItem['entity_id'],
-      'contribution_id' => $lineItem['contribution_id'],
-      'price_field_value_id' => $lineItem['price_field_value_id'],
-      'price_field_id' => $lineItem['price_field_id'],
+      'entity_table' => CRM_Utils_Array::value('entity_table', $lineItem),
+      'entity_id' => CRM_Utils_Array::value('entity_id', $lineItem),
+      'contribution_id' => CRM_Utils_Array::value('contribution_id', $lineItem),
+      'price_field_value_id' => CRM_Utils_Array::value('price_field_value_id', $lineItem),
+      'price_field_id' => CRM_Utils_Array::value('price_field_id', $lineItem),
     ]);
 
     if ($result['count'] > 0) {

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -341,7 +341,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
      * than once.
      */
     if ($this->linesExistForPaymentPlan($paymentPlan)) {
-      $this->deleteLineITemsForPaymentPlan($paymentPlan);
+      return;
     }
 
     foreach ($lineItems as $lineItem) {
@@ -384,35 +384,6 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     }
 
     return FALSE;
-  }
-
-  /**
-   * Deletes lines for the given payment plan.
-   *
-   * @param array $paymentPlan
-   *   Payment plan's data.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function deleteLineITemsForPaymentPlan($paymentPlan) {
-    $options = [
-      'sequential' => 1,
-      'contribution_recur_id' => $paymentPlan['id'],
-      'api.LineItem.getsingle' => [
-        'id' => '$value.line_item_id',
-        'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
-      ],
-    ];
-    $result = civicrm_api3('ContributionRecurLineItem', 'get', $options);
-
-    if ($result['count'] < 1) {
-      return;
-    }
-
-    foreach ($result['values'] as $lineItem) {
-      civicrm_api3('LineItem', 'delete', ['id' => $lineItem['api.LineItem.getsingle']['id']]);
-    }
   }
 
   private function getCustomFieldId($customGroupName, $customFieldName) {

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -335,6 +335,15 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
    * @param array $lineItems
    */
   private function copyLastInstalmentLineItemsToRecurContrib($paymentPlan, $lineItems) {
+    /*
+     * If there is an exception thrown at some point, we need to make this
+     * idempotent, so line items are not duplicated if the upgrader is ran more
+     * than once.
+     */
+    if ($this->linesExistForPaymentPlan($paymentPlan)) {
+      $this->deleteLineITemsForPaymentPlan($paymentPlan);
+    }
+
     foreach ($lineItems as $lineItem) {
       unset($lineItem['id']);
       unset($lineItem['contribution_id']);
@@ -352,6 +361,60 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       civicrm_api3('LineItem', 'create', $params);
     }
   }
+
+  /**
+   * Checks if payment plan already has lines.
+   *
+   * @param array $paymentPlan
+   *   Data for the payment plan.
+   *
+   * @return bool
+   *   TRUE if it finds a line item, FALSE otherwise.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function linesExistForPaymentPlan($paymentPlan) {
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $paymentPlan['id'],
+    ]);
+
+    if ($result['count'] > 0) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Deletes lines for the given payment plan.
+   *
+   * @param array $paymentPlan
+   *   Payment plan's data.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function deleteLineITemsForPaymentPlan($paymentPlan) {
+    $options = [
+      'sequential' => 1,
+      'contribution_recur_id' => $paymentPlan['id'],
+      'api.LineItem.getsingle' => [
+        'id' => '$value.line_item_id',
+        'entity_table' => ['IS NOT NULL' => 1],
+        'entity_id' => ['IS NOT NULL' => 1]
+      ],
+    ];
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', $options);
+
+    if ($result['count'] < 1) {
+      return;
+    }
+
+    foreach ($result['values'] as $lineItem) {
+      civicrm_api3('LineItem', 'delete', ['id' => $lineItem['api.LineItem.getsingle']['id']]);
+    }
+  }
+
   private function getCustomFieldId($customGroupName, $customFieldName) {
     return civicrm_api3('CustomField', 'getvalue', [
       'return' => 'id',

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -400,8 +400,8 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
     civicrm_api3('ContributionRecur', 'create', [
       'id' => $paymentPlanId,
-      'custom_' . $nextPeriodCustomFieldId => 0,
-      'custom_' . $prevPeriodCustomFieldId => 0,
+      'custom_' . $nextPeriodCustomFieldId => 'null',
+      'custom_' . $prevPeriodCustomFieldId => 'null',
     ]);
   }
 


### PR DESCRIPTION
## OVerview
After upgrading, payment plans with multiple installments were not upgrading, even if the apparently met criteria to renew.

## Before
When upgrading, a new custom group, payment_plan_periods, is added to the recurring contribution entity. For existing payment plans, records for this new custom group are created, and initialized by setting the 'next_period' and 'prev_period' fields to 0. This caused a problem when upgrading old plans, as only plans with next_perio = NULL where being picked for auto-renew.

Problems in upgrader can cause recurring line items to be duplicated, if two simultaneous upgrade jobs are run, for example. These line items then cause exceptions to be thrown when renewing the payment plan, due to a unique key in the line items table.

## After
Implemented fix so payment plans with next_period = 0 are also picked for renewal. Also made upgrader idempotent when creating line items for recurring contributions and checking if line item already exists before creating one on renewal.
