### PR TITLE
MAE-159: Fix Wrong Period Dates Shown After Plan Renewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -218,7 +218,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
 
     $result = [];
     foreach ($lineItems['values'] as $line) {
-      $lineData = $line['api.LineItem.getsingle'];
+      $lineData = $line;
+      $lineData['subscription_line_id'] = $line['id'];
+      unset($lineData['id']);
+      unset($lineData['api.LineItem.getsingle']);
+      $lineData = array_merge($lineData, $line['api.LineItem.getsingle']);
+
       $result[] =  $lineData;
     }
 

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -529,7 +529,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       $existingMembershipID = $this->getExistingMembershipForLineItem($lineItem, $priceFieldValue);
 
       if ($existingMembershipID) {
-        $this->extendExistingMembership($existingMembershipID, $lineItem);
+        $this->extendExistingMembership($existingMembershipID, $lineItem['start_date']);
       } else {
         $existingMembershipID = $this->createMembership($lineItem, $priceFieldValue);
       }
@@ -603,13 +603,13 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    *
    * @param int $membershipID
    *   ID of the membership to be extended.
-   * @param array $lineItem
-   *   Data with the line item the membership belongs to.
+   * @param string $startDate
+   *   New start date for the membership.
    */
-  private function extendExistingMembership($membershipID, $lineItem) {
+  private function extendExistingMembership($membershipID, $startDate) {
     $membership = new CRM_Member_DAO_Membership();
     $membership->id = $membershipID;
-    $membership->start_date = $lineItem['start_date'];
+    $membership->start_date = $startDate;
     $membership->end_date = MembershipEndDateCalculator::calculate($membershipID);
     $membership->save();
   }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -529,7 +529,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       $existingMembershipID = $this->getExistingMembershipForLineItem($lineItem, $priceFieldValue);
 
       if ($existingMembershipID) {
-        $this->extendExistingMembership($existingMembershipID);
+        $this->extendExistingMembership($existingMembershipID, $lineItem);
       } else {
         $existingMembershipID = $this->createMembership($lineItem, $priceFieldValue);
       }
@@ -602,10 +602,14 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    * Extend membership identified by given ID.
    *
    * @param int $membershipID
+   *   ID of the membership to be extended.
+   * @param array $lineItem
+   *   Data with the line item the membership belongs to.
    */
-  private function extendExistingMembership($membershipID) {
+  private function extendExistingMembership($membershipID, $lineItem) {
     $membership = new CRM_Member_DAO_Membership();
     $membership->id = $membershipID;
+    $membership->start_date = $lineItem['start_date'];
     $membership->end_date = MembershipEndDateCalculator::calculate($membershipID);
     $membership->save();
   }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -251,7 +251,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
 
     $result = [];
     foreach ($lineItems['values'] as $line) {
-      $lineData = $line['api.LineItem.getsingle'];
+      $lineData = $line;
+      $lineData['subscription_line_id'] = $line['id'];
+      unset($lineData['id']);
+      unset($lineData['api.LineItem.getsingle']);
+      $lineData = array_merge($lineData, $line['api.LineItem.getsingle']);
+
       $result[] =  $lineData;
     }
 

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -292,35 +292,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @throws \Exception
    */
   private function calculateCurrentPeriodEndDate() {
-    if (!isset($this->contribRecur['end_date'])) {
-      return $this->getLargestMembershipEndDate($this->currentPeriodLineItems);
-    }
-
-    $numberOfInstallments = 1;
-    if (!empty($this->contribRecur['installments'])) {
-      $numberOfInstallments = $this->contribRecur['installments'];
-    }
-
-    $intervalLength = CRM_Utils_Array::value('frequency_interval', $this->contribRecur, 0) * $numberOfInstallments;
-    switch (CRM_Utils_Array::value('frequency_unit', $this->contribRecur)) {
-      case 'month':
-        $interval = 'P' . $intervalLength . 'M';
-        break;
-      case 'day':
-        $interval = 'P' . $intervalLength .'D';
-        break;
-      case 'year':
-        $interval = 'P' . $intervalLength .'Y';
-        break;
-    }
-
-    $nextPeriodStartDate = new DateTime(CRM_Utils_Array::value('start_date', $this->contribRecur));
-    $nextPeriodStartDate->add(new DateInterval($interval));
-
-    $currentPeriodEndDate = new DateTime($nextPeriodStartDate->format('Y-m-d'));
-    $currentPeriodEndDate->sub(new DateInterval('P1D'));
-
-    return $currentPeriodEndDate->format('Y-m-d');
+    return $this->getLargestMembershipEndDate($this->currentPeriodLineItems);
   }
 
   /**

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -201,7 +201,10 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('recurringContributionID', $this->contribRecur['id']);
 
     $this->assign('periodStartDate', $this->calculateCurrentPeriodStartDate());
-    $this->assign('periodEndDate', $this->calculateCurrentPeriodEndDate());
+
+    $currentPeriodEndDate = $this->calculateCurrentPeriodEndDate();
+    $this->assign('periodEndDate', $currentPeriodEndDate);
+    $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate($currentPeriodEndDate));
     $this->assign('largestMembershipEndDate', $this->getLargestMembershipEndDate($this->currentPeriodLineItems));
 
     $this->assign('currentPeriodMembershipTypes', $this->getCurrentTabMembershipTypes());
@@ -210,7 +213,6 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
     $this->assign('lineItems', $this->currentPeriodLineItems);
 
     $this->assign('showNextPeriodTab', $this->showNextPeriodTab());
-    $this->assign('nextPeriodStartDate', $this->calculateNextPeriodStartDate());
     $this->assign('financialTypes', $this->financialTypes);
     $this->assign('currencySymbol', $this->getCurrencySymbol());
     $this->assign('nextPeriodLineItems', $this->nextPeriodLineItems);
@@ -278,14 +280,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @throws \Exception
    */
   private function calculateCurrentPeriodStartDate() {
-    $earliestStartDate = new DateTime($this->getEarliestMembershipStartDate($this->currentPeriodLineItems));
-    $recurringContributionStartDate = new DateTime(CRM_Utils_Array::value('start_date', $this->contribRecur));
-
-    if ($earliestStartDate > $recurringContributionStartDate) {
-      return $earliestStartDate->format('Y-m-d');
-    }
-
-    return $recurringContributionStartDate->format('Y-m-d');
+    return $this->getEarliestLineStartDate($this->currentPeriodLineItems);
   }
 
   /**
@@ -339,21 +334,16 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    *
    * @throws \Exception
    */
-  private function getEarliestMembershipStartDate($lineItems) {
+  private function getEarliestLineStartDate($lineItems) {
     $earliestDate = null;
 
     foreach ($lineItems as $line) {
-      if ($line['entity_table'] != 'civicrm_membership') {
-        continue;
-      }
-
-      $membership = $this->getMembership($line['entity_id']);
-      $membershipStartDate = new DateTime($membership['start_date']);
+      $startDate = new DateTime($line['start_date']);
 
       if (!isset($earliestDate)) {
-        $earliestDate = $membershipStartDate;
-      } elseif ($earliestDate > $membershipStartDate) {
-        $earliestDate = $membershipStartDate;
+        $earliestDate = $startDate;
+      } elseif ($earliestDate > $startDate) {
+        $earliestDate = $startDate;
       }
     }
 
@@ -451,8 +441,8 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    *
    * @throws \Exception
    */
-  private function calculateNextPeriodStartDate() {
-    $membershipDate = new DateTime($this->getLargestMembershipEndDate($this->currentPeriodLineItems));
+  private function calculateNextPeriodStartDate($currentPeriodEndDate) {
+    $membershipDate = new DateTime($currentPeriodEndDate);
     $membershipDate->add(new DateInterval('P1D'));
 
     return $membershipDate->format('Y-m-d');

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -278,7 +278,14 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @throws \Exception
    */
   private function calculateCurrentPeriodStartDate() {
-    return $this->getEarliestMembershipStartDate($this->currentPeriodLineItems);
+    $earliestStartDate = new DateTime($this->getEarliestMembershipStartDate($this->currentPeriodLineItems));
+    $recurringContributionStartDate = new DateTime(CRM_Utils_Array::value('start_date', $this->contribRecur));
+
+    if ($earliestStartDate > $recurringContributionStartDate) {
+      return $earliestStartDate->format('Y-m-d');
+    }
+
+    return $recurringContributionStartDate->format('Y-m-d');
   }
 
   /**
@@ -286,9 +293,39 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    *
    * @return string
    *   End date of current period.
+   *
+   * @throws \Exception
    */
   private function calculateCurrentPeriodEndDate() {
-    return $this->getLargestMembershipEndDate($this->currentPeriodLineItems);
+    if (!isset($this->contribRecur['end_date'])) {
+      return $this->getLargestMembershipEndDate($this->currentPeriodLineItems);
+    }
+
+    $numberOfInstallments = 1;
+    if (!empty($this->contribRecur['installments'])) {
+      $numberOfInstallments = $this->contribRecur['installments'];
+    }
+
+    $intervalLength = CRM_Utils_Array::value('frequency_interval', $this->contribRecur, 0) * $numberOfInstallments;
+    switch (CRM_Utils_Array::value('frequency_unit', $this->contribRecur)) {
+      case 'month':
+        $interval = 'P' . $intervalLength . 'M';
+        break;
+      case 'day':
+        $interval = 'P' . $intervalLength .'D';
+        break;
+      case 'year':
+        $interval = 'P' . $intervalLength .'Y';
+        break;
+    }
+
+    $nextPeriodStartDate = new DateTime(CRM_Utils_Array::value('start_date', $this->contribRecur));
+    $nextPeriodStartDate->add(new DateInterval($interval));
+
+    $currentPeriodEndDate = new DateTime($nextPeriodStartDate->format('Y-m-d'));
+    $currentPeriodEndDate->sub(new DateInterval('P1D'));
+
+    return $currentPeriodEndDate->format('Y-m-d');
   }
 
   /**

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -46,7 +46,7 @@
       <tr id="lineitem-{$currentItem.id}" data-item-data='{$currentItem|@json_encode}' class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
         <td>{$currentItem.label}</td>
         <td>{$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}</td>
-        <td>{$largestMembershipEndDate|crmDate}</td>
+        <td>{$periodEndDate|crmDate}</td>
         {if $recurringContribution.auto_renew}
           <td>
               <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />


### PR DESCRIPTION
## Overview
Issues were found with the dates shown on the View/Manage Future Installments screen.

After Completing All Payments:
- Current Period End Date: Updated to recieve date of last installment, which is not correct.


## Before
Period end date being shown on screen was end date of recurring contribution, which starts empty and is finally set when all installments are completed with the recieve date of the last installment.

After renewal, first, membership start date was not being updated to the start date of the new period. Secondly, end date shown on line items was the membership's current end date, which of course, after renewal, changed.

The following example is for a payment plan starting on 2018-01-01, ending on 2018-12-31.

### Previous period After Renewal
![image](https://user-images.githubusercontent.com/21999940/70909642-e6480580-1fdb-11ea-955d-a8778c60bc56.png)
- Period end-date is shown as 31st December 2019. This is wrong, as end date for this period should be 31st December 2018. This happens because period end date is calculated by checking the largest membership end date, which is in fact the renewed memberhips end date (ie. 31st December 2019).
- Line item end-date is shown as 31st December 2019. This is also wrong, should be 31st December 2018. Also calculated from largest membership end-date.

### New Period on Renewal
![image](https://user-images.githubusercontent.com/21999940/70909721-12fc1d00-1fdc-11ea-94e6-1e480e590734.png)
- Period start date start date is shown as 1st January 2018, which is wrong, as it should be 1st January 2019. This happens because period start date is calculated from earliest membership start date, and membership start dates were not being updated on renewal job.

## After
It was decided, we should only allow to View/Modify Future Inatallments on the last recurring contribution in a succession of renewals. Thus we no longer have to deal with wrong dates being shown on prior periods after a renewal, as the link was removed from these.

Also, fixed renewals so that membership start date is updated to start date of the new period.

### New Period on Renewal
![image](https://user-images.githubusercontent.com/21999940/70911269-86ebf480-1fdf-11ea-8f07-ea733959f869.png)


