### PR TITLE
MAE-348: Fix memberships and payment plan dates after autorenewal

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
@@ -41,7 +41,7 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
     if ($contributionStatus === 'Completed' && $this->contributionRecurBAO->installments > 1) {
       $subscriptionLines = $this->getSubscriptionLines();
 
-      foreach($subscriptionLines as $line) {
+      foreach ($subscriptionLines as $line) {
         if (!empty($line['start_date']) && empty($line['end_date'])) {
           civicrm_api3('ContributionRecurLineItem', 'create', [
             'id' => $line['id'],
@@ -65,7 +65,7 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
       'api.LineItem.getsingle' => [
         'id' => '$value.line_item_id',
         'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
+        'entity_id' => ['IS NOT NULL' => 1],
       ],
     ]);
 
@@ -79,13 +79,15 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
   private function calculateSubscriptionLineItemEndDate($subscriptionLineItem) {
     $entityTable = $subscriptionLineItem['api.LineItem.getsingle']['entity_table'];
     if ($entityTable == 'civicrm_membership') {
-      $membershipId =  $subscriptionLineItem['api.LineItem.getsingle']['entity_id'];
-      return  civicrm_api3('Membership', 'getvalue', [
+      $membershipId = $subscriptionLineItem['api.LineItem.getsingle']['entity_id'];
+      return civicrm_api3('Membership', 'getvalue', [
         'return' => 'end_date',
         'id' => $membershipId,
       ]);
-    } else {
+    }
+    else {
       return $this->contributionRecurBAO->end_date;
     }
   }
+
 }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -291,7 +291,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $result = [];
     foreach ($lineItems['values'] as $line) {
       $lineData = $line['api.LineItem.getsingle'];
-      $result[] =  $lineData;
+      $result[] = $lineData;
     }
 
     return $result;

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -105,8 +105,8 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
     $currentRecurContribution = $this->currentRecurringContribution;
     $paymentProcessorID = !empty($currentRecurContribution['payment_processor_id']) ? $currentRecurContribution['payment_processor_id'] : NULL;
 
+    $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate();
     $this->paymentPlanStartDate = $this->calculateNewPeriodStartDate();
-    $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate() ?: $this->paymentPlanStartDate;
     $paymentInstrumentName = $this->getPaymentMethodNameFromItsId($currentRecurContribution['payment_instrument_id']);
 
     $newRecurringContribution = civicrm_api3('ContributionRecur', 'create', [
@@ -149,8 +149,8 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
    */
   private function calculateNewPeriodStartDate() {
     $installmentReceiveDateCalculator = new InstallmentReceiveDateCalculator($this->currentRecurringContribution);
-
-    return $installmentReceiveDateCalculator->calculate($this->currentRecurringContribution['installments'] + 1);
+    $installmentReceiveDateCalculator->setStartDate($this->membershipsStartDate);
+    return $installmentReceiveDateCalculator->calculate();
   }
 
   /**
@@ -235,7 +235,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
         CRM_MembershipExtras_BAO_ContributionRecurLineItem::create([
           'contribution_recur_id' => $nextContribution['id'],
           'line_item_id' => $newLineItem['id'],
-          'start_date' => $this->paymentPlanStartDate,
+          'start_date' => $this->membershipsStartDate,
           'auto_renew' => 1,
         ]);
       }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -169,7 +169,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
       'api.LineItem.getsingle' => [
         'id' => '$value.line_item_id',
         'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
+        'entity_id' => ['IS NOT NULL' => 1],
       ],
       'options' => ['limit' => 0],
     ]);
@@ -286,7 +286,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
     $result = [];
     foreach ($lineItems['values'] as $line) {
       $lineData = $line['api.LineItem.getsingle'];
-      $result[] =  $lineData;
+      $result[] = $lineData;
     }
 
     return $result;

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -174,7 +174,8 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       ]);
 
       return $result['api.MembershipType.getsingle'];
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return [];
     }
   }
@@ -314,18 +315,15 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @throws \Exception
    */
   private function getEarliestLineStartDate($lineItems) {
-    $earliestDate = null;
+    $earliestDate = NULL;
 
     foreach ($lineItems as $line) {
       $startDate = new DateTime($line['start_date']);
-      if ($line['entity_table'] === 'civicrm_membership') {
-        $membership = $this->getMembership($line['entity_id']);
-        $startDate = new DateTime($membership['start_date']);
-      }
 
       if (!isset($earliestDate)) {
         $earliestDate = $startDate;
-      } elseif ($earliestDate > $startDate) {
+      }
+      elseif ($earliestDate > $startDate) {
         $earliestDate = $startDate;
       }
     }
@@ -369,7 +367,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @return string
    */
   private function getLargestMembershipEndDate($lineItems) {
-    $latestDate = null;
+    $latestDate = NULL;
 
     foreach ($lineItems as $line) {
       if ($line['entity_table'] != 'civicrm_membership') {
@@ -381,7 +379,8 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
 
       if (!isset($latestDate)) {
         $latestDate = $membershipDate;
-      } elseif ($latestDate < $membershipDate) {
+      }
+      elseif ($latestDate < $membershipDate) {
         $latestDate = $membershipDate;
       }
     }
@@ -452,7 +451,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       'api.LineItem.getsingle' => [
         'id' => '$value.line_item_id',
         'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
+        'entity_id' => ['IS NOT NULL' => 1],
       ],
     ]);
 

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -47,18 +47,16 @@
       <tr id="lineitem-{$currentItem.id}" data-item-data='{$currentItem|@json_encode}' class="crm-entity rc-line-item {cycle values="odd-row,even-row"}">
         <td>{$currentItem.label}</td>
         <td>
-          {if $currentItem.related_membership.start_date}
-            {$currentItem.related_membership.start_date|date_format:"%Y-%m-%d"|crmDate}
-          {else}
             {$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}
-          {/if}
         </td>
         <td>
-          {if $currentItem.related_membership.end_date}
-            {$currentItem.related_membership.end_date|date_format:"%Y-%m-%d"|crmDate}
-          {else}
-            {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
-          {/if}
+            {if $currentItem.end_date}
+              {$currentItem.end_date|date_format:"%Y-%m-%d"|crmDate}
+            {elseif $currentItem.related_membership.end_date}
+                {$currentItem.related_membership.end_date|date_format:"%Y-%m-%d"|crmDate}
+            {else}
+                {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
+            {/if}
         </td>
         {if $recurringContribution.auto_renew}
           <td>


### PR DESCRIPTION
## Overview
This PR extends on the work that was done here : https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/276
by fixing some of the issues with memberships autorenewal dates, some of these issues are caused by the PR above and some were there already, the details of these issues and their fixes are explained before.

Also note because many of these issues are strongly linked together, it was hard to separate them into separate commits.

## Issue 1

The PR above decided if it should updated the membership start date or not using the new setting inside calculateRenewedMembershipsStartDate() method using the first membership line item it found instead, which will result in updating all the memberships start dates (if there are more than one membership line item) to start at the same time, but the point of this setting is to keep the start date untouched if it is not set, so I moved this check to extendExistingMembership() method and ignored updating the start date if the new setting is not set.

Here is an example of two memberships that are part of the same payment plan,  and one of the memberships start date was changed : 

![2020-08-17 14_27_27-fdsdsfdfs dfsdfs _ ASE](https://user-images.githubusercontent.com/6275540/90391694-74055480-e085-11ea-9bb8-2cb222b8deab.png)

and here is after running the running the autorenewal scheduled job with the "Update start date on renewal?" unchecked (hence that both membership start dates get updated, but non should and that they should have stayed the same)  : 

![2020-08-17 14_28_18-Movies   TV](https://user-images.githubusercontent.com/6275540/90391729-841d3400-e085-11ea-9185-28ff2c9af9dc.png)


Here is the same example but after my fix : 

![2020-08-17 14_36_53-asffdfds sfd333 _ ASE](https://user-images.githubusercontent.com/6275540/90392226-62707c80-e086-11ea-8540-fa11949d7ecd.png)

and after running the autorenewal job (hence that the start dates remained the same) : 
![2020-08-17 14_38_29-asffdfds sfd333 _ ASE](https://user-images.githubusercontent.com/6275540/90392350-98156580-e086-11ea-8f2e-69d79d4938d7.png)




## Issue 2

If the new setting is not set (means that the membership start date should not be updated), then the line items dates as well as the period start and end date on the manage installments screens are wrong. 

Example: 

- Setting "Update start date on renewal" is unchecked
- Signup a new memberships with payment plan (Annual or >1 Installments) with any payment method with the dates : 1st January 2019 - 31st December 2019
- After Auto-renewal job, membership start date remains the same (which is correct based on the above setting). Membership Dates : 1st January 2019 - 31st December 2020 - Correct
- Period Start Date and Line Item Start date should be 1st January 2020, but it is showing 1st January 2019
- Current Period Tab :
Period Start Date: 1st January 2019 Period End Date: 31st December 2020 => should be 1st January 2020 - 31st December 2020 
Line item Start Date: 1st January 2019 Period End Date: 31st December 2020  =>  should be 1st January 2020 - 31st December 2020 

The issue was caused by more than one thing that are linked to another ticket (MAE-188) , the point of that ticket was to to fix the issues around date calculation by establishing the following : 

- when renewing, the new membership start date should be equal the membership end date before renewal + 1 day and the end date should be one term from the start date. (that was before introducing the new setting here to keep the membership start date the same, but with this setting the membership start date should never change but the end date logic should remain the same)
- if there are more than one installment, then the new payment plan start date should equal the new membership start date +- the cycle day offset of the payment plan (with the new setting and if it we are configuring it not to update the start date then the new payment plan start date should be what the membership start date is supposed to be if the new setting is checked).

so part of the problem was is the extension calculates the payment plan start date as well as its line items based on the number of contributions in the previous payment plan (or total number of contributions in case of single installment payment plan) instead of the new membership start date, there was also some UI level code that update the line items dates as well as the period start and end date to be based on the minimum   membership start date among the payment plan line items, but the issue is that the recur line items were stored wrong at the first place , which caused issues when this new setting is not enabled. since the minimum membership start date with the new setting become useless to base any calculation upon.

here is a "before" example : 

here we have a one year autorenewal membership that got created with start date = 1/1/2019 and payment plan start date = 5/1/2019, after renewal with "Update start date on renewal?" unchecked. hence since we have ""Update start date on renewal?" unchecked the start date remained the same after autorenewal which is correct.

![2020-08-17 15_39_44-Calendar](https://user-images.githubusercontent.com/6275540/90397228-710f6180-e08f-11ea-9051-1ba5a8fa66e5.png)


 now on the manage installments screen, the membership line item "Primary Teacher" should have start date of "1/1/2020" instead of "1/1/2019" , also the period start date should be "1/1/2020" instead of "1/1/2019" since it should be based on the minimum membership start date (or what it is supposed to be if the "Update start date on renewal?" was checked, which is "1/1/2020"). it also make sense to be "1/1/2020" since this is a new period/term.

![2020-08-17 15_39_18-Calendar](https://user-images.githubusercontent.com/6275540/90397222-6d7bda80-e08f-11ea-863b-76da78ce5feb.png)


also the recur contribution line item dates have wrong dates, the 1st period line item end date should reflect the membership end date at that period which should be "31/12/2019" where the start date of the 2nd period line item is "5/1/2020" where it should be the start date of the new membership "1/1/2020" : 
![2020-08-17 15_40_06-CiviCRM API v3 _ ASE](https://user-images.githubusercontent.com/6275540/90397235-753b7f00-e08f-11ea-9e05-c371dc637f92.png)

the difference between "manage installments" screen" and the the recur line items dates that are stored in the database happen because of the two reasons mentioned above, which I am going to repeat again : 

1- the manage installment screen has some UI only code that fetch the minimum membership start date and update the start date on the UI to it.
2- they are stored wrong on the database because the calculation is based on the payment plan start date as well as the number of contributions that are connected to it.

which I both resolved by : 

1- removing the UI code that update the dates.
2- calculating the recur line items dates based on what the new membership period start date is supposed to be (whether the new setting is enabled or not), and to use the minimum membership start date if there are more than one with different dates.


here is how the same example looks like after the code update that I did in this PR: 

first the membership record which looks exactly like before which is correct : 
![2020-08-17 16_07_38-adsdasdas 22dasads _ ASE](https://user-images.githubusercontent.com/6275540/90400358-4378e700-e094-11ea-828f-eb57f6c27d24.png)


the manage installments screen now also have the correct dates for both the line item start date and the period start date : 

![2020-08-17 16_08_11-Calendar](https://user-images.githubusercontent.com/6275540/90400452-67d4c380-e094-11ea-9e5f-b2ea213d34ca.png)

and finally the actual recur line item dates are also correct and reflect what is shown in the manage installments screen above : 


![2020-08-17 16_09_13-CiviCRM API v3 _ ASE](https://user-images.githubusercontent.com/6275540/90400535-88048280-e094-11ea-9515-0c9c592e0b60.png)