### PR TITLE
MAE-176: Fix contribution receive date issue when creating memberships with webforms

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -94,11 +94,22 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
    * contribution.
    */
   public function preProcess() {
+    if ($this->operation == 'create') {
+      $this->calculateCycleDay();
+    }
+
     $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $this->recurringContribution, 0);
     $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($paymentProcessorID);
 
     if ($this->operation == 'edit' && $isManualPaymentPlan) {
       $this->rectifyPaymentPlanStatus();
+    }
+  }
+
+  private function calculateCycleDay() {
+    if (!empty($this->params['start_date']) && !empty($this->params['frequency_unit'])) {
+      $this->params['cycle_day'] =
+        CRM_MembershipExtras_Service_CycleDayCalculator::calculate($this->params['start_date'], $this->params['frequency_unit']);
     }
   }
 

--- a/CRM/MembershipExtras/Service/CycleDayCalculator.php
+++ b/CRM/MembershipExtras/Service/CycleDayCalculator.php
@@ -15,7 +15,7 @@ class CRM_MembershipExtras_Service_CycleDayCalculator {
    *
    * @return int
    */
-  public static function calculate($targetDate, $frequencyUnit) {;
+  public static function calculate($targetDate, $frequencyUnit) {
     $recurContStartDate = new DateTime($targetDate);
 
     switch ($frequencyUnit) {


### PR DESCRIPTION
## Problem

When creating payment plan membership (paid with more that one installment), then the receive date day of the contributions other than the first one will always be the 1st day of the month/year ..etc.


![2019-12-19 17_11_03-sao22@ad com sao22@ad com _ m7civi519](https://user-images.githubusercontent.com/6275540/71184543-cfbadc00-2271-11ea-9774-1b9fe7a6a9a0.png)



## Solution

When creating the upfront contribution, we calculate the receive date for each one based on the recur contribution cycle day, the cycle day in general is default to 1 in CiviCRM and CiviCRM does not really touch it but we have a code in place to calculate it, but for webforms, the webform will create the prepare the recur contribution params and the cylce day is not include so it will default to 1 and thus causing the issue, in this PR I made sure that the cycle day get calculated inside the recur contribution pre save hook which will correct the issue.

![2019-12-19 17_31_16-dsaok202@ad com dsaok202@ad com _ m7civi519](https://user-images.githubusercontent.com/6275540/71186143-a3548f00-2274-11ea-99af-2e0660299843.png)
