### PR TITLE
MAE-171: Fix membership creation in pending status

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
+++ b/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
@@ -38,24 +38,7 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
   public function postProcess() {
     if ($this->operation == 'create') {
       $this->fixRecurringLineItemMembershipReferences();
-      $this->recalculateMembershipStatus();
     }
-  }
-
-  /**
-   * Recaalculates the status of the related membership.
-   *
-   * Recalculates the status of the related membership to check if payment plan
-   * related events imply a status change (eg. In Arrears).
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  public function recalculateMembershipStatus() {
-    $membership = civicrm_api3('Membership', 'getsingle', ['id' => $this->membershipPayment->membership_id]);
-    $membership['id'] = $this->membershipPayment->membership_id;
-    $membership['skipStatusCal'] = 0;
-
-    civicrm_api3('Membership', 'create', $membership);
   }
 
   /**


### PR DESCRIPTION
## Problem

Creating a membership with pending  contribution  will always set the membership status to "New" instead of pending. 

![ffff](https://user-images.githubusercontent.com/6275540/71892141-2bc1a380-3140-11ea-8c99-29d0f0be427b.gif)

This also affect creating memberships with webforms too.

## Solution

Creating membership with pending payment will put the membership in its correct status : 

![affteer](https://user-images.githubusercontent.com/6275540/71892384-ac809f80-3140-11ea-9c36-0671703b7d84.gif)

## Technical notes 

1- This issue was introduced by this PR : 

https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/223

the PR above tried to resolve "In-arrears" status calculation by forcing CiviCRM to recalculating the membership status during the creating of the related membership-payment record, the PR uses  CiviCRM membership API with skipStatusCal set to 0 to force CiviCRM to recalculate the status, but The status calculation here depends on the membership dates and does not care about any related contribution unlike the calculation that happen during the creation of the membership, and because of this the status will be changed to "New" instead of "Pending" even though there is a pending contribution related to the membership.

2- Removing the code here will bring back the issue reported in BASW-65 back that the PR above fixed, but we will need to look into different approach to resolve it, I tried to keep the code that I removed in this PR for example and update CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus class in a way that fix both these two issues but there are different scenarios and cases that might be affected that will make such change complex to do, not to mention that it will hit the performance since this calculation will be called for every installment that get created, and imagine if you have 12 installments. 

I will try to fix BASW-65 issue with another PR, currently I am thinking to move the calculation for in-arrears to a scheduled job since it will be easier and more efficient to get the payment plan information and calculate the status.
