### PR TITLE
MAE-279: Create Only one Renewal Activity on Auto-renew

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -243,27 +243,18 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   abstract public function renew();
 
   /**
-   * Dispatches postOfflineAutoRenewal hook for each membership line item in the
-   * new payment plan.
+   * Dispatches postOfflineAutoRenewal hook for the recurring contribution.
    */
   private function dispatchMembershipRenewalHook() {
-    $recurringLineItems = $this->getNewPaymentPlanActiveLineItems();
-
-    foreach ($recurringLineItems as $lineItem) {
-      if ($lineItem['entity_table'] != 'civicrm_membership') {
-        continue;
-      }
-
-      $nullObject = CRM_Utils_Hook::$_nullObject;
-      CRM_Utils_Hook::singleton()->invoke(
-        ['membershipId', 'recurContributionId', 'previousRecurContributionId'],
-        $lineItem['entity_id'],
-        $this->newRecurringContributionID,
-        $this->currentRecurContributionID,
-        $nullObject, $nullObject, $nullObject,
-        'membershipextras_postOfflineAutoRenewal'
-      );
-    }
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    CRM_Utils_Hook::singleton()->invoke(
+      ['membershipId', 'recurContributionId', 'previousRecurContributionId'],
+      $nullObject,
+      $this->newRecurringContributionID,
+      $this->currentRecurContributionID,
+      $nullObject, $nullObject, $nullObject,
+      'membershipextras_postOfflineAutoRenewal'
+    );
   }
 
   /**


### PR DESCRIPTION
## Overview
After Auto-renewal of Direct Debit memberships, 'Offline Direct Debit Auto-renewal' activity is created for each membership but we should create one activity for each renewed payment plan.

## Before
When auto-renewing a payment plan, a hook wes being triggered for each renewed membership in it. This hook was being implemented by DD extension to create activities for the contact to record the memberships' renewal. This resulted in many activities being recorded, cluttering the contact.

## After
Triggered the hook only once, after the payment plan has been removed.