### PR TITLE
MAE-217: Update membership status rules for future start date cases

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -430,4 +430,27 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Compuclient Database is already
+   * upgrader to upgrade_0002 which means
+   * that the old current_renew status
+   * is still on it. This upgrader is to provide
+   * support for Compuclient sites by removing
+   * the old status and force creating the new
+   * ones.
+   */
+  public function upgrade_0003() {
+    $this->removeOldCurrentRenewMembershipStatusRule();
+    $this->createFutureMembershipStatusRules();
+
+    return TRUE;
+  }
+
+  private function removeOldCurrentRenewMembershipStatusRule() {
+    civicrm_api3('MembershipStatus', 'get', [
+      'name' => 'current_renew',
+      'api.MembershipStatus.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
 }


### PR DESCRIPTION
## Before

Currently out the box CiviCRM does not have a status rule configured where the start date is in the future.

With membership extra's there are a few situations where a start date could be in the future:

1. Where a member has signed up and the membership line is planned to start on a future date. This could be on it's own or part of a payment plan.

2. When the automated renewal runs, membership extra will change the start date of the membership to be +1 day from the end date. The issue being that normally the renewal will be configured to run several days before the end date so that invoices are created in good time for the renewal, thus the start date will be in the future.

As such CiviCRM did not have a membership status to give to those memberships.

In the case of 2 above, this was a problem as the membership would not have a "current" status and members would lose their benefits when the renewal was run.

As such we added a membership status for memberships that have the following configurations:

![screenshot-compuclient-mev21-s35 compubox co uk-2020 04 10-12_19_52](https://user-images.githubusercontent.com/6275540/79262459-08726700-7e9a-11ea-84f5-2ae7d4c1c675.png)

so that any memberships with a start date in the future would get this status, which would be another "current" status, however this is a problem as case 1 above should not have a current status.


## After

We replaced the previous status rule with the following two statues rules : 

A status which covers 1:

- Name : **Future Start**
- Membership since in the future
- Membership start date in the future
- "Current Membership" option is disabled


A status which covers 2:
- Name : **Current Renewed**
- Membership since in the past
- Membership start date in the future
- "Current Membership" option is enabled


The configuration for each status rule goes as following : 

1- **Future Start** status rule : 

- Start Event : Membership Join Date; Adjustment Interval/Unit : -1000 years
- End Event : Membership Start Date
- Order (Weight) : The last one, so it applies if no other status rule applies (given that it meet the conditions above)

2-  **Current Renewed** : 
- Start Event : Membership Join Date; Adjustment Interval/Unit : 1 day
- End Event : Membership Start Date; Adjustment Interval/Unit : -1 day
- Order (Weight) : The first one, since the "New" Status will be set instead if this was the last one in order and we need to prevent that.


![2020-04-14 20_01_13-Membership Status Rules _ s1mev2](https://user-images.githubusercontent.com/6275540/79263450-8420e380-7e9b-11ea-8184-da9ac6de81ab.png)


And while these configurations  for these two status rules might look a bit odd, they actually cover what we are trying to do, since CiviCRM core at the end, compare the dates for every status rule like this : 

```
// for every status rule
if ((today date >= (start event date +/- adjustment amount)) && (today date <= (end event date +/- adjustment amount)){
    // if true, set the membership status
   // skip the other status rules 
}
```
