### PR TITLE
MAE-317: Allow autorenewal even if payment plan is still pending

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -39,7 +39,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $daysToRenewInAdvance = $this->daysToRenewInAdvance;
 
     $query = "
-      SELECT ccr.id as contribution_recur_id, ccr.installments 
+      SELECT ccr.id as contribution_recur_id, ccr.installments
         FROM civicrm_contribution_recur ccr
    LEFT JOIN membershipextras_subscription_line msl ON msl.contribution_recur_id = ccr.id
    LEFT JOIN civicrm_line_item cli ON msl.line_item_id = cli.id
@@ -47,16 +47,14 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
    LEFT JOIN civicrm_value_payment_plan_periods ppp ON ppp.entity_id = ccr.id
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorsIDs}))
          AND ccr.installments > 1
-         AND ccr.end_date IS NOT NULL
-         AND ccr.auto_renew = 1 
+         AND ccr.auto_renew = 1
          AND (
-          ccr.contribution_status_id != {$cancelledStatusID} 
+          ccr.contribution_status_id != {$cancelledStatusID}
           AND ccr.contribution_status_id != {$refundedStatusID}
          )
          AND (ppp.next_period IS NULL OR ppp.next_period = 0)
          AND msl.auto_renew = 1
          AND msl.is_removed = 0
-         AND msl.end_date IS NOT NULL
     GROUP BY ccr.id
       HAVING MIN(cm.end_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
           OR (
@@ -291,7 +289,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $result = [];
     foreach ($lineItems['values'] as $line) {
       $lineData = $line['api.LineItem.getsingle'];
-      $result[] =  $lineData;
+      $result[] = $lineData;
     }
 
     return $result;

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -44,7 +44,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
     $manualPaymentProcessorsIDs = implode(',', $this->manualPaymentProcessorIDs);
     $cancelledStatusID = $this->contributionStatusesNameMap['Cancelled'];
     $refundedStatusID = $this->contributionStatusesNameMap['Refunded'];
-    $pendingStatusID = $this->contributionStatusesNameMap['Pending'];
     $daysToRenewInAdvance = $this->daysToRenewInAdvance;
 
     $query = "
@@ -78,30 +77,28 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
             END,
             INTERVAL frequency_interval YEAR
           )
-        END AS next_run_date 
+        END AS next_run_date
         FROM civicrm_contribution_recur ccr
    LEFT JOIN membershipextras_subscription_line msl ON msl.contribution_recur_id = ccr.id
    LEFT JOIN civicrm_line_item cli ON msl.line_item_id = cli.id
    LEFT JOIN civicrm_membership cm ON (cm.id = cli.entity_id AND cli.entity_table = 'civicrm_membership')
    LEFT JOIN civicrm_value_payment_plan_periods ppp ON ppp.entity_id = ccr.id
-   LEFT JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id AND cc.contribution_status_id = {$pendingStatusID}
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorsIDs}))
-         AND cc.id IS NULL
          AND ccr.end_date IS NULL
          AND (
           ccr.installments < 2
           OR ccr.installments IS NULL
          )
-         AND ccr.auto_renew = 1 
+         AND ccr.auto_renew = 1
          AND (
-          ccr.contribution_status_id != {$cancelledStatusID} 
+          ccr.contribution_status_id != {$cancelledStatusID}
           AND ccr.contribution_status_id != {$refundedStatusID}
          )
          AND ppp.next_period IS NULL
          AND msl.auto_renew = 1
          AND msl.is_removed = 0
          AND msl.end_date IS NULL
-         
+
     GROUP BY ccr.id
       HAVING MIN(cm.end_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
       OR (
@@ -167,7 +164,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
       'api.LineItem.getsingle' => [
         'id' => '$value.line_item_id',
         'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
+        'entity_id' => ['IS NOT NULL' => 1],
       ],
       'options' => ['limit' => 0],
     ]);
@@ -288,7 +285,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
     $result = [];
     foreach ($lineItems['values'] as $line) {
       $lineData = $line['api.LineItem.getsingle'];
-      $result[] =  $lineData;
+      $result[] = $lineData;
     }
 
     return $result;


### PR DESCRIPTION
## Overview

We decided long ago that we are only auto-renewing offline memberships if all the contributions (installments) attached to an expired membership are completed, which means if there is at least one contribution that is still pending then the membership will not auto-renew.

The behavior was revised again and it seems that it is not the case for many organisations, since uncompleted payment does not means  that the membership should end (specially in Direct Debit kind of payments).

In this PR we are changing this behavior so expired offline memberships are auto-renewed even if they have unpaid payments. This also means that if a membership with an end date far in the past (e.g 2017) with a pending contribution is created for whatever reason, so it will get autorenewed each time the scheduled job for auto-renewal run, so it is the admin responsibly to cancel such payment plans to prevent that from happening. 


## Before
Expired Memberships paid with offline payment plan are renewed only if the payment plan installments are all paid (aka, the payment plan is completed). 

## After
The mentioned memberships will get autorenewed even if the payment plan is pending or in progress.

## Notes

This work was done originally by @erawat here : https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/278 , and reverted back later since it was not tested properly yet, so this work just bring it back.
