### PR TITLE
MAE-188: Fix Start Dates for Lines Added with Different Recieve Date

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
@@ -14,105 +14,22 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
   private $contributionRecurBAO;
 
   /**
-   * List of subscription lines associated to the recurring contribution.
-   *
-   * @var
-   */
-  private $subscriptionLines;
-
-  /**
    * CRM_MembershipExtras_Hook_Post_ContributionRecur constructor.
    *
    * @param \CRM_Contribute_BAO_ContributionRecur $contributionBAO
-   *
-   * @throws \Exception
    */
   public function __construct(CRM_Contribute_BAO_ContributionRecur $contributionBAO) {
     $this->contributionRecurBAO = CRM_Contribute_BAO_ContributionRecur::findById($contributionBAO->id);
-    $this->subscriptionLines = $this->getSubscriptionLines();
   }
 
   /**
    * Post processes recurring contribution entity.
-   *
-   * @throws \CiviCRM_API3_Exception
    */
   public function postProcess() {
     $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($this->contributionRecurBAO->payment_processor_id);
     if ($isManualPaymentPlan) {
-      $this->updateStartDates();
       $this->updateLineItemEndDates();
     }
-  }
-
-  /**
-   * Updates start dates of recurring contribution and lines.
-   *
-   * Sets start date of recurring contribution and related line items to the
-   * earliest membership start date.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function updateStartDates() {
-    $earliestDate = $this->getEarliestStartDate();
-    if (!$earliestDate) {
-      return;
-    }
-
-    foreach ($this->subscriptionLines as $line) {
-      civicrm_api3('ContributionRecurLineItem', 'create', [
-        'id' => $line['id'],
-        'start_date' => $earliestDate,
-      ]);
-    }
-  }
-
-  /**
-   * Obtains earliest membership start date.
-   *
-   * @return string
-   *   Earliest membership start date.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getEarliestStartDate() {
-    $earliestDate = NULL;
-
-    foreach ($this->subscriptionLines as $line) {
-      if ($line['entity_table'] !== 'civicrm_membership') {
-        continue;
-      }
-
-      $membership = $this->getMembership($line['entity_id']);
-      $startDate = new DateTime($membership['start_date']);
-
-      if (!isset($earliestDate)) {
-        $earliestDate = $startDate;
-      } elseif ($earliestDate > $startDate) {
-        $earliestDate = $startDate;
-      }
-    }
-
-    if ($earliestDate) {
-      return $earliestDate->format('Y-m-d');
-    }
-
-    return NULL;
-  }
-
-  /**
-   * Obtains data for membership identitfied by given ID.
-   *
-   * @param int $membershipID
-   *   ID of the membership.
-   *
-   * @return array
-   *   Array with the membership's data.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getMembership($membershipID) {
-    return civicrm_api3('Membership', 'getsingle', ['id' => $membershipID]);
   }
 
   /**
@@ -122,7 +39,9 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
     $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus($this->contributionRecurBAO->contribution_status_id, 'name');
 
     if ($contributionStatus === 'Completed' && $this->contributionRecurBAO->installments > 1) {
-      foreach($this->subscriptionLines as $line) {
+      $subscriptionLines = $this->getSubscriptionLines();
+
+      foreach($subscriptionLines as $line) {
         if (!empty($line['start_date']) && empty($line['end_date'])) {
           civicrm_api3('ContributionRecurLineItem', 'create', [
             'id' => $line['id'],
@@ -134,39 +53,22 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
   }
 
   /**
-   * Returns LineItems associated to a recurring contribution.
+   * Returns LineItems associated to a recurring contribution
    *
    * @return array
-   *   List of current line items for the payment plan.
-   *
-   * @throws \CiviCRM_API3_Exception
    */
   private function getSubscriptionLines() {
     $result = civicrm_api3('ContributionRecurLineItem', 'get', [
       'sequential' => 1,
       'contribution_recur_id' => $this->contributionRecurBAO->id,
-      'is_removed' => 0,
-      'start_date' => ['IS NOT NULL' => 1],
-      'api.LineItem.getsingle' => [
-        'id' => '$value.line_item_id',
-        'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
-      ],
+      'options' => ['limit' => 0],
     ]);
 
-    if ($result['count'] < 1) {
-      return [];
+    if ($result['count']) {
+      return $result['values'];
     }
 
-    $lineItems = [];
-    foreach ($result['values'] as $lineItemData) {
-      $lineDetails = $lineItemData['api.LineItem.getsingle'];
-      unset($lineDetails['id']);
-      unset($lineItemData['api.LineItem.getsingle']);
-      $lineItems[] = array_merge($lineItemData, $lineDetails);
-    }
-
-    return $lineItems;
+    return [];
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
@@ -14,22 +14,105 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
   private $contributionRecurBAO;
 
   /**
+   * List of subscription lines associated to the recurring contribution.
+   *
+   * @var
+   */
+  private $subscriptionLines;
+
+  /**
    * CRM_MembershipExtras_Hook_Post_ContributionRecur constructor.
    *
    * @param \CRM_Contribute_BAO_ContributionRecur $contributionBAO
+   *
+   * @throws \Exception
    */
   public function __construct(CRM_Contribute_BAO_ContributionRecur $contributionBAO) {
     $this->contributionRecurBAO = CRM_Contribute_BAO_ContributionRecur::findById($contributionBAO->id);
+    $this->subscriptionLines = $this->getSubscriptionLines();
   }
 
   /**
    * Post processes recurring contribution entity.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function postProcess() {
     $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($this->contributionRecurBAO->payment_processor_id);
     if ($isManualPaymentPlan) {
+      $this->updateStartDates();
       $this->updateLineItemEndDates();
     }
+  }
+
+  /**
+   * Updates start dates of recurring contribution and lines.
+   *
+   * Sets start date of recurring contribution and related line items to the
+   * earliest membership start date.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function updateStartDates() {
+    $earliestDate = $this->getEarliestStartDate();
+    if (!$earliestDate) {
+      return;
+    }
+
+    foreach ($this->subscriptionLines as $line) {
+      civicrm_api3('ContributionRecurLineItem', 'create', [
+        'id' => $line['id'],
+        'start_date' => $earliestDate,
+      ]);
+    }
+  }
+
+  /**
+   * Obtains earliest membership start date.
+   *
+   * @return string
+   *   Earliest membership start date.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getEarliestStartDate() {
+    $earliestDate = NULL;
+
+    foreach ($this->subscriptionLines as $line) {
+      if ($line['entity_table'] !== 'civicrm_membership') {
+        continue;
+      }
+
+      $membership = $this->getMembership($line['entity_id']);
+      $startDate = new DateTime($membership['start_date']);
+
+      if (!isset($earliestDate)) {
+        $earliestDate = $startDate;
+      } elseif ($earliestDate > $startDate) {
+        $earliestDate = $startDate;
+      }
+    }
+
+    if ($earliestDate) {
+      return $earliestDate->format('Y-m-d');
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Obtains data for membership identitfied by given ID.
+   *
+   * @param int $membershipID
+   *   ID of the membership.
+   *
+   * @return array
+   *   Array with the membership's data.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembership($membershipID) {
+    return civicrm_api3('Membership', 'getsingle', ['id' => $membershipID]);
   }
 
   /**
@@ -39,9 +122,7 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
     $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus($this->contributionRecurBAO->contribution_status_id, 'name');
 
     if ($contributionStatus === 'Completed' && $this->contributionRecurBAO->installments > 1) {
-      $subscriptionLines = $this->getSubscriptionLines();
-
-      foreach($subscriptionLines as $line) {
+      foreach($this->subscriptionLines as $line) {
         if (!empty($line['start_date']) && empty($line['end_date'])) {
           civicrm_api3('ContributionRecurLineItem', 'create', [
             'id' => $line['id'],
@@ -53,22 +134,39 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
   }
 
   /**
-   * Returns LineItems associated to a recurring contribution
+   * Returns LineItems associated to a recurring contribution.
    *
    * @return array
+   *   List of current line items for the payment plan.
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   private function getSubscriptionLines() {
     $result = civicrm_api3('ContributionRecurLineItem', 'get', [
       'sequential' => 1,
       'contribution_recur_id' => $this->contributionRecurBAO->id,
-      'options' => ['limit' => 0],
+      'is_removed' => 0,
+      'start_date' => ['IS NOT NULL' => 1],
+      'api.LineItem.getsingle' => [
+        'id' => '$value.line_item_id',
+        'entity_table' => ['IS NOT NULL' => 1],
+        'entity_id' => ['IS NOT NULL' => 1]
+      ],
     ]);
 
-    if ($result['count']) {
-      return $result['values'];
+    if ($result['count'] < 1) {
+      return [];
     }
 
-    return [];
+    $lineItems = [];
+    foreach ($result['values'] as $lineItemData) {
+      $lineDetails = $lineItemData['api.LineItem.getsingle'];
+      unset($lineDetails['id']);
+      unset($lineItemData['api.LineItem.getsingle']);
+      $lineItems[] = array_merge($lineItemData, $lineDetails);
+    }
+
+    return $lineItems;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
@@ -58,8 +58,6 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
     foreach ($lastContributionLineItems as $lineItemParams) {
       $this->createRecurLineItem($lineItemParams, $earliestStartDate);
     }
-
-    $this->updateRecurringContribution($earliestStartDate);
   }
 
   private function getLastContributionLineItems() {
@@ -141,13 +139,6 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
       'line_item_id' => $lineItemCopy['id'],
       'start_date' => $lineStartDate,
       'auto_renew' => $autoRenew,
-    ]);
-  }
-
-  private function updateRecurringContribution($recurringContributionStartDate) {
-    civicrm_api3('ContributionRecur', 'create', [
-      'id' => $this->recurContributionID,
-      'start_date' => $recurringContributionStartDate,
     ]);
   }
 

--- a/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
@@ -54,9 +54,12 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
       return;
     }
 
+    $earliestStartDate = $this->getEarliestMembershipStartDate($lastContributionLineItems);
     foreach ($lastContributionLineItems as $lineItemParams) {
-      $this->createRecurLineItem($lineItemParams);
+      $this->createRecurLineItem($lineItemParams, $earliestStartDate);
     }
+
+    $this->updateRecurringContribution($earliestStartDate);
   }
 
   private function getLastContributionLineItems() {
@@ -66,32 +69,65 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
         'contribution_recur_id' => $this->recurContributionID,
         'options' => ['limit' => 1, 'sort' => 'id DESC'],
       ]);
+      $lineItemsFilterParams = [
+        'sequential' => 1,
+        'return' => ['entity_table', 'entity_id', 'price_field_id',
+          'label', 'qty', 'unit_price', 'line_total', 'participant_count', 'id',
+          'price_field_value_id', 'financial_type_id', 'non_deductible_amount', 'tax_amount'],
+        'contribution_id' => $lastContributionId,
+        'api.Membership.get' => ['id' => '$value.entity_id'],
+        'options' => ['limit' => 0],
+      ];
+
+      $lastContributionLineItems = civicrm_api3('LineItem', 'get', $lineItemsFilterParams);
     } catch (CiviCRM_API3_Exception $exception) {
-      return NULL;
+      return [];
     }
 
-    $lineItemsFilterParams = [
-      'sequential' => 1,
-      'return' => ['entity_table', 'entity_id', 'price_field_id',
-        'label', 'qty', 'unit_price', 'line_total', 'participant_count', 'id',
-        'price_field_value_id', 'financial_type_id', 'non_deductible_amount', 'tax_amount'],
-      'contribution_id' => $lastContributionId,
-      'options' => ['limit' => 0],
-    ];
-
-    if ($this->calculateAutorenewalFlag) {
-      $lineItemsFilterParams['api.Membership.get'] = ['id' => '$value.entity_id'];
-    }
-
-    $lastContributionLineItems = civicrm_api3('LineItem', 'get', $lineItemsFilterParams);
     if ($lastContributionLineItems['count'] < 1) {
-      return NULL;
+      return [];
     }
 
     return $lastContributionLineItems['values'];
   }
 
-  private function createRecurLineItem($lineItemParams) {
+  /**
+   * Obtains earliest membership start date from the given line items.
+   *
+   * @param array $lineItems
+   *   List of line items to check.
+   *
+   * @return null|string
+   *   Earliest membership end date, if at least one membership is found. Null
+   *   if no memberships are part of the payment plan.
+   *
+   * @throws \Exception
+   */
+  private function getEarliestMembershipStartDate($lineItems) {
+    $earliestDate = NULL;
+
+    foreach ($lineItems as $line) {
+      if ($line['entity_table'] !== 'civicrm_membership') {
+        continue;
+      }
+
+      $startDate = new DateTime($line['api.Membership.get']['values'][0]['start_date']);
+
+      if (!isset($earliestDate)) {
+        $earliestDate = $startDate;
+      } elseif ($earliestDate > $startDate) {
+        $earliestDate = $startDate;
+      }
+    }
+
+    if ($earliestDate) {
+      return $earliestDate->format('Y-m-d');
+    }
+
+    return NULL;
+  }
+
+  private function createRecurLineItem($lineItemParams, $lineStartDate) {
     $autoRenew = TRUE;
     if ($this->calculateAutorenewalFlag) {
       $autoRenew = $this->calculateAutorenewalFlag($lineItemParams);
@@ -103,8 +139,15 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
     CRM_MembershipExtras_BAO_ContributionRecurLineItem::create([
       'contribution_recur_id' => $this->recurContributionID,
       'line_item_id' => $lineItemCopy['id'],
-      'start_date' => $this->recurContribution['start_date'],
+      'start_date' => $lineStartDate,
       'auto_renew' => $autoRenew,
+    ]);
+  }
+
+  private function updateRecurringContribution($recurringContributionStartDate) {
+    civicrm_api3('ContributionRecur', 'create', [
+      'id' => $this->recurContributionID,
+      'start_date' => $recurringContributionStartDate,
     ]);
   }
 

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -311,6 +311,10 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
 
     foreach ($lineItems as $line) {
       $startDate = new DateTime($line['start_date']);
+      if ($line['entity_table'] === 'civicrm_membership') {
+        $membership = $this->getMembership($line['entity_id']);
+        $startDate = new DateTime($membership['start_date']);
+      }
 
       if (!isset($earliestDate)) {
         $earliestDate = $startDate;


### PR DESCRIPTION
## Overview
On Manage Installments screen, membership line start date should be the actual membership start dates and not the received date of the contribution.

While signing up membership using Webforms, received date of DD membership is set based on Payment collection run dates set on DD configuration. But it does affect the membership dates on Manage Installments which is not correct. 

Same issue, if membership is created using 'New membership' or 'Add Membership' option with a different received date, it updates the received date on Manage Installments as the membership start date.

## Before
When adding a membership, if the recieve date for the first installment was different to the start date of the membership, the dates shown on the Manage Future Installments Screen showed contribution recieve date as start date, instead of the membership's actual start date. This is beacuse the dates shown on the screen are calculated by checking the earliest start date of the plan's line items, which are all set to the recieve date of the first contribution.

## After
Fixed by using membership start dates for lines that are memberships when calculating earliest start date on the manage future installments form. Also added logic on line item creation to store the earliest membership's start date on line items start dates when the payment plan is created.