### PR TITLE
MAE-203: Prevent adding additional memberships with end date after max end date of the period

### DIFF
--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -569,6 +569,12 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
       return false;
     }
 
+    var periodEndDate = new Date(CRM.$('#current_period_end_date').html());
+    if (endDate > periodEndDate) {
+      CRM.alert('<p>Additional memberships must end on or before the end date of the period. Please select a different end date for the membership.</p>', 'Dates Validation', 'error', {expires: NOTIFICATION_EXPIRE_TIME_IN_MS});
+      return false;
+    }
+
     return true;
   };
 

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -19,6 +19,7 @@
   &nbsp;&nbsp;&nbsp;
   Period End Date: {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
 </div>
+<span id="current_period_end_date" style="display: none;">{$periodEndDate}</span>
 <form>
   <input name="recurringContributionID" id="recurringContributionID" value="{$recurringContributionID}" type="hidden" />
   <table class="selector row-highlight" id="currentPeriodLineItems">


### PR DESCRIPTION
## Before

In manage installments screen, the user can add a membership line with an end date larger than the period end date  (which is the largest date of any membership lines in the period).

![beefff](https://user-images.githubusercontent.com/6275540/74061456-f381df00-49e3-11ea-89cf-b3811da3eb45.gif)



## After

If the user tried to add membership line in manage installments screen with an end date that is after the max end date of the period, the following error notification will appear : 

```
Additional memberships must end on or before the end date of the period. Please select a different end date for the membership.
```

![afff](https://user-images.githubusercontent.com/6275540/74061472-fa105680-49e3-11ea-8f17-9b730f4471c5.gif)
