### PR TITLE
MAE-178: Fix Validation of Membership Type Change

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipUpdate.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipUpdate.php
@@ -68,11 +68,11 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate {
   private function isPaymentPlan() {
     $contribution = $this->getLastMembershipPayment();
 
-    if (empty($contribution['contribution_recur_id'])) {
+    if (empty($contribution['contribution_id.contribution_recur_id'])) {
       return FALSE;
     }
 
-    $recurringContribution = $this->getRecurringContribution($contribution['contribution_recur_id']);
+    $recurringContribution = $this->getRecurringContribution($contribution['contribution_id.contribution_recur_id']);
     $processorID = CRM_Utils_Array::value('payment_processor_id', $recurringContribution);
     $isManualPaymentPlan = ManualPaymentProcessors::isManualPaymentProcessor($processorID);
 


### PR DESCRIPTION
## Overview
Validation error is not thrown as expected,

Membership signup with payment plan and without Auto-renew and then change the Membership Type to a different one using 'Edit Membership' form.  Expected validation error is not displayed. Instead it allows the user to edit membership type with a warning message.

## Before
When checking if a membership was part of a payment plan, all memberships were determined to be outside of a manual payment plan, due to a bug in evaluating the recurring contribution id.

## After
Fixed bug by using the correct array key to obtain the recurring contribution associated to the membership.