### PR TITLE
MAE-161: Show Membership End Dates Instead of Largest End Date

### DIFF
--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -46,7 +46,13 @@
       <tr id="lineitem-{$currentItem.id}" data-item-data='{$currentItem|@json_encode}' class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
         <td>{$currentItem.label}</td>
         <td>{$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}</td>
-        <td>{$periodEndDate|crmDate}</td>
+        <td>
+          {if $currentItem.related_membership.end_date}
+            {$currentItem.related_membership.end_date|date_format:"%Y-%m-%d"|crmDate}
+          {else}
+            {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
+          {/if}
+        </td>
         {if $recurringContribution.auto_renew}
           <td>
               <input type="checkbox" class="auto-renew-line-checkbox"{if $currentItem.auto_renew} checked{/if} />


### PR DESCRIPTION
## Overview
When you are trying to add a line item on manage installments with a different end date and biggest one, it also updates the end date of existing line items of the recurring contribution. This is working as per the logic - biggest end date among all linked memberships.

But on Membership tab, date values are different.

## Before
Largest end date was being used to show as the end date of each line item of the payment plan.

## After
Loaded membership end dates to show them on each line item. Left period end date (ie. largest memberhip end date) as end dates of lines that are not memberships.