### PR TITLE
MAE-274: Add contribution action that allows duplicating contributions

### DIFF
--- a/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.php
+++ b/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.php
@@ -81,7 +81,7 @@ class CRM_MembershipExtras_Form_Contribution_Action_Duplicate extends CRM_Core_F
       'id' => $this->contributionId,
       'return' => ['currency', 'contact_id',  'total_amount', 'receive_date',
         'payment_instrument_id', 'financial_type_id', 'is_test',
-        'is_pay_later', 'contribution_recur_id', 'tax_amount',
+        'contribution_recur_id', 'tax_amount',
         'contribution_page_id', 'campaign_id'],
     ])['values'][0];
 
@@ -97,7 +97,7 @@ class CRM_MembershipExtras_Form_Contribution_Action_Duplicate extends CRM_Core_F
       'financial_type_id' => $contribution['financial_type_id'],
       'is_test' => $contribution['is_test'],
       'contribution_status_id' => $this->getPendingStatusId(),
-      'is_pay_later' => $contribution['is_pay_later'],
+      'is_pay_later' => 1,
       'skipLineItem' => 1,
       'skipCleanMoney' => TRUE,
       'contribution_recur_id' => CRM_Utils_Array::value('contribution_recur_id', $contribution),
@@ -213,7 +213,7 @@ class CRM_MembershipExtras_Form_Contribution_Action_Duplicate extends CRM_Core_F
     }
 
     $updateParams = [
-      'id' => $this->recurContribution['id'],
+      'id' => $recurContributionId,
       'contribution_status_id' => $newStatus,
     ];
 

--- a/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.php
+++ b/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.php
@@ -1,0 +1,215 @@
+<?php
+
+class CRM_MembershipExtras_Form_Contribution_Action_Duplicate extends CRM_Core_Form {
+
+  /**
+   * ID of the contribution that we want to duplicate
+   *
+   * @var int
+   */
+  private $contributionId;
+
+  /**
+   * The created duplicate contribution
+   *
+   * @var CRM_Contribute_BAO_Contribution
+   */
+  private $duplicateContribution;
+
+  /**
+   * @inheritdoc
+   */
+  public function preProcess() {
+    $this->contributionId = CRM_Utils_Request::retrieve('crid', 'Positive', $this);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Duplicate As New Pending Contribution Confirmation'));
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => ts('Yes'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('No'),
+      ],
+    ]);
+  }
+
+  /**
+   * @@inheritdoc
+   */
+  public function postProcess() {
+    $this->createDuplicatePendingContribution();
+    $this->showNotification();
+  }
+
+  private function createDuplicatePendingContribution() {
+    $transaction = new CRM_Core_Transaction();
+
+    try {
+      $this->createContributionRecord();
+      $this->createSoftContribution();
+      $this->createMembershipPaymentRecord();
+      $this->copyCustomFields();
+      $this->createLineItems();
+
+      $transaction->commit();
+    }
+    catch (Exception $e) {
+      $transaction->rollback();
+    }
+  }
+
+  private function createContributionRecord() {
+    $duplicateContributionParams = $this->getContributionDuplicationParams();
+    $this->duplicateContribution = CRM_Contribute_BAO_Contribution::create($duplicateContributionParams);
+  }
+
+  private function getContributionDuplicationParams() {
+    $contribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'id' => $this->contributionId,
+      'return' => ['currency', 'contact_id',  'total_amount', 'receive_date',
+        'payment_instrument_id', 'financial_type_id', 'is_test',
+        'is_pay_later', 'contribution_recur_id', 'tax_amount',
+        'contribution_page_id', 'campaign_id'],
+    ])['values'][0];
+
+    $params =  [
+      'currency' => $contribution['currency'],
+      'source' => 'Duplicate As Pending Contribution Action',
+      'contact_id' => $contribution['contact_id'],
+      'fee_amount' => 0,
+      'net_amount' => $contribution['total_amount'],
+      'total_amount' => $contribution['total_amount'],
+      'receive_date' =>$contribution['receive_date'],
+      'payment_instrument_id' => $contribution['payment_instrument_id'],
+      'financial_type_id' => $contribution['financial_type_id'],
+      'is_test' => $contribution['is_test'],
+      'contribution_status_id' => $this->getPendingStatusId(),
+      'is_pay_later' => $contribution['is_pay_later'],
+      'skipLineItem' => 1,
+      'skipCleanMoney' => TRUE,
+      'contribution_recur_id' => CRM_Utils_Array::value('contribution_recur_id', $contribution),
+      'contribution_page_id' => CRM_Utils_Array::value('contribution_page_id', $contribution),
+      'campaign_id' => CRM_Utils_Array::value('contribution_campaign_id', $contribution),
+    ];
+
+    if (!empty($contribution['tax_amount'])) {
+      $params['tax_amount'] = $contribution['tax_amount'];
+    }
+
+    return $params;
+  }
+
+  private function getPendingStatusId() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'contribution_status',
+      'name' => 'Pending',
+    ]);
+  }
+
+  private function createSoftContribution() {
+    $softContribution = civicrm_api3('ContributionSoft', 'get', [
+      'sequential' => 1,
+      'return' => ['contact_id', 'soft_credit_type_id'],
+      'contribution_id' => $this->contributionId,
+    ]);
+    if (!empty($softContribution['values'])) {
+      $softContribution = $softContribution['values'][0];
+
+      $contributionSoftParams = [
+        'soft_credit_type_id' => $softContribution['soft_credit_type_id'],
+        'contact_id' => $softContribution['contact_id'],
+        'contribution_id' => $this->duplicateContribution->id,
+        'currency' => $this->duplicateContribution->currency,
+        'amount' => $this->duplicateContribution->amount,
+      ];
+      CRM_Contribute_BAO_ContributionSoft::add($contributionSoftParams);
+    }
+  }
+
+  private function createMembershipPaymentRecord() {
+    $membershipPayments = civicrm_api3('MembershipPayment', 'get', [
+      'return' => 'membership_id',
+      'contribution_id' => $this->contributionId,
+      'options' => ['limit' => 0],
+    ])['values'];
+    foreach ($membershipPayments as $membershipPayment) {
+      CRM_Member_BAO_MembershipPayment::create([
+        'membership_id' => $membershipPayment['membership_id'],
+        'contribution_id' => $this->duplicateContribution->id,
+      ]);
+    }
+  }
+
+  private function copyCustomFields() {
+    CRM_MembershipExtras_Service_CustomFieldsCopier::copy(
+      $this->contributionId,
+      $this->duplicateContribution->id,
+      'Contribution'
+    );
+  }
+
+  private function createLineItems() {
+    $lineItems = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'contribution_id' => $this->contributionId,
+    ])['values'];
+
+    foreach($lineItems as $lineItem) {
+      $entityID = $lineItem['entity_id'];
+      if ($lineItem['entity_table'] === 'civicrm_contribution') {
+        $entityID = $this->duplicateContribution->id;
+      }
+
+      $lineItemParms = [
+        'entity_table' => $lineItem['entity_table'],
+        'entity_id' => $entityID,
+        'contribution_id' => $this->duplicateContribution->id,
+        'price_field_id' => CRM_Utils_Array::value('price_field_id', $lineItem),
+        'label' => $lineItem['label'],
+        'qty' => $lineItem['qty'],
+        'unit_price' => $lineItem['unit_price'],
+        'line_total' => $lineItem['line_total'],
+        'price_field_value_id' => CRM_Utils_Array::value('price_field_value_id', $lineItem),
+        'financial_type_id' => $lineItem['financial_type_id'],
+        'non_deductible_amount' => $lineItem['non_deductible_amount'],
+      ];
+      if (!empty($lineItem['tax_amount'])) {
+        $lineItemParms['tax_amount'] = $lineItem['tax_amount'];
+      }
+      $newLineItem = CRM_Price_BAO_LineItem::create($lineItemParms);
+
+      CRM_Financial_BAO_FinancialItem::add($newLineItem, $this->duplicateContribution);
+
+      if (!empty((float) $this->duplicateContribution->tax_amount) && !empty($newLineItem->tax_amount)) {
+        CRM_Financial_BAO_FinancialItem::add($newLineItem, $this->duplicateContribution, TRUE);
+      }
+    }
+  }
+
+  private function showNotification() {
+    if (empty($this->duplicateContribution)) {
+      $message = ts('Something went wrong! no duplicate contribution is created.');
+      $type = 'error';
+    } elseif(!empty($this->duplicateContribution->contribution_recur_id)) {
+      $message = ts('Duplicate contribution created successfully and attached to recurring contribution');
+      $type = 'success';
+    } else {
+      $message = ts('Duplicate contribution created successfully');
+      $type = 'success';
+    }
+
+    CRM_Core_Session::setStatus($message, '', $type);
+  }
+
+}

--- a/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.php
+++ b/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.php
@@ -131,7 +131,7 @@ class CRM_MembershipExtras_Form_Contribution_Action_Duplicate extends CRM_Core_F
         'contact_id' => $softContribution['contact_id'],
         'contribution_id' => $this->duplicateContribution->id,
         'currency' => $this->duplicateContribution->currency,
-        'amount' => $this->duplicateContribution->amount,
+        'amount' => $this->duplicateContribution->total_amount,
       ];
       CRM_Contribute_BAO_ContributionSoft::add($contributionSoftParams);
     }

--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+use CRM_MembershipExtras_Service_PaymentPlanStatusCalculator as PaymentPlanStatusCalculator;
 
 class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
 
@@ -101,27 +102,8 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
    * @return string|NULL
    */
   private function generatePaymentPlanNewStatus() {
-    $paidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
-      'contribution_recur_id' => $this->recurContribution['id'],
-      'contribution_status_id' => 'Completed',
-    ]);
-
-    $partiallyPaidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
-      'contribution_recur_id' => $this->recurContribution['id'],
-      'contribution_status_id' => 'Partially paid',
-    ]);
-
-    $newStatus = NULL;
-    if ($paidInstallmentsCount >= 1 || $partiallyPaidInstallmentsCount >=  1) {
-      $newStatus = 'In Progress';
-    }
-
-    $arePaymentsCompleted = $paidInstallmentsCount >= $this->recurContribution['installments'];
-    if ($arePaymentsCompleted && $this->recurContribution['installments'] > 1) {
-      $newStatus = 'Completed';
-    }
-
-    return $newStatus;
+    $paymentPlanStatusCalculator = new PaymentPlanStatusCalculator($this->recurContribution['id']);
+    return $paymentPlanStatusCalculator->calculate();
   }
 
   private function generateNewPaymentPlanEndDate() {

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -231,6 +231,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
 
     $paymentPlanContributionsCount = civicrm_api3('Contribution', 'getcount', [
       'contribution_recur_id' => $this->currentRecurContributionID,
+      'contribution_status_id' => ['Pending', 'Completed'],
     ]);
 
     return $installmentReceiveDateCalculator->calculate($paymentPlanContributionsCount + 1);

--- a/CRM/MembershipExtras/Service/PaymentPlanStatusCalculator.php
+++ b/CRM/MembershipExtras/Service/PaymentPlanStatusCalculator.php
@@ -41,7 +41,7 @@ class CRM_MembershipExtras_Service_PaymentPlanStatusCalculator {
       'id' => $this->recurContributionId,
     ])['values'][0];
 
-    $this->installmentsCount = CRM_Utils_Array::value('installments', $this->$recurContribution, 0);
+    $this->installmentsCount = CRM_Utils_Array::value('installments', $recurContribution, 0);
     $this->currentStatusId = $recurContribution['contribution_status_id'];
   }
 

--- a/CRM/MembershipExtras/Service/PaymentPlanStatusCalculator.php
+++ b/CRM/MembershipExtras/Service/PaymentPlanStatusCalculator.php
@@ -1,0 +1,97 @@
+<?php
+
+class CRM_MembershipExtras_Service_PaymentPlanStatusCalculator {
+
+  const CONTRIBUTION_STATUS_PENDING = 'Pending';
+  const CONTRIBUTION_STATUS_INPROGRESS = 'In Progress';
+  const CONTRIBUTION_STATUS_COMPLETED = 'Completed';
+
+  private $recurContributionId;
+
+  private $contributionStatusValueMap;
+
+  private $installmentsCount;
+
+  private $currentStatusId;
+
+  public function __construct($recurContributionId) {
+    $this->recurContributionId = $recurContributionId;
+
+    $this->setContributionStatusesValueMap();
+    $this->setRecurContributionDetails();
+  }
+
+  private function setContributionStatusesValueMap() {
+    $contributionStatuses = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'contribution_status',
+      'options' => ['limit' => 0],
+    ]);
+    $contributionStatusValueMap = [];
+    foreach ($contributionStatuses['values'] as $currentStatus) {
+      $contributionStatusValueMap[$currentStatus['name']] = $currentStatus['value'];
+    }
+
+    $this->contributionStatusValueMap =  $contributionStatusValueMap;
+  }
+
+  private function setRecurContributionDetails() {
+    $recurContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'return' => ['contribution_status_id', 'installments'],
+      'id' => $this->recurContributionId,
+    ])['values'][0];
+
+    $this->installmentsCount = CRM_Utils_Array::value('installments', $this->$recurContribution, 0);
+    $this->currentStatusId = $recurContribution['contribution_status_id'];
+  }
+
+  /**
+   * Calculates the status of the payment
+   * plan (recuring contribution) based
+   * on its current status and the related
+   * contributions statuses.
+   *
+   * @param int $recurContributionId
+   *   DateTime acceptable format
+   *
+   * @return string
+   */
+  public function calculate() {
+    $processableStatuses = [
+      $this->contributionStatusValueMap[self::CONTRIBUTION_STATUS_PENDING],
+      $this->contributionStatusValueMap[self::CONTRIBUTION_STATUS_COMPLETED],
+      $this->contributionStatusValueMap[self::CONTRIBUTION_STATUS_INPROGRESS],
+    ];
+    if (!in_array($this->currentStatusId, $processableStatuses)) {
+      return NULL;
+    }
+
+    $paidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurContributionId,
+      'contribution_status_id' => self::CONTRIBUTION_STATUS_COMPLETED,
+    ]);
+
+    $partiallyPaidInstallmentsCount = civicrm_api3('Contribution', 'getcount', [
+      'contribution_recur_id' => $this->recurContributionId,
+      'contribution_status_id' => 'Partially paid',
+    ]);
+
+    $allPaid = $paidInstallmentsCount >= $this->installmentsCount;
+    $moreThanOneInstallment = $this->installmentsCount > 1;
+
+    switch (true) {
+      case $moreThanOneInstallment && $allPaid:
+        $status = self::CONTRIBUTION_STATUS_COMPLETED;
+        break;
+
+      case $paidInstallmentsCount >= 1 || $partiallyPaidInstallmentsCount >=  1:
+        $status = self::CONTRIBUTION_STATUS_INPROGRESS;
+        break;
+
+      default:
+        $status = self::CONTRIBUTION_STATUS_PENDING;
+    }
+
+    return $status;
+  }
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -399,6 +399,17 @@ function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$
     $recurContribuLinksHook = new CRM_MembershipExtras_Hook_Links_RecurringContribution($objectId, $links, $mask);
     $recurContribuLinksHook->alterLinks();
   }
+
+  if ($op == 'contribution.selector.row' && $objectName == 'Contribution') {
+    if (CRM_Core_Permission::check('edit contributions')) {
+      $links[] = [
+        'name' => 'Duplicate As New Pending Contribution',
+        'url' => 'civicrm/contribution/duplicate-contribution',
+        'qs' => 'reset=1&crid=%%id%%',
+        'title' => 'Duplicate As New Pending Contribution',
+      ];
+    }
+  }
 }
 
 /**

--- a/templates/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.tpl
+++ b/templates/CRM/MembershipExtras/Form/Contribution/Action/Duplicate.tpl
@@ -1,0 +1,8 @@
+<div class="crm-block crm-form-block">
+  <p>
+    <strong>Are you sure you would like to duplicate this contribution?</strong>
+  </p>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+</div>

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -36,4 +36,10 @@
     <title>RecurringContribution_AddDonationLineItem</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contribution/duplicate-contribution</path>
+    <page_callback>CRM_MembershipExtras_Form_Contribution_Action_Duplicate</page_callback>
+    <title>Cancel Recurring Contribution</title>
+    <access_arguments>edit contributions</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Introduction
Whilst it was originally specified that the process for retrying a direct debit payment would be as follows:

1- User creates payment batch
2- User submits payment batch using the submit button
3- Contributions are updated to completed status
4- For any failed payments user should update the status manually and set status to cancelled.
5- The batch screen should pick up any payments which are cancelled also so that it can retry
6- If the user does not want to retry then they should cancel the recurring contribution which will ensure that no further payments are displayed in the batch screen regardless of status.

Having discussed, the ability to retry payments with a cancelled status is confusing for users and there are situations where an organisation might want to take a one off payment by credit card or another payment method.

A suggested solution is to have some sort of "duplicate contribution as pending" feature outside the batch screens entirely (e.g on the contributions list) so users can duplicate any contribution they want  in pending status and for it to be available in batches .


## Before

There was no easy way to handle  (e.g retry them) cancelled or failed payments after the payment batch is submitted.

## After

A new action is added called "Duplicate As Pending Contribution" that allows users to duplicate any contribution they want as a pending contribution, the action is available on any contribution list page such as the contact contributions list and in "find contributions" results : 

![1](https://user-images.githubusercontent.com/6275540/79559586-e3e6dc80-809d-11ea-92f0-27a6306ea663.png)


![2020-04-17 13_23_44-Window](https://user-images.githubusercontent.com/6275540/79559612-f06b3500-809d-11ea-95f5-be6ddbf01bd4.png)



Here is how it work in action : 

![dadsdsdas](https://user-images.githubusercontent.com/6275540/79559933-7be4c600-809e-11ea-96d4-4a2a148080e4.gif)

This action require the user to have "CiviContribute: edit contribution".

also hence that the duplicate contribution will be attached to the same recur contribution if the original contribution is part of recur contribution.
