### PR TITLE
MAE-195: Fix Calculation of Renewed Period Start Date

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -106,7 +106,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $paymentProcessorID = !empty($currentRecurContribution['payment_processor_id']) ? $currentRecurContribution['payment_processor_id'] : NULL;
 
     $this->paymentPlanStartDate = $this->calculateNewPeriodStartDate();
-    $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate();
+    $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate() ?: $this->paymentPlanStartDate;
     $paymentInstrumentName = $this->getPaymentMethodNameFromItsId($currentRecurContribution['payment_instrument_id']);
 
     $newRecurringContribution = civicrm_api3('ContributionRecur', 'create', [
@@ -141,8 +141,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
   }
 
   /**
-   * Calculates the new period's start date from the largest membership end date
-   * of the previous period.
+   * Calculates the new period's start date.
    *
    * @return string
    *   The new period's start date.
@@ -170,6 +169,10 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
         continue;
       }
 
+      if (empty($lineItem['memberhsip_end_date'])) {
+        continue;
+      }
+
       $membershipEndDate = new DateTime($lineItem['memberhsip_end_date']);
       if (!isset($latestDate)) {
         $latestDate = $membershipEndDate;
@@ -183,7 +186,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
       return $latestDate->format('Y-m-d');
     }
 
-    return $this->calculateNewPeriodStartDate();
+    return NULL;
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -49,6 +49,13 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   protected $paymentPlanStartDate;
 
   /**
+   * Start date for renewed memberships.
+   *
+   * @var
+   */
+  protected $membershipsStartDate;
+
+  /**
    * True if we should use the membership latest price
    * for renewal or false otherwise.
    *
@@ -529,7 +536,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       $existingMembershipID = $this->getExistingMembershipForLineItem($lineItem, $priceFieldValue);
 
       if ($existingMembershipID) {
-        $this->extendExistingMembership($existingMembershipID, $lineItem['start_date']);
+        $this->extendExistingMembership($existingMembershipID, $this->membershipsStartDate);
       } else {
         $existingMembershipID = $this->createMembership($lineItem, $priceFieldValue);
       }
@@ -590,7 +597,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       'contact_id' => $this->currentRecurringContribution['contact_id'],
       'membership_type_id' => $priceFieldValue['membership_type_id'],
       'join_date' => date('YmdHis'),
-      'start_date' => $lineItem['start_date'],
+      'start_date' => $this->membershipsStartDate,
       'end_date' => $lineItem['end_date'],
       'contribution_recur_id' => $this->newRecurringContributionID,
     ]);

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -45,7 +45,13 @@
 
       <tr id="lineitem-{$currentItem.id}" data-item-data='{$currentItem|@json_encode}' class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
         <td>{$currentItem.label}</td>
-        <td>{$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}</td>
+        <td>
+          {if $currentItem.related_membership.start_date}
+            {$currentItem.related_membership.start_date|date_format:"%Y-%m-%d"|crmDate}
+          {else}
+            {$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}
+          {/if}
+        </td>
         <td>
           {if $currentItem.related_membership.end_date}
             {$currentItem.related_membership.end_date|date_format:"%Y-%m-%d"|crmDate}


### PR DESCRIPTION
## Overview
Period start date for a renewed payment plan with multiple installments should be calculated by using the previous period end date and adding 1 day.

## Before
Period start date was being determined by calculating the recieve date of the nth+1 installment. Eg. on a payment plan with 12 installments, the new period's start date would've been the recieve date of what would be the 13th installment.

## After
Period start date is now alculated from the previos period's start date (largest membership end date) and adding one day. If a payment plan is being renewed without any memberships, start date of new perios id still calculated from nth+1 installment recieve date.