### PR TITLE
BASW-269: Fix Minor Styling Issues With ShoreDitch

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,7 +18,7 @@ div.period-dates {
 
 #currentPeriodLineItems tr.columnheader th,
 #nextPeriodLineItems tr.columnheader th {
-  white-space: nowrap;
+  line-height: 23px;
 }
 
 tr.disabled-row th,

--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,7 @@
+div.period-dates {
+  margin-bottom: 10px;
+}
+
 .crm-container a:hover .crm-i.fa-check,
 .crm-container a:hover .crm-i.fa-times,
 .crm-container a:hover .crm-i.fa-trash {
@@ -27,7 +31,15 @@ tr.rc-new-line-item input.required,
   width: 50%;
 }
 
+tr.rc-line-item td {
+  white-space: nowrap;
+}
+
 tr.rc-new-line-item td, td.confirmation-icons {
+  vertical-align: middle;
+}
+
+tr.rc-new-line-item td select.crm-form-select {
   vertical-align: middle;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -16,6 +16,11 @@ div.period-dates {
 
 }
 
+#currentPeriodLineItems tr.columnheader th,
+#nextPeriodLineItems tr.columnheader th {
+  white-space: nowrap;
+}
+
 tr.disabled-row th,
 tr.disabled-row td {
   color: #ddd !important;
@@ -28,7 +33,11 @@ tr.rc-new-line-item input.required,
 }
 
 #newline_amount, #newline_donation_amount {
-  width: 50%;
+  width: 60%;
+}
+
+#newline_donation_item {
+  width: 75%;
 }
 
 tr.rc-line-item td {

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -14,7 +14,7 @@
 </script>
 <div id="confirmLineItemDeletion" style="display: none;"></div>
 
-<div class="right">
+<div class="right period-dates">
   Period Start Date: {$periodStartDate|date_format:"%Y-%m-%d"|crmDate}
   &nbsp;&nbsp;&nbsp;
   Period End Date: {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
@@ -51,7 +51,7 @@
           <td>
               <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />
           </td>
-        {/if}&nbsp;
+        {/if}
         <td>{$currentItem.financial_type}</td>
         <td>{if $currentItem.tax_rate == 0}N/A{else}{$currentItem.tax_rate}%{/if}</td>
         <td nowrap>{$currentItem.line_total|crmMoney}</td>
@@ -83,7 +83,7 @@
         <td>
             <input name="newline_auto_renew" id="newline_auto_renew" type="checkbox" checked />&nbsp;
         </td>
-      {/if}&nbsp;
+      {/if}
       <td id="newline_financial_type"> - </td>
       <td id="newline_tax_rate" nowrap> - </td>
       <td><input name="newline_amount" id="newline_amount" class="crm-form-text"/></td>

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -21,7 +21,7 @@
 </div>
 <form>
   <input name="recurringContributionID" id="recurringContributionID" value="{$recurringContributionID}" type="hidden" />
-  <table class="selector row-highlight">
+  <table class="selector row-highlight" id="currentPeriodLineItems">
     <tbody>
     <tr class="columnheader">
       <th scope="col">{ts}Item{/ts}</th>

--- a/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/NextPeriodTab.tpl
@@ -1,7 +1,7 @@
 <script>
 var nextPeriodMembershipTypes = {$nextPeriodMembershipTypes|@json_encode};
 </script>
-<div class="right">
+<div class="right period-dates">
   Period Start Date: {$nextPeriodStartDate|date_format:"%Y-%m-%d"|crmDate}
 </div>
 <table class="selector row-highlight" id="nextPeriodLineItems">


### PR DESCRIPTION
## Overview
Some styling issues with shoreditch needed to be fixed:

1. When clicked on Add other amount on Current Tab, new line caused previous end-dates to wrap.
![image](https://user-images.githubusercontent.com/21999940/69550342-d1da9500-0f68-11ea-93a9-e853dddf4274.png)

2. Current Period - 'Select' item & 'Start Date' fields seem to be vertically misaligned.
![image](https://user-images.githubusercontent.com/21999940/69550378-df901a80-0f68-11ea-8db6-1106012103bc.png)

3. Add a gap after period start date on next period tab.
![image](https://user-images.githubusercontent.com/21999940/69550395-eb7bdc80-0f68-11ea-9dca-377b510f2c87.png)

## Before
Styling problems were found on form.

## After
Styling issues fixed.

1. When clicked on Add other amount on Current Tab, new line caused previous end-dates to wrap.
![image](https://user-images.githubusercontent.com/21999940/69551115-28949e80-0f6a-11ea-9693-4941029238bf.png)

2. Current Period - 'Select' item & 'Start Date' fields seem to be vertically misaligned.
![image](https://user-images.githubusercontent.com/21999940/69551165-406c2280-0f6a-11ea-9cbc-cad172af9ed7.png)

3. Add a gap after period start date on next period tab.
![image](https://user-images.githubusercontent.com/21999940/69551266-642f6880-0f6a-11ea-8956-c967ed901f0d.png)

