### PR TITLE
BASW-222: Don't show memberships types that are already selected in next period tab

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -187,7 +187,9 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
 
     $currentPeriodLineItems = $this->getCurrentPeriodLineItems();
     $this->setCurrentLineItemMembershipTypes($currentPeriodLineItems);
-    $this->setNextLineItemMembershipTypes($currentPeriodLineItems);
+
+    $nextPeriodLineItems = $this->getNextPeriodLineItems();
+    $this->setNextLineItemMembershipTypes($nextPeriodLineItems);
 
     $this->assign('largestMembershipEndDate', $this->getLargestMembershipEndDate($currentPeriodLineItems));
 
@@ -196,7 +198,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
 
     $this->assign('lineItems', $currentPeriodLineItems);
 
-    $nextPeriodLineItems = $this->getNextPeriodLineItems();
+
     $this->assign('showNextPeriodTab', $this->showNextPeriodTab());
     $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('financialTypes', $this->financialTypes);
@@ -243,19 +245,17 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     }
   }
 
-  private function setNextLineItemMembershipTypes($currentPeriodLineItems) {
-    foreach ($currentPeriodLineItems as $lineItem) {
-      if ($lineItem['entity_table'] != 'civicrm_contribution_recur') {
-        continue;
-      }
-
+  private function setNextLineItemMembershipTypes($nextPeriodLineItems) {
+    foreach ($nextPeriodLineItems as $lineItem) {
       $typeDetails = [];
 
       $lineItemMembershipType = $this->getMembershipTypeFromPriceFieldValue($lineItem['price_field_value_id']);
-      $typeDetails['name'] = $lineItemMembershipType['name'];
-      $typeDetails['org_id'] = $lineItemMembershipType['member_of_contact_id'];
+      if (!empty($lineItemMembershipType)) {
+        $typeDetails['name'] = $lineItemMembershipType['name'];
+        $typeDetails['org_id'] = $lineItemMembershipType['member_of_contact_id'];
 
-      $this->nextLineItemMembershipTypes[] = $typeDetails;
+        $this->nextLineItemMembershipTypes[] = $typeDetails;
+      }
     }
   }
 


### PR DESCRIPTION
## Before

In "Next Period" tab, if a membership get added then it will still appear in the select list which will allow users to be able to add it again and again.

![bef](https://user-images.githubusercontent.com/6275540/69352139-4c0ecf00-0c74-11ea-8cdc-648e59069d38.gif)

## After
Already added memberships won't appear anymore in the "Next Period" tab


![aft](https://user-images.githubusercontent.com/6275540/69352162-54670a00-0c74-11ea-9d16-984f4f2a561f.gif)
