### PR TITLE
MAE-189: Validate No Auto-renew for Memberships With Single Contribution

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipContribution.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipContribution.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_ValidateForm_MembershipContribution.
+ *
+ * Implements ValidateForm hook for membership creation with a single
+ * contribution.
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_MembershipContribution {
+
+  /**
+   * @var \CRM_Member_Form_Membership
+   *   Form object that is being validated.
+   */
+  private $form;
+
+  /**
+   * @var array
+   *   List of the submitted fields and their values passed from the hook.
+   */
+  private $fields;
+
+  /**
+   * @var array
+   *   List of form validation errors passed from the hook.
+   */
+  private $errors;
+
+  /**
+   * CRM_MembershipExtras_Hook_ValidateForm_MembershipContribution constructor.
+   *
+   * @param \CRM_Member_Form $form
+   *   Form that is being validated.
+   * @param array $fields
+   *   List of fields for the form with their current values.
+   * @param array $errors
+   *   List of validation errors that have been found on the form.
+   */
+  public function __construct(CRM_Member_Form &$form, &$fields, &$errors) {
+    $this->form = $form;
+    $this->fields = &$fields;
+    $this->errors = &$errors;
+  }
+
+  /**
+   * Validates the form.
+   */
+  public function validate() {
+    $isOfflineAutoRenew = CRM_Utils_Array::value('offline_auto_renew', $this->fields, FALSE);
+    if ($isOfflineAutoRenew) {
+      $this->errors['offline_auto_renew'] = ts(
+        '"Auto-renew offline" is only available for memberships paid with a
+         payment plan. Please choose a payment plan, or uncheck the auto-renew 
+         option if the membership will be paid for with a single contribution.'
+      );
+    }
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -365,6 +365,9 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
     if ($contributionIsPaymentPlan) {
       $paymentPlanValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($form, $fields, $errors);
       $paymentPlanValidateHook->validate();
+    } else {
+      $contributionValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipContribution($form, $fields, $errors);
+      $contributionValidateHook->validate();
     }
   }
 }


### PR DESCRIPTION
## Overview
We have decided to ignore Auto-Renewal scenarios if Contribution tab is selected as this is not a possible real time scenario.

## Before
Currently there are two ways to create Single Payment Membership with Auto-Renew and we need to add a validation to "Auto-Renew offline" field to ensure it cannot be selected if “contribution” tab is enabled:
1. Select Contribution Tab and Auto-Renew Offline
1. Select Payment Plan Tab, 1 Installment 1 Year and Auto-Renew Offline

## After
Added validation on membership creation form so an error message is shown if auto-renew is enabled and it is being paid for with a single contribution from Contribution Tab:

> "Auto-renew offline" is only available for memberships paid with a payment plan. Please choose a payment plan, or uncheck the auto-renew option if the membership will be paid for with a single contribution.