### PR TITLE
MAE-227: Update Recurring Contribution Start Date on Cycle Day Change

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -79,10 +79,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
       $params['next_sched_contribution_date'] = $this->nextContributionDate;
 
       $firstInstallment = $this->getFirstInstallment();
-      $isInstallmentPending = $firstInstallment['contribution_status'] == 'Pending';
-      $isReceiveDateInFuture = !$this->isReceiveDateInThePast($firstInstallment);
-
-      if ($isInstallmentPending && $isReceiveDateInFuture) {
+      if ($firstInstallment['contribution_status'] == 'Pending') {
         $params['start_date'] = $firstInstallment['receive_date'];
       }
     }

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -75,9 +75,28 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
 
     if ($this->isUpdatedCycleDate()) {
       $params['next_sched_contribution_date'] = $this->nextContributionDate;
+      $params['start_date'] = $this->calculateNewStartDate();
     }
 
     civicrm_api3('ContributionRecur', 'create', $params);
+  }
+
+  /**
+   * Calculates the new start date for the recurring contribution.
+   *
+   * Uses cycle day to calculate the start date for the contribution.
+   *
+   * @return string
+   */
+  private function calculateNewStartDate() {
+    $formValues = $this->form->exportValues();
+    $currentStartDate = new DateTime($this->recurringContribution['start_date']);
+
+    $newStartDate = new DateTime(
+      $currentStartDate->format('Y-m-') . $formValues['cycle_day']
+    );
+
+    return $newStartDate->format('Y-m-d');
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -265,7 +265,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
     }
 
     $params = [];
-    if ($this->isUpdatedCycleDate() && $this->isReceiveDateInTheFuture($contribution)) {
+    if ($this->isUpdatedCycleDate() && !$this->isReceiveDateInThePast($contribution)) {
       $params['receive_date'] = $this->receiveDateCalculator->calculate($installmentNumber);
 
       if (empty($this->nextContributionDate)) {
@@ -291,11 +291,11 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
    * @return bool
    * @throws \Exception
    */
-  private function isReceiveDateInTheFuture($contribution) {
+  private function isReceiveDateInThePast($contribution) {
     $now = new DateTime();
     $receiveDate = new DateTime($contribution['receive_date']);
 
-    if ($receiveDate > $now) {
+    if ($receiveDate < $now) {
       return TRUE;
     }
 

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -85,7 +85,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
    */
   private function updateSubscriptionLineItems() {
     $autoRenew = $this->form->getElementValue('auto_renew');
-    
+
     if (!$autoRenew) {
       return;
     }
@@ -101,7 +101,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
       ]
     ]);
   }
-  
+
   /**
    * Updates membership if necessary.
    */

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -79,11 +79,11 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
       $params['next_sched_contribution_date'] = $this->nextContributionDate;
 
       $firstInstallment = $this->getFirstInstallment();
-      $isInstallmentPending = $firstInstallment['contribution_status'] != 'Pending';
+      $isInstallmentPending = $firstInstallment['contribution_status'] == 'Pending';
       $isReceiveDateInFuture = !$this->isReceiveDateInThePast($firstInstallment);
 
       if ($isInstallmentPending && $isReceiveDateInFuture) {
-        $params['start_date'] = $this->getFirstInstallment() ?: $params['start_date'];
+        $params['start_date'] = $firstInstallment['receive_date'];
       }
     }
 
@@ -105,8 +105,8 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
       'options' => ['limit' => 1, 'sort' => 'receive_date ASC'],
     ]);
 
-    if (count($contributions)) {
-      return $contributions[0];
+    if ($contributions['count'] > 0) {
+      return $contributions['values'][0];
     }
 
     return [];

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -308,7 +308,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
    * @throws \Exception
    */
   private function isReceiveDateInThePast($contribution) {
-    $now = new DateTime();
+    $now = new DateTime(date('Y-m-d 00:00:00'));
     $receiveDate = new DateTime($contribution['receive_date']);
 
     if ($receiveDate < $now) {


### PR DESCRIPTION
## Overview
When Cycle Day of a recurring contribution is changed, its start date is not updated.

## Before
Changing the cycle day did not update the recurring contribution's start date.

## After
Changing the cycle day will recalculate the start date, based on the new cycle day.

## Notes
The file CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php had wrong line endings. I separated the line-endings fix in a different commit, and added a second commit with just the fixes done to update the recurring contribution's start date, to facilitate review.