### PR TITLE
MAE-195: Fix membership start date for single installment auto-renewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -154,42 +154,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
   }
 
   /**
-   * Calculates the start date renewed memberships should have.
-   *
-   * @return string
-   *   Date the renewed memberships should have as start date.
-   *
-   * @throws \Exception
-   */
-  private function calculateRenewedMembershipsStartDate() {
-    $latestDate = NULL;
-    $currentPeriodLines = $this->getRecurringContributionLineItemsToBeRenewed($this->currentRecurContributionID);
-    foreach ($currentPeriodLines as $lineItem) {
-      if ($lineItem['entity_table'] != 'civicrm_membership') {
-        continue;
-      }
-
-      if (empty($lineItem['memberhsip_end_date'])) {
-        continue;
-      }
-
-      $membershipEndDate = new DateTime($lineItem['memberhsip_end_date']);
-      if (!isset($latestDate)) {
-        $latestDate = $membershipEndDate;
-      } elseif ($latestDate < $membershipEndDate) {
-        $latestDate = $membershipEndDate;
-      }
-    }
-
-    if ($latestDate) {
-      $latestDate->add(new DateInterval('P1D'));
-      return $latestDate->format('Y-m-d');
-    }
-
-    return NULL;
-  }
-
-  /**
    * Obtains membership identified with provided ID.
    *
    * @param int $id
@@ -291,7 +255,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
       AND msl.contribution_recur_id = %1
       AND msl.auto_renew = 1
       AND msl.is_removed = 0
-    ';
+      ';
       $dbResultSet = CRM_Core_DAO::executeQuery($q, [
         1 => [$recurringContributionID, 'Integer'],
       ]);

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -799,4 +799,40 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
     return FALSE;
   }
 
+  /**
+   * Calculates the start date renewed memberships should have.
+   *
+   * @return string
+   *   Date the renewed memberships should have as start date.
+   *
+   * @throws \Exception
+   */
+  protected function calculateRenewedMembershipsStartDate() {
+    $latestDate = NULL;
+    $currentPeriodLines = $this->getRecurringContributionLineItemsToBeRenewed($this->currentRecurContributionID);
+    foreach ($currentPeriodLines as $lineItem) {
+      if ($lineItem['entity_table'] != 'civicrm_membership') {
+        continue;
+      }
+
+      if (empty($lineItem['memberhsip_end_date'])) {
+        continue;
+      }
+
+      $membershipEndDate = new DateTime($lineItem['memberhsip_end_date']);
+      if (!isset($latestDate)) {
+        $latestDate = $membershipEndDate;
+      } elseif ($latestDate < $membershipEndDate) {
+        $latestDate = $membershipEndDate;
+      }
+    }
+
+    if ($latestDate) {
+      $latestDate->add(new DateInterval('P1D'));
+      return $latestDate->format('Y-m-d');
+    }
+
+    return NULL;
+  }
+
 }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -13,6 +13,13 @@ use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as Installment
 class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
 
   /**
+   * List of line items to be renewed.
+   *
+   * @var array
+   */
+  private $linesToBeRenewed = [];
+
+  /**
    * Obtains list of payment plans with a single installment that are ready to
    * be renewed. This means:
    *
@@ -124,6 +131,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
     $this->buildLineItemsParams();
     $this->setTotalAndTaxAmount();
     $this->paymentPlanStartDate = $this->calculateNoInstallmentsPaymentPlanStartDate();
+    $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate() ?: $this->paymentPlanStartDate;
 
     $this->recordPaymentPlanFirstContribution();
     $this->renewPaymentPlanMemberships($this->currentRecurContributionID);
@@ -232,35 +240,28 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
    * @inheritdoc
    */
   protected function getRecurringContributionLineItemsToBeRenewed($recurringContributionID) {
-    $lineItems = civicrm_api3('ContributionRecurLineItem', 'get', [
-      'sequential' => 1,
-      'contribution_recur_id' => $recurringContributionID,
-      'auto_renew' => 1,
-      'is_removed' => 0,
-      'end_date' => ['IS NULL' => 1],
-      'api.LineItem.getsingle' => [
-        'id' => '$value.line_item_id',
-        'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1],
-      ],
-    ]);
+    if (!isset($this->linesToBeRenewed[$recurringContributionID])) {
+      $q = '
+      SELECT msl.*, li.*, m.end_date AS memberhsip_end_date
+      FROM membershipextras_subscription_line msl, civicrm_line_item li
+      LEFT JOIN civicrm_membership m ON li.entity_id = m.id
+      WHERE msl.line_item_id = li.id
+      AND msl.contribution_recur_id = %1
+      AND msl.auto_renew = 1
+      AND msl.is_removed = 0
+      AND msl.end_date IS NULL
+      ';
+      $dbResultSet = CRM_Core_DAO::executeQuery($q, [
+        1 => [$recurringContributionID, 'Integer'],
+      ]);
 
-    if (!$lineItems['count']) {
-      return [];
+      $this->linesToBeRenewed[$recurringContributionID] = [];
+      while ($dbResultSet->fetch()) {
+        $this->linesToBeRenewed[$recurringContributionID][] = $dbResultSet->toArray();
+      }
     }
 
-    $result = [];
-    foreach ($lineItems['values'] as $line) {
-      $lineData = $line;
-      $lineData['subscription_line_id'] = $line['id'];
-      unset($lineData['id']);
-      unset($lineData['api.LineItem.getsingle']);
-      $lineData = array_merge($lineData, $line['api.LineItem.getsingle']);
-
-      $result[] =  $lineData;
-    }
-
-    return $result;
+    return $this->linesToBeRenewed[$recurringContributionID];
   }
 
   /**


### PR DESCRIPTION
## Before

When auto-renewing a single installment membership, the start date remains the same instead of getting updated to reflect the new term start date.

for example, create a single installment autorenewal membership with : 

- start date = 1/1/2017
- end date = 31/12/2017 ( will be set automatically if the membership is 1 year term)
- payment plan start date = 10/1/2017 with frequency 1 Year

after auto-renewal, a new contribution with receive date = 10/1/2018 will be created, where the membership end date will become 31/12/2018, but the membership start date will remain 1/1/2017 instead of 1/1/2018.

## After

Auto-renewing a membership with single installment is also updating the start date of the membership to reflect the new term.

so in the above example, the membership start date will become 1/1/2018 .

