### PR TITLE
CGP-1490: Prevent Cancelled Plans From Having Their Status Changed

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -50,13 +50,7 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
     $this->operation = $op;
     $this->recurringContribution = $this->getRecurringContribution($id);
     $this->params = &$params;
-
-    $contributionStatuses = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'contribution_status',
-    ]);
-    foreach ($contributionStatuses['values'] as $currentStatus) {
-      $this->contributionStatusValueMap[$currentStatus['name']] = $currentStatus['value'];
-    }
+    $this->contributionStatusValueMap = $this->getContributionStatusesValueMap();
   }
 
   /**
@@ -75,6 +69,24 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
       'sequential' => 1,
       'id' => $id,
     ]);
+  }
+
+  /**
+   * Builds an array mapping contribution status name's to their value.
+   *
+   * @return array
+   */
+  private function getContributionStatusesValueMap() {
+    $contributionStatuses = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'contribution_status',
+      'options' => ['limit' => 0],
+    ]);
+    $contributionStatusValueMap = [];
+    foreach ($contributionStatuses['values'] as $currentStatus) {
+      $contributionStatusValueMap[$currentStatus['name']] = $currentStatus['value'];
+    }
+
+    return $contributionStatusValueMap;
   }
 
   /**


### PR DESCRIPTION
## Overview
When running the upgrader (or the scheduled job - need to find out which one causing it) all the cancelled recurring contributions are changed to status Pending or In progress. 

## Before
When running upgrader, contributions are updated to record links between periods. Doing this was triggering a Pre hook which recalculated the payment plan's status by counting payed contributions, thus breaking cancelled payment plans and setting the as either pending or in progress.

## After
Fixed by only calculating recurring contribution status if current status is eithe Pending, In Progress or Completed.