### PR TITLE
MAE-192: Allow editing/overriding auto-renewal/payment plan membership status after its creation

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipEdit.php
@@ -1,0 +1,35 @@
+<?php
+
+class CRM_MembershipExtras_Hook_BuildForm_MembershipEdit {
+
+
+  /**
+   * @var CRM_Member_Form_Membership
+   */
+  private $form;
+
+  /**
+   * @param \CRM_Member_Form_Membership $form
+   */
+  public function __construct(CRM_Member_Form_Membership $form) {
+    $this->form = $form;
+  }
+
+  public function buildForm() {
+    $this->allowMembershipStatusChange();
+  }
+
+  /**
+   * CiviCRM core prevents editing auto-renewal
+   * membership status by override using the edit
+   * form, but Membershipextras workflow is different
+   * from CiviCRM core and changing the membership
+   * status should be allowed which is what this
+   * method does.
+   */
+  private function allowMembershipStatusChange() {
+    $isOverrideElement = $this->form->getElement('is_override');
+    $isOverrideElement->unfreeze();
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -286,6 +286,11 @@ function membershipextras_civicrm_postProcess($formName, &$form) {
  * Implements hook_civicrm_buildForm()
  */
 function membershipextras_civicrm_buildForm($formName, &$form) {
+  if ($formName === 'CRM_Member_Form_Membership' && ($form->getAction() & CRM_Core_Action::UPDATE)) {
+    $offlineAutoRenew = new CRM_MembershipExtras_Hook_BuildForm_MembershipEdit($form);
+    $offlineAutoRenew->buildForm();
+  }
+
   if (
     ($formName === 'CRM_Member_Form_Membership' && ($form->getAction() & CRM_Core_Action::ADD))
     || ($formName === 'CRM_Member_Form_MembershipRenewal' && ($form->getAction() & CRM_Core_Action::RENEW))


### PR DESCRIPTION
## Problem

Users cannot change/override the status of an auto-renewal or payment plan membership after its creation.

![2020-01-24 03_12_55-Calendar](https://user-images.githubusercontent.com/6275540/73037428-b2bc8e80-3e57-11ea-9c91-67bbc2601e65.png)


## Solution

Overriding status in membership edit form is available for auto-renewal and payment plan memberships.

![2020-01-24 03_13_25-wewdefw ewffew _ m7civi519](https://user-images.githubusercontent.com/6275540/73037437-b9e39c80-3e57-11ea-9608-3c4ef164b3c3.png)

## Technical notes

The described behavior is something coming from CiviCRM core and was introduced in this core PR : https://github.com/civicrm/civicrm-core/pull/12642

But our workflow in membershipextras extension is different from the core one and overriding the status for such cases should be allowed, which was achieved by basically unfreezing the is_override element which is frozen by default by CiviCRM core.
