### PR TITLE
MAE-331: Add Linter, Test Actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+## Comments
+_Anything else you would like the reviewer to note_

--- a/.github/linters.yml
+++ b/.github/linters.yml
@@ -1,0 +1,23 @@
+name: Linters
+
+on: pull_request
+
+env:
+  GITHUB_BASE_REF: ${{ github.base_ref }}
+
+jobs:
+  run-linters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install phpcs
+        run: cd bin && ./install-php-linter
+
+      - name: Fetch target branch
+        run: git fetch -n origin ${GITHUB_BASE_REF}
+
+      - name: Run phpcs linter
+        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' | xargs -r ./bin/phpcs.phar --standard=phpcs-ruleset.xml

--- a/.github/tests.yml
+++ b/.github/tests.yml
@@ -1,0 +1,52 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  run-unit-tests:
+
+    runs-on: ubuntu-latest
+    container: compucorp/civicrm-buildkit:1.0.0
+
+    env:
+      CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+
+      - name: Config mysql database as per CiviCRM requirement
+        run: echo "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" | mysql -u root --password=root --host=mysql
+
+      - name: Config amp
+        run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
+
+      - name: Build Drupal site
+        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.24.6
+          path: site/web/sites/all/modules/civicrm
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.manualdirectdebit
+
+      - name: Installing Membership Extras
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
+        run: cv en uk.co.compucorp.membershipextras
+
+      - name: Run phpunit tests
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membershipextras
+        run: phpunit5

--- a/.github/tests.yml
+++ b/.github/tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.manualdirectdebit
+          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membershipextras
 
       - name: Installing Membership Extras
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Download PHPCS if it already does not exist
+if [ ! -f phpcs.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+fi
+# Give executable permission to PHPCS
+chmod +x phpcs.phar
+
+# Download PHPCBF if it already does not exist
+if [ ! -f phpcbf.phar ]; then
+  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar
+fi
+
+# Give executable permission to PHPCBF
+chmod +x phpcbf.phar
+
+# Clone CiviCRM Coder repo
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 https://github.com/civicrm/coder.git civicrm/coder
+fi

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="PHP Custom Ruleset">
+  <description>CiviCRM Coder Ruleset</description>
+  <rule ref="bin/civicrm/coder/coder_sniffer/Drupal"></rule>
+  <exclude-pattern>tests/phpunit/bootstrap.php</exclude-pattern>
+  <exclude-pattern>membershipextras.civix.php</exclude-pattern>
+  <exclude-pattern>CRM/MembershipExtras/Upgrader/Base.php</exclude-pattern>
+</ruleset>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -2,7 +2,14 @@
 
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
-eval(cv('php:boot --level=classloader', 'phpcode'));
+
+define('CIVICRM_TEST', 1);
+putenv('CIVICRM_UF=' . ($_ENV['CIVICRM_UF'] = 'UnitTests'));
+eval(cv('php:boot --level=settings', 'phpcode'));
+
+if (CIVICRM_UF === 'UnitTests') {
+  Civi\Test::headless()->apply();
+}
 
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();


### PR DESCRIPTION
### Overview

This PR adds

- Github Actions
  - Linters action to run phpcs linters again the php codes that have been added or updated when PR is created.
  - Test action to run phpunit tests to run tests against the repository when PR is created. 
- Github Pull Request Template
- PHPCS Ruleset 

This PR also changes the phpunit bootstrap level from classloader to settings, so we could fabricate the CiviCRM settings on unit tests. 