### PR TITLE
BASW-622: Hide and reserve Manage installment activity types

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -297,14 +297,18 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       ]);
 
       if ($result['count'] > 0) {
-        continue;
+        $updateParams = [
+          'id' => $result['id'],
+          'filter' => 1,
+          'is_reserved' => 1,
+        ];
+        civicrm_api3('OptionValue', 'create', $updateParams);
+      } else {
+        $optionValue['option_group_id'] = 'activity_type';
+        $optionValue['filter'] = 1;
+        $optionValue['is_reserved'] = 1;
+        civicrm_api3('OptionValue', 'create', $optionValue);
       }
-
-      civicrm_api3('OptionValue', 'create', [
-        'option_group_id' => 'activity_type',
-        'name' => $optionValue['name'],
-        'label' => $optionValue['label'],
-      ]);
     }
   }
 
@@ -451,6 +455,18 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
       'name' => 'current_renew',
       'api.MembershipStatus.delete' => ['id' => '$value.id'],
     ]);
+  }
+
+  /**
+   * We here recreate manage installment
+   * activity types if they do not exist,
+   * if they do then we update them to be
+   * reserved and hidden.
+   */
+  public function upgrade_0004() {
+    $this->createManageInstallmentActivityTypes();
+
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
## Before

The activity types created by this extension are not reserved (by setting is_reserved field value to True) or hidden (by setting filter field value to True), this might allow users to delete these activities types by mistake as it happened with one of our clients.

## After

The existing installation method that creates these activities is updated to make sure they are both hidden and reserved, also a new upgrader is created to make sure that these activities are created with the mentioned filters if they are not already.