### PR TITLE
MAE-169: Fix Copying of Donation Line Items to Contributions on Renewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -127,7 +127,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $this->copyRecurringLineItems($currentRecurContribution, $newRecurringContribution);
     $this->updateRecurringContributionAmount($newRecurringContribution['id']);
 
-    // The new recurring contribution is now the current one.
     $this->newRecurringContribution = $newRecurringContribution;
     $this->newRecurringContributionID = $newRecurringContribution['id'];
   }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -74,7 +74,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
    */
   public function renew() {
     $this->createRecurringContribution();
-    $this->renewPaymentPlanMemberships();
+    $this->renewPaymentPlanMemberships($this->newRecurringContributionID);
     $this->buildLineItemsParams();
     $this->setTotalAndTaxAmount();
     $this->recordPaymentPlanFirstContribution();

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -751,9 +751,11 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   }
 
   /**
-   * Checks if given line item already exists, by checking if there is already a
-   * line item with same entity_table, entity_id, contribution_id,
-   * price_field_value_id, and price_field_id.
+   * Checks if given line item already exists.
+   *
+   * Checks if there is already a similar line item related to the contribution,
+   * by checking if there is already a line item with same entity_table,
+   * entity_id, contribution_id, price_field_value_id, and price_field_id.
    *
    * @param array $lineItem
    *   Data for the line item to be used to check if it already exists.
@@ -765,12 +767,18 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    * @throws \CiviCRM_API3_Exception
    */
   private function isDuplicateLineItem($lineItem) {
+    $priceFieldID = CRM_Utils_Array::value('price_field_id', $lineItem);
+    $priceFieldValueID = CRM_Utils_Array::value('price_field_value_id', $lineItem);
+    if (!$priceFieldID || !$priceFieldValueID) {
+      return FALSE;
+    }
+
     $result = civicrm_api3('LineItem', 'get', [
       'entity_table' => CRM_Utils_Array::value('entity_table', $lineItem),
       'entity_id' => CRM_Utils_Array::value('entity_id', $lineItem),
       'contribution_id' => CRM_Utils_Array::value('contribution_id', $lineItem),
-      'price_field_value_id' => CRM_Utils_Array::value('price_field_value_id', $lineItem),
-      'price_field_id' => CRM_Utils_Array::value('price_field_id', $lineItem),
+      'price_field_id' => $priceFieldID,
+      'price_field_value_id' => $priceFieldValueID,
     ]);
 
     if ($result['count'] > 0) {

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -510,9 +510,14 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   /**
    * Renews/Extend the related payment plan memberships to be auto-renewed
    * for one term.
+   *
+   * @param int $sourceRecurringContribution
+   *   ID of the recurring contribution to be used to copy line items.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
-  protected function renewPaymentPlanMemberships() {
-    $recurringLineItems = $this->getRecurringContributionLineItemsToBeRenewed($this->currentRecurContributionID);
+  protected function renewPaymentPlanMemberships($sourceRecurringContribution) {
+    $recurringLineItems = $this->getRecurringContributionLineItemsToBeRenewed($sourceRecurringContribution);
     $existingMembershipID = null;
 
     foreach ($recurringLineItems as $lineItem) {
@@ -618,7 +623,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       $lineTotal = MoneyUtilities::roundToCurrencyPrecision($unitPrice * $lineItem['qty']);
       $taxAmount = $this->calculateLineItemTaxAmount($lineTotal, $lineItem['financial_type_id']);
 
-      switch ($lineItem['entity_id']) {
+      switch ($lineItem['entity_table']) {
         case 'civicrm_contribution':
         case 'civicrm_contribution_recur':
           $entityID = 'null';

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -126,7 +126,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
     $this->paymentPlanStartDate = $this->calculateNoInstallmentsPaymentPlanStartDate();
 
     $this->recordPaymentPlanFirstContribution();
-    $this->renewPaymentPlanMemberships();
+    $this->renewPaymentPlanMemberships($this->currentRecurContributionID);
   }
 
   /**


### PR DESCRIPTION
## Overview
When the renewal job ran and a payment plan with new donation or event line items got renewed, the new contributions for the next period gor created, with the correct total amounts, but line items different to memberships got skipped. So for example, if the payment plan required 4 line items (two memberships, a donation, and an event), only the two line items for memberships were created for each new contribution of the next period.

## Before
A validation was added on renewal job to check line items were not being duplicated, as there is a Unique constraint set on the line items table that will cause an exception to be thrown if a line item for the same contribution_id, entity_table, entity_id, price_field_id and price_field_value_id is added.

Now, price_field_id and price_field_value_id are nullable in the unique constraint, and donation line items actually have these fields as null. But this was not taken into account when checking for existing line items, so these lines got skipped as the check always returned congruent line items already existed for the contribution.

## After
Changed validation to check for duplicate line items, so that if either price_field_id or price_field_value_id are null, the line item is evaluated as not being a duplicate.

Some other bugs were fixed while wokring on this problem. First, all line items were being treated as if they were memberships, which caused to line items that were donations to have a related entity_id (this value should be null on this kind of line items). The second problem was when creating new memberships for the new recurring contribution, as the new memberships were being related to the old line items instead of the new ones.