### PR TITLE
Updating CiviCRM XML file to be compatiable with CiviCRM.org rules for publishing

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -12,10 +12,16 @@
   <version>1.0.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.13.5</ver>
+    <ver>5.13</ver>
   </compatibility>
-  <comments/>
+  <comments>
+    Supported CiviCRM versions  :
+    - 5.13.5
+  </comments>
   <civix>
     <namespace>CRM/MembershipExtras</namespace>
   </civix>
+  <urls>
+    <url desc="Documentation">https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/master/readme.md</url>
+  </urls>
 </extension>


### PR DESCRIPTION
We received the following email : 

```
This is a message from the automated release system on civicrm.org.
Congratulations on releasing version v1.0.0 of extension 'Membership Extras'.

Unfortunately we have found a few errors while processing your release:
- The Version Compatibility tag contains an incorrect value
- In info.xml, the element ("documentation") is missing or invalid.

You will need to correct these errors before we can accept this release.
```

which was sent because membershipextras is published on civicrm.org extensions directory.

In this PR I fixed these issues with the XML file
