### PR TITLE
MAE-263: Prevent completing the contribution from the contribution edit form

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/ContributionEdit.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/ContributionEdit.php
@@ -1,0 +1,13 @@
+<?php
+
+class CRM_MembershipExtras_Hook_BuildForm_ContributionEdit {
+
+  public function buildForm() {
+    $this->addPreventCompletingContributionJSFile();
+  }
+
+  private function addPreventCompletingContributionJSFile() {
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.membershipextras', 'js/preventCompletingContribution.js');
+  }
+
+}

--- a/js/preventCompletingContribution.js
+++ b/js/preventCompletingContribution.js
@@ -1,0 +1,6 @@
+CRM.$(function($) {
+  var selectedContributionStatus = $('#contribution_status_id option:selected').text();
+  if (selectedContributionStatus == 'Pending') {
+    $('#contribution_status_id option:contains(Completed)').hide();
+  }
+});

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -319,6 +319,11 @@ function membershipextras_civicrm_buildForm($formName, &$form) {
     $membershipTypeHook = new CRM_MembershipExtras_Hook_BuildForm_MembershipTypeColour($form);
     $membershipTypeHook->buildForm();
   }
+
+  if ($formName === 'CRM_Contribute_Form_Contribution') {
+    $membershipTypeHook = new CRM_MembershipExtras_Hook_BuildForm_ContributionEdit();
+    $membershipTypeHook->buildForm();
+  }
 }
 
 /**


### PR DESCRIPTION
## Before

Users could complete a single contribution mainly using two methods, either from the contribution edit form or using the "Record payment" option, And since civicrm core runs different code for each method that is becoming sometimes annoying to support both ways, so we decided to minimize the ways in which users can complete contributions so they can now only use the "Record Payment" option to complete contributions.

![aaaadd](https://user-images.githubusercontent.com/6275540/78947987-a0a1d200-7acf-11ea-922e-59a100e9a8ed.gif)

 

## After
If the the contribution status is Pending, then you cannot change it to Completed.

![dadsdsdas](https://user-images.githubusercontent.com/6275540/78947995-a7304980-7acf-11ea-87c1-47cd4d0fa631.gif)

