### PR TITLE
MAE-271: Fix Removal of Multiple Donation Items from a Plan

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -291,7 +291,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
         'entity_id' => $entityID,
         'price_field_id' => $this->recurringLineItemData['price_field_id'],
         'price_field_value_id' => $this->recurringLineItemData['price_field_value_id'],
-        'financial_type_id' => $this->recurringLineItemData['price_field_value_id'],
+        'financial_type_id' => $this->recurringLineItemData['financial_type_id'],
         'qty' => $this->recurringLineItemData['qty'],
         'unit_price' => $this->recurringLineItemData['unit_price'],
         'options' => ['limit' => 1],

--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -282,7 +282,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
       $contributionID : $this->recurringLineItemData['entity_id']
     ;
 
-    $lineITem = [];
+    $lineItem = [];
     try {
       $apiResponse = civicrm_api3('LineItem', 'get', [
         'sequential' => 1,
@@ -297,13 +297,13 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
         'options' => ['limit' => 1],
       ]);
       if ($apiResponse['count'] > 0) {
-        $lineITem = $apiResponse['values'][0];
+        $lineItem = $apiResponse['values'][0];
       }
     } catch (Exception $e) {
       return [];
     }
 
-    return $lineITem;
+    return $lineItem;
   }
 
   /**

--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -268,10 +268,12 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
   }
 
   /**
-   * Obtains information about the line item that corresponds to the one being
-   * deleted from the recurring contribution for the given contribution.
+   * Returns line item to be deleted from the contribution.
    *
-   * @param $contributionID
+   * Obtains information about the line item that corresponds to the one being
+   * deleted from the recurring contribution for the given contribution ID.
+   *
+   * @param int $contributionID
    *
    * @return array
    */
@@ -280,20 +282,28 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
       $contributionID : $this->recurringLineItemData['entity_id']
     ;
 
+    $lineITem = [];
     try {
-      $lineItem = civicrm_api3('LineItem', 'getsingle', [
+      $apiResponse = civicrm_api3('LineItem', 'get', [
         'sequential' => 1,
         'entity_table' => $this->recurringLineItemData['entity_table'],
         'contribution_id' => $contributionID,
         'entity_id' => $entityID,
         'price_field_id' => $this->recurringLineItemData['price_field_id'],
         'price_field_value_id' => $this->recurringLineItemData['price_field_value_id'],
+        'financial_type_id' => $this->recurringLineItemData['price_field_value_id'],
+        'qty' => $this->recurringLineItemData['qty'],
+        'unit_price' => $this->recurringLineItemData['unit_price'],
+        'options' => ['limit' => 1],
       ]);
+      if ($apiResponse['count'] > 0) {
+        $lineITem = $apiResponse['values'][0];
+      }
     } catch (Exception $e) {
-      $lineItem = [];
+      return [];
     }
 
-    return $lineItem;
+    return $lineITem;
   }
 
   /**


### PR DESCRIPTION
## Overview
Removal would only work if there was a single line that was not a membership, on the payment plan.

## Before
When there were multiple lines, the system did not have a reliable way to identify the line that should be removed, thus it chose to skip it, and no lines would be removed from any of the contributions.

## After
Fixed by adding more details to identify the line, and removing the first line found if several meet the criteria. Criteria being used to search for the line item was:

- 'entity_table',
- 'contribution_id'
- 'entity_id'
- 'price_field_id'
- 'price_field_value_id'

I've added:
- 'financial_type_id'
- 'qty'
- 'unit_price'

This way we can better zero-in on the line item that needs to be deleted. This may still yield more than one line item, but as discussed with @jamienovick, we can assume if lines meet all this criteria, they can be treated as equivalent, and thus any of the lines can be removed.
