### PR TITLE
MAE-183: Fix autorenewal when 'date in advance' setting is set

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -529,7 +529,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       $existingMembershipID = $this->getExistingMembershipForLineItem($lineItem, $priceFieldValue);
 
       if ($existingMembershipID) {
-        $this->extendExistingMembership($existingMembershipID, $lineItem['start_date']);
+        $this->extendExistingMembership($existingMembershipID);
       } else {
         $existingMembershipID = $this->createMembership($lineItem, $priceFieldValue);
       }
@@ -603,13 +603,10 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    *
    * @param int $membershipID
    *   ID of the membership to be extended.
-   * @param string $startDate
-   *   New start date for the membership.
    */
-  private function extendExistingMembership($membershipID, $startDate) {
+  private function extendExistingMembership($membershipID) {
     $membership = new CRM_Member_DAO_Membership();
     $membership->id = $membershipID;
-    $membership->start_date = $startDate;
     $membership->end_date = MembershipEndDateCalculator::calculate($membershipID);
     $membership->save();
   }


### PR DESCRIPTION
## Before

Offline Auto-renewal scheduled job fails when "days to renew in advance" setting is set and shows the following error in the logs : 

`Finished execution of Renew offline auto-renewal memberships with result: Failure, Error message: Errors found on auto-renewals: An error occurred renewing a payment plan with id (3): The membership cannot be saved because the status cannot be calculated for start_date: XXXXX end_date XXXXX  join_date XXXXX  as at XXXXX`

## After

Offline Auto-renewal scheduled job works normally as it used to.

## Technical notes

The issue is caused by two other PRs : 

https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/225

and 

https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/223
 
The first PR changed the offline auto-renewal so the membership start date is updated to start after the end of the first auto-renewal instead of staying always the same.

the 2nd PR tried to fix the in-arrears status calculation for some scenarios by calling the membership API with skip skipStatusCal  to 0 during the creation of membership payment.


And with  "days to renew in advance"  setting being set to let's say 10, The offline autorenewal job will result in calling the membership api with skipStatusCal = 0 after creating the membership and the new start date will be passed, but the start date here will be in the future since "days to renew in advance" = 10 means that the auto-renewal will renew the membership 10 days before it start date, and since there is no CiviCRM status rule that handle future membership, the auto-renewal will fail.

I resolved this issue by reverting the code in the 2nd PR here : https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/232 
which was also causing other issues to other tickets and in this PR I resolved the other Part by keeping the membership start date always the same upon renewal and only extending the end date, at the end CiviCRM does not have the concept of membership period yet, and the main reason is that it really impossible to create/configure a reliable "future" membership status rule which if was possible should fix this issue without the need to keep the start date the same.
