### PR TITLE
MAE-259: Remove Deleted Lines from Installments

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -235,6 +235,13 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
 
       // Record financial item on cancellation of lineitem
       CRM_MembershipExtras_Service_FinancialTransactionManager::insertFinancialItemOnLineItemDeletion($lineItemBefore);
+
+      // Remove line item from contribution
+      civicrm_api3('LineItem', 'create', [
+        'id' => $lineItemBefore['id'],
+        'label' => $lineItemBefore['label'] . " - Line removed from contribution [{$lineItemBefore['contribution_id']}]",
+        'contribution_id' => 'null',
+      ]);
     }
   }
 


### PR DESCRIPTION
## Overview
When removing a line item from a payment plan, corresponding lines on installments are left, although their amounts are changed and thus the actual amounts for the contributions show the appropriate value. But if a line is removed from the payment plan, it should no longer appear in the contribution overview. 

## Before
When deleting lines from a payment plan, respective lines on contributions on installments were being set to 0 quantity and total. Thus, they still showed on contributions and invoices. This is done as the financial transactions required by civicrm to record the amount change of the contribution require the refernce to the line item

## After
Fixed by doing a soft delete of the line after financial calculations are done by setting contribution_id to null on the line item, thus removing it from the related contribution.
