### PR TITLE
MAE-178: Add Validation to Membership Update Form to Prevent Changing its Membership Type

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipUpdate.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipUpdate.php
@@ -84,12 +84,9 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate {
   }
 
   /**
-   * Obtains payment processor ID used for the last membership payment.
+   * Obtains last payment used for the membership.
    *
-   * Returns tha las payment processor ID used to pay for the membership with a
-   * recurring contribution.
-   *
-   * @return mixed
+   * @return array
    *
    * @throws \CiviCRM_API3_Exception
    */
@@ -107,7 +104,11 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate {
       ],
     ]);
 
-    return $contribution['values'][0];
+    if ($contribution['count'] > 0) {
+      return $contribution['values'][0];
+    }
+
+    return [];
   }
 
   /**
@@ -127,9 +128,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate {
     }
 
     return civicrm_api3('ContributionRecur', 'getsingle', [
-      'sequential' => 1,
       'id' => $recurringContributionID,
-      'options' => ['limit' => 0]
     ]);
   }
 

--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipUpdate.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipUpdate.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate.
+ *
+ * Implements hook to validate the membership update form.
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate {
+
+  /**
+   * Form object that is being validated.
+   *
+   * @var \CRM_Member_Form_Membership
+   */
+  private $form;
+
+  /**
+   * List of the submitted fields and their values passed from the hook.
+   *
+   * @var array
+   */
+  private $fields;
+
+  /**
+   * List of form validation errors passed from the hook.
+   *
+   * @var array
+   */
+  private $errors;
+
+  /**
+   * CRM_MembershipExtras_Hook_BuildForm_Membership constructor.
+   *
+   * @param \CRM_Member_Form $form
+   */
+  public function __construct(CRM_Member_Form &$form, &$fields, &$errors) {
+    $this->form = $form;
+    $this->fields = &$fields;
+    $this->errors = &$errors;
+  }
+
+  /**
+   * Validates the form.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function validate() {
+    if ($this->isMembershipTypeChanged()) {
+      $this->errors['membership_type_id'] = ts(
+        'This membership is part of an ongoing payment plan and cannot be 
+        edited directly. To modify the active memberships in this payment plan 
+        please go to the manage future instalments screen which can be found as 
+        an action on the most recent recurring contribution record. There you 
+        can add or remove memberships.'
+      );
+    }
+  }
+
+  /**
+   * Checks if the membership type was changed by the user.
+   *
+   * @return bool
+   *   TRUE if the membershipt ype changed, FALSE otherwise.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function isMembershipTypeChanged() {
+    $membership = civicrm_api3('Membership', 'getsingle', [
+      'id' => $this->form->_id,
+    ]);
+
+    if ($membership['membership_type_id'] != $this->fields['membership_type_id'][1]) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -356,8 +356,10 @@ function membershipextras_civicrm_pageRun($page) {
  * Implements hook_civicrm_validateForm()
  */
 function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
-  $isNewMembershipForm = $formName === 'CRM_Member_Form_Membership' && ($form->getAction() & CRM_Core_Action::ADD);
-  $isRenewMembershipForm = $formName === 'CRM_Member_Form_MembershipRenewal' && ($form->getAction() & CRM_Core_Action::RENEW);
+  $formAction = $form->getAction();
+  $isNewMembershipForm = ($formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::ADD));
+  $isRenewMembershipForm = ($formName === 'CRM_Member_Form_MembershipRenewal' && ($formAction & CRM_Core_Action::RENEW));
+  $isMembershipUpdateForm = $formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::UPDATE);
 
   if ($isNewMembershipForm || $isRenewMembershipForm) {
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
@@ -366,6 +368,11 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
       $paymentPlanValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($form, $fields, $errors);
       $paymentPlanValidateHook->validate();
     }
+  }
+
+  if ($isMembershipUpdateForm) {
+    $membershipUpdateValidationHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate($form, $fields, $errors);
+    $membershipUpdateValidationHook->validate();
   }
 }
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -359,8 +359,6 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
   $formAction = $form->getAction();
   $isNewMembershipForm = ($formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::ADD));
   $isRenewMembershipForm = ($formName === 'CRM_Member_Form_MembershipRenewal' && ($formAction & CRM_Core_Action::RENEW));
-  $isMembershipUpdateForm = $formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::UPDATE);
-
   if ($isNewMembershipForm || $isRenewMembershipForm) {
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
@@ -370,6 +368,7 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
     }
   }
 
+  $isMembershipUpdateForm = $formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::UPDATE);
   if ($isMembershipUpdateForm) {
     $membershipUpdateValidationHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate($form, $fields, $errors);
     $membershipUpdateValidationHook->validate();


### PR DESCRIPTION
## Overview
Changing a membership's type after it has been created is only allowed by CiviCRM if it is not associated to a recurring contribution (ie. the membership is not auto-renewable). However, we need to prevent this from happenin on non-renewable payment plans too, as changing the membership type will cause several problems on existing installments.

## Before
CiviCRM allowed changing the membership type of a membership so long as it was not auto-renewable.

## After
Added validation to membership edit form so that if membership is changed and it belongs to a pyament plan, an error is shown with the text: 
>This membership is part of an ongoing payment plan and cannot be edited directly. To modify the active memberships in this payment plan please go to the manage future instalments screen which can be found as an action on the most recent recurring contribution record. There you can add or remove memberships.