### PR TITLE
MAE-219: Improvements to manage installments UI

### DIFF
--- a/js/NextPeriodLineItemHandler.js
+++ b/js/NextPeriodLineItemHandler.js
@@ -344,6 +344,7 @@ function showNextPeriodLineItemRemovalConfirmation(lineItemData) {
       }
     });
   }).on('crmConfirm:no', function() {
+    CRM.refreshParent('#periodsContainer');
     return;
   });
 }


### PR DESCRIPTION
## Overview 
In Manage Installments page, when updating “renew automatically” checkbox and click cancel, the selected option is not cancelled

## Before
1. Create a membership with payment plan , Auto-renew set & submit
2. Go to Recurring contribution -> Manage Installments and see membership line item is shows with 'Renew Automatically' check box selected.
3. Un-check the 'Renew Automatically' field and see a popup to remove the line item is displayed. Click on 'Cancel' button.
4. 'Renew Automatically' field is still showing unchecked. It should be checked again after cancelling.- Incorrect

![beefff](https://user-images.githubusercontent.com/6275540/77901468-879b5480-7277-11ea-94a4-d4bbc01961cc.gif)



## After

![afffff](https://user-images.githubusercontent.com/6275540/77901483-8b2edb80-7277-11ea-8d3f-4ea127ce6c37.gif)
