### PR TITLE
ASESPRT-179: Show Contribution Receive Date as Invoice Date

### DIFF
--- a/CRM/MembershipExtras/Hook/Alter/MailParamsHandler.php
+++ b/CRM/MembershipExtras/Hook/Alter/MailParamsHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_Alter_MailParamsHandler.
+ *
+ * Implements alterMailParams hook.
+ */
+class CRM_MembershipExtras_Hook_Alter_MailParamsHandler {
+
+  /**
+   * Parameters being passed to template.
+   *
+   * @var array
+   */
+  private $params = [];
+
+  public function __construct(&$params) {
+    $this->params =& $params;
+  }
+
+  /**
+   * Alters the parameters for the e-mail.
+   */
+  public function handle() {
+    $this->useReceiveDateAsInvoiceDate();
+  }
+
+  /**
+   * Changes the invoice date to be the contribution's receive date.
+   */
+  public function useReceiveDateAsInvoiceDate() {
+    if (empty($this->params['valueName']) || $this->params['valueName'] != 'contribution_invoice_receipt') {
+      return;
+    }
+
+    $contribution = civicrm_api3('Contribution', 'getsingle', [
+      'id' => $this->params['tplParams']['id'],
+    ]);
+
+    $this->params['tplParams']['invoice_date'] = date('F j, Y', strtotime($contribution['receive_date']));
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -424,3 +424,14 @@ function membershipextras_civicrm_preProcess($formName, $form) {
     $preProcessor->preProcess();
   }
 }
+
+/**
+ * Implements alterMailParams hook.
+ *
+ * @param array $params
+ * @param $context
+ */
+function membershipextras_civicrm_alterMailParams(&$params, $context) {
+  $alterMailParamsHook = new CRM_MembershipExtras_Hook_Alter_MailParamsHandler($params);
+  $alterMailParamsHook->handle();
+}


### PR DESCRIPTION
## Overview
When you print an invoice of a contribution, today's date is displayed on the invoice instead of the receive date.

## Before
CiviCRM always uses current date as the invoice date on the template used to produce the PDF.

![image](https://user-images.githubusercontent.com/21999940/78031629-6bf08680-7329-11ea-94c7-2a77dd822995.png)

## After
Invoice date is set to be the contribution's receive date.

![image](https://user-images.githubusercontent.com/21999940/78031548-4e232180-7329-11ea-8ae8-3044646965fa.png)
