### PR TITLE
MAE-317: Create next contribution when last contribution is not “Completed”

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -289,7 +289,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $result = [];
     foreach ($lineItems['values'] as $line) {
       $lineData = $line['api.LineItem.getsingle'];
-      $result[] =  $lineData;
+      $result[] = $lineData;
     }
 
     return $result;

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -39,7 +39,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $daysToRenewInAdvance = $this->daysToRenewInAdvance;
 
     $query = "
-      SELECT ccr.id as contribution_recur_id, ccr.installments 
+      SELECT ccr.id as contribution_recur_id, ccr.installments
         FROM civicrm_contribution_recur ccr
    LEFT JOIN membershipextras_subscription_line msl ON msl.contribution_recur_id = ccr.id
    LEFT JOIN civicrm_line_item cli ON msl.line_item_id = cli.id
@@ -47,16 +47,14 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
    LEFT JOIN civicrm_value_payment_plan_periods ppp ON ppp.entity_id = ccr.id
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorsIDs}))
          AND ccr.installments > 1
-         AND ccr.end_date IS NOT NULL
-         AND ccr.auto_renew = 1 
+         AND ccr.auto_renew = 1
          AND (
-          ccr.contribution_status_id != {$cancelledStatusID} 
+          ccr.contribution_status_id != {$cancelledStatusID}
           AND ccr.contribution_status_id != {$refundedStatusID}
          )
          AND (ppp.next_period IS NULL OR ppp.next_period = 0)
          AND msl.auto_renew = 1
          AND msl.is_removed = 0
-         AND msl.end_date IS NOT NULL
     GROUP BY ccr.id
       HAVING MIN(cm.end_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
           OR (

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -44,7 +44,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
     $manualPaymentProcessorsIDs = implode(',', $this->manualPaymentProcessorIDs);
     $cancelledStatusID = $this->contributionStatusesNameMap['Cancelled'];
     $refundedStatusID = $this->contributionStatusesNameMap['Refunded'];
-    $pendingStatusID = $this->contributionStatusesNameMap['Pending'];
     $daysToRenewInAdvance = $this->daysToRenewInAdvance;
 
     $query = "
@@ -78,30 +77,28 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
             END,
             INTERVAL frequency_interval YEAR
           )
-        END AS next_run_date 
+        END AS next_run_date
         FROM civicrm_contribution_recur ccr
    LEFT JOIN membershipextras_subscription_line msl ON msl.contribution_recur_id = ccr.id
    LEFT JOIN civicrm_line_item cli ON msl.line_item_id = cli.id
    LEFT JOIN civicrm_membership cm ON (cm.id = cli.entity_id AND cli.entity_table = 'civicrm_membership')
    LEFT JOIN civicrm_value_payment_plan_periods ppp ON ppp.entity_id = ccr.id
-   LEFT JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id AND cc.contribution_status_id = {$pendingStatusID}
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorsIDs}))
-         AND cc.id IS NULL
          AND ccr.end_date IS NULL
          AND (
           ccr.installments < 2
           OR ccr.installments IS NULL
          )
-         AND ccr.auto_renew = 1 
+         AND ccr.auto_renew = 1
          AND (
-          ccr.contribution_status_id != {$cancelledStatusID} 
+          ccr.contribution_status_id != {$cancelledStatusID}
           AND ccr.contribution_status_id != {$refundedStatusID}
          )
          AND ppp.next_period IS NULL
          AND msl.auto_renew = 1
          AND msl.is_removed = 0
          AND msl.end_date IS NULL
-         
+
     GROUP BY ccr.id
       HAVING MIN(cm.end_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
       OR (

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -164,7 +164,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
       'api.LineItem.getsingle' => [
         'id' => '$value.line_item_id',
         'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
+        'entity_id' => ['IS NOT NULL' => 1],
       ],
       'options' => ['limit' => 0],
     ]);
@@ -285,7 +285,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
     $result = [];
     foreach ($lineItems['values'] as $line) {
       $lineData = $line['api.LineItem.getsingle'];
-      $result[] =  $lineData;
+      $result[] = $lineData;
     }
 
     return $result;


### PR DESCRIPTION
## Overview
This PR changes behaviour of offline auto-renewal job schedule. 

Normally when executing the job OfflineAutoRenewalJob.run to renew memberships offline, the next contribution will be created 
only if the contribution is completed. 

It's very usual (specially in offline payment methods as SEPA bank collections) that the Organizations tries many times to collect a payment and it could last for several weeks to accomplish it (or even until it gets cancelled for any reason). For many organizations that have a monthly basis membership, having the last Contribution still not completed, doesn't mean that the Membership is over, or they cannot try to collect the next payment.

This PR will overcome this issue and will allow next contribution to be created even the last contribution status is not "Completed"

This PR is also covered behaviour for Single and Multiple instalment payment plans.

## Before
Membership will only be reviewed if the last contribution status is "completed"

## After
Membership will only be reviewed if the last contribution status is not "completed"

## Technical Details
We only need to update where clause on SQL statement that getting recurring contributions. 

 **Single Instalment** 

Since we don't care if the contribution status is completed or not, we would not check the status of linked contribution record.

**Multiple Instalment** 

The civicrm_contribution_recur.end_date and membershipextras_subscription_line.end_date shall not be checked as these fields will be recorded only when the payment has been recorded. 
