### PR TITLE
CGP-1486: Fix Changing of Membership End Dates on Payment Record

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -39,7 +39,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    * Preprocesses parameters used for Membership operations.
    */
   public function preProcess() {
-    if ($this->paymentContributionID) {
+    if ($this->paymentContributionID || $this->isRecordingPayment()) {
       $this->preventExtendingPaymentPlanMembership();
     }
 
@@ -52,6 +52,21 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
     if ($this->isOfflinePaymentPlanMembership()) {
       $this->verifyMembershipStartDate();
     }
+  }
+
+  private function isRecordingPayment() {
+    $isAddAction = CRM_Utils_Request::retrieve('action', 'String') & CRM_Core_Action::ADD;
+    $isContributionComponent = CRM_Utils_Request::retrieve('component', 'String') === 'contribution';
+    $idContribution = CRM_Utils_Request::retrieve('id', 'String');
+    $isRecordPayment = CRM_Utils_Request::retrieve('_qf_AdditionalPayment_upload', 'String') === 'Record Payment';
+
+    if ($isAddAction && $isContributionComponent && $isRecordPayment && $idContribution) {
+      $this->paymentContributionID = $idContribution;
+
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
## Overview
When recording a payment, membership end dates is getting updated, as if the membership was being renewed. 

## Before
We had logic in place on the Membership Entity pre hook to prevent this from happening, but this relied on the fact that the contribution would be updated BEFORE the membership, as we needed the contribution ID in order to determine if the membership was for a manual payment plan and thus prevent membership extension.

## After
Added a condition to the Membership pre hook by checking if the membership is being updated through the record payment form, so that if a payment is being recorded, membership end date extension is also prevented.