### PR TITLE
SPAB-1002: Implement Fixes From SPABSPRT-28

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstallmentPlan.php
@@ -280,6 +280,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstallmentPlan extend
         'entity_table' => ['IS NOT NULL' => 1],
         'entity_id' => ['IS NOT NULL' => 1],
       ],
+      'options' => ['limit' => 0],
     ]);
 
     if (!$lineItems['count']) {

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -381,7 +381,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    *
    * @return boolean
    */
-  protected function isMembershipLineItem($lineItem, $priceFieldValue = null) {
+  protected function isMembershipLineItem($lineItem, $priceFieldValue = NULL) {
     if ($lineItem['entity_table'] == 'civicrm_membership') {
       return TRUE;
     }
@@ -408,7 +408,8 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       $membershipTypeID = civicrm_api3('Membership', 'getsingle', [
         'id' => $lineItem['entity_id'],
       ])['membership_type_id'];
-    } else {
+    }
+    else {
       $membershipTypeID = $priceFieldValue['membership_type_id'];
     }
 
@@ -457,7 +458,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    * @return mixed
    */
   private function calculateSingleInstallmentAmount($amount) {
-    $resultAmount =  $amount;
+    $resultAmount = $amount;
 
     if ($this->currentRecurringContribution['installments'] > 1) {
       $resultAmount = MoneyUtilities::roundToCurrencyPrecision(($amount / $this->currentRecurringContribution['installments']));

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -276,6 +276,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
         'entity_table' => ['IS NOT NULL' => 1],
         'entity_id' => ['IS NOT NULL' => 1],
       ],
+      'options' => ['limit' => 0],
     ]);
 
     if (!$lineItems['count']) {

--- a/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
@@ -24,11 +24,11 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
         break;
 
       case 'day':
-        $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] .'D';
+        $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] . 'D';
         break;
 
       case 'year':
-        $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] .'Y';
+        $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] . 'Y';
         break;
 
       default:

--- a/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
@@ -18,21 +18,30 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
     ])['values'][0];
 
     $currentEndDate = new DateTime($membershipDetails['end_date']);
-
     switch ($membershipDetails['membership_type_id.duration_unit']) {
       case 'month':
         $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] . 'M';
         break;
+
       case 'day':
         $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] .'D';
         break;
+
       case 'year':
         $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] .'Y';
         break;
+
+      default:
+        $interval = NULL;
+        break;
     }
 
-    $currentEndDate->add(new DateInterval($interval));
-    $newEndDate = $currentEndDate->format('Ymd');
+    $newEndDate = 'null';
+    if (!empty($interval)) {
+      $currentEndDate->add(new DateInterval($interval));
+      $newEndDate = $currentEndDate->format('Ymd');
+    }
+
     return $newEndDate;
   }
 

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipTypeAmountProraterTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipTypeAmountProraterTest.php
@@ -12,6 +12,15 @@ use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabrica
  */
 class CRM_MembershipExtras_Service_MembershipTypeAmountProraterTest extends BaseHeadlessTest {
 
+  private $startDate;
+
+  private $endDate;
+
+  public function setUp() {
+    $this->startDate = new DateTime();
+    $this->endDate = new DateTime();
+  }
+
   public function testCalculateProRata() {
     $originalDurationDays = 360;
     $calculatedDays = 60;
@@ -21,7 +30,8 @@ class CRM_MembershipExtras_Service_MembershipTypeAmountProraterTest extends Base
     $taxAmount = 0;
     $membershipTypeTaxAmount = $this->getMembershipTypeTaxAmount($membershipType, $expectedProrata, $taxAmount);
     $membershipTypeAmount = new MembershipTypeAmount($membershipTypeDuration, $membershipTypeTaxAmount);
-    $proRata = $membershipTypeAmount->calculateProRata($membershipType, new DateTime(), new DateTime());
+
+    $proRata = $membershipTypeAmount->calculateProRata($membershipType, $this->startDate, $this->endDate);
     $this->assertEquals($expectedProrata, $proRata);
   }
 
@@ -35,14 +45,16 @@ class CRM_MembershipExtras_Service_MembershipTypeAmountProraterTest extends Base
     $membershipTypeDuration = $this->getMembershipTypeDuration($originalDurationDays, $calculatedDays);
     $membershipTypeTaxAmount = $this->getMembershipTypeTaxAmount($membershipType, $expectedProrata, $taxAmount);
     $membershipTypeAmount = new MembershipTypeAmount($membershipTypeDuration, $membershipTypeTaxAmount);
-    $proRata = $membershipTypeAmount->calculateProRata($membershipType, new DateTime(), new DateTime());
+
+    $proRata = $membershipTypeAmount->calculateProRata($membershipType, $this->startDate, $this->endDate);
     $this->assertEquals($expectedTotal, $proRata);
   }
 
   private function getMembershipTypeDuration($originalDays, $calculatedDays) {
     $membershipTypeDurationCalculator = $this->prophesize(MembershipTypeDurationCalculator::class);
     $membershipTypeDurationCalculator->calculateOriginalInDays()->willReturn($originalDays);
-    $membershipTypeDurationCalculator->calculateDaysBasedOnDates(new DateTime(), new DateTime(), NULL)->willReturn($calculatedDays);
+
+    $membershipTypeDurationCalculator->calculateDaysBasedOnDates($this->startDate, $this->endDate, NULL)->willReturn($calculatedDays);
 
     return $membershipTypeDurationCalculator->reveal();
   }

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipTypeAmountProraterTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipTypeAmountProraterTest.php
@@ -25,7 +25,10 @@ class CRM_MembershipExtras_Service_MembershipTypeAmountProraterTest extends Base
     $originalDurationDays = 360;
     $calculatedDays = 60;
     $membershipType = MembershipTypeFabricator::fabricate(['minimum_fee' => 120]);
-    $expectedProrata = 20; //i.e 60/360 *120
+
+    // Expected prorata: 60/360 * 120 = 20
+    $expectedProrata = 20;
+
     $membershipTypeDuration = $this->getMembershipTypeDuration($originalDurationDays, $calculatedDays);
     $taxAmount = 0;
     $membershipTypeTaxAmount = $this->getMembershipTypeTaxAmount($membershipType, $expectedProrata, $taxAmount);
@@ -39,9 +42,12 @@ class CRM_MembershipExtras_Service_MembershipTypeAmountProraterTest extends Base
     $originalDurationDays = 360;
     $calculatedDays = 60;
     $membershipType = MembershipTypeFabricator::fabricate(['minimum_fee' => 120], TRUE);
-    $expectedProrata = 20; //i.e 60/360 *120 + 10tax
+
+    // Expected Prorata: 60/360 * 120
+    $expectedProrata = 20;
     $taxAmount = 30;
-    $expectedTotal =  $expectedProrata + $taxAmount;
+    $expectedTotal = $expectedProrata + $taxAmount;
+
     $membershipTypeDuration = $this->getMembershipTypeDuration($originalDurationDays, $calculatedDays);
     $membershipTypeTaxAmount = $this->getMembershipTypeTaxAmount($membershipType, $expectedProrata, $taxAmount);
     $membershipTypeAmount = new MembershipTypeAmount($membershipTypeDuration, $membershipTypeTaxAmount);
@@ -65,5 +71,5 @@ class CRM_MembershipExtras_Service_MembershipTypeAmountProraterTest extends Base
 
     return $membershipTypeTaxAmount->reveal();
   }
-}
 
+}


### PR DESCRIPTION
## Overview
Fixes done for SPAB as a hotfix on the membership extras extension they had installed, now need to be brought into the main membership extras extension.

These fixes include:
- Fix for renewal of life-time memberships, which cused errors due to empty end-date being used to calculate new end-date.
- Removing limits when obtaining list of line items to renew.
- Handling of joint memberships, where renewing the main membership extends the dates for all its related memberships.

## Before
- Life time membership renewals caused exceptions.
- Obtaining list of line items associated to a payment plan was limited to 25 (default civicrm limit).
- Renewing the main membership would extend it, but not its related memberships.

## After
- Life time membership renewals do not cause exceptions.
- Obtaining list of line items associated to a payment plan is unlimited.
- Renewing a membership with joint accounts extends both the main membership and its related memberships.

## Comments
I also fixed the failing Amount Ptorater test. Yay!