### PR TITLE
BASW-222: Fixing an issue with the ability to add future installments

### DIFF
--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -270,20 +270,16 @@ function roundUp(num, decimalPlaces) {
 }
 
 /**
- * @param {string} memTypeId 
- * 
+ * @param {string} memTypeId
+ *
  * @returns {Object}
  */
-function getMembershipType(memTypeId) { 
-  var result = CRM.$.grep(nextPeriodMembershipTypes, function(membershipType){
-    return membershipType.id == memTypeId;
-  });
-  
-  if (result.length === 0) {
-    return {};
+function getMembershipType(memTypeId) {
+  if (memTypeId in nextPeriodMembershipTypes) {
+    return nextPeriodMembershipTypes[memTypeId];
   }
 
-  return result[0];
+  return  {};
 }
 
 function showNextPeriodLineItemRemovalConfirmation(lineItemData) {


### PR DESCRIPTION
## Problem

Users can no longer add future installments inside the manage Next
period screen, and an error in the browser console appears that says :

Invalid financial type id passed

The error is caused by getMembershipType() function inside
NextPeriodLineItemHandler.js file which use JQuery grep() method
to find the matching membership type from nextPeriodMembershipTypes
dictionary which contain the list of membership types for next period,
but grep works with arrays so the function end up returning an empty
dictionary which result in not being able to fetch the financial type
for the selected membership type and thus the error appear.

![beeefff](https://user-images.githubusercontent.com/6275540/68940716-d69a8e80-079b-11ea-83e4-fa29f07ea2f0.gif)



## Solution

I replaced the the call to JQuery grep() method with the expression (key
in Dict) to check for the existence of the membership type instead, which fixes
the issue.

![afffttt](https://user-images.githubusercontent.com/6275540/68940748-ec0fb880-079b-11ea-9cd7-177cc3ec1dd9.gif)
