### PR TITLE
MAE-242: Stop Showing Payment Plan Toggler on Submit Card Membership

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
@@ -46,6 +46,10 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan {
    * juggles around exiting ones.
    */
   private function addPaymentPlanSection() {
+    if ($this->form->_mode === 'live') {
+      return;
+    }
+
     $paymentToggler = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String', $this->form, FALSE);
     $this->form->assign('contribution_type_toggle', $paymentToggler ?: 'contribution');
 

--- a/tests/phpunit/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlanTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlanTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlanTest extends BaseHeadlessTest {
+
+  private $membershipCreationForm;
+
+  public function setUp() {
+    $formController = new CRM_Core_Controller();
+    $this->membershipCreationForm = new CRM_Member_Form_Membership();
+    $this->membershipCreationForm->controller = $formController;
+  }
+
+  public function testPaymentPlanTogglerGetsAddedToPayLaterMembershipCreationForm() {
+    $this->membershipCreationForm->_mode = NULL;
+
+    $mebershipBuildFormHook = new CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan($this->membershipCreationForm);
+    $mebershipBuildFormHook->buildForm();
+
+    $installmentsField = $this->membershipCreationForm->getElement('installments');
+    $this->assertTrue(is_object($installmentsField));
+  }
+
+  public function testPaymentPlanTogglerIsNotAddedToCreditCardLiveMembershipCreationForm() {
+    $this->membershipCreationForm->_mode = 'live';
+
+    $mebershipBuildFormHook = new CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan($this->membershipCreationForm);
+    $mebershipBuildFormHook->buildForm();
+
+    $this->expectException(PEAR_Exception::class);
+    $this->membershipCreationForm->getElement('installments');
+  }
+
+}


### PR DESCRIPTION
## Overview
The memberships tab of a contact record has a 'Submit Credit Card Membership' button. Clicking it will open a form to use live payment methods to add a membership. 'Payment Plan' option is displayed. This is not supported for Credit card membership and only 'Contribution' option should be displayed here. 

## Before
The same form is used by CiviCRM to show both the offline and on-line membership creation forms. The only thing that distinguishes onw from the other is the use of a 'mode' variable that, in the case of Credit Card Memberships, will hold the value 'live'.

![image](https://user-images.githubusercontent.com/21999940/78169774-8dc83700-7417-11ea-85f1-ed1799e209ef.png)

## After
Fix by checking the mode of the form, so that if it is 'live', the payment plan toggle functionality is not added at the buildForm stage.

![image](https://user-images.githubusercontent.com/21999940/78169879-b5b79a80-7417-11ea-8aeb-0fd43e6197da.png)
