### PR TITLE
MAE-306: Prevent process membership payment post hook on non payment plan

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -247,6 +247,10 @@ function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef)
   }
 
   if ($objectName == 'MembershipPayment') {
+    $isPaymentPlanPayment = _membershipextras_isPaymentPlanWithAtLeastOneInstallment();
+    if (!$isPaymentPlanPayment) {
+      return;
+    }
     $membershipPaymentPostHook = new CRM_MembershipExtras_Hook_Post_MembershipPayment($op, $objectId, $objectRef);
     $membershipPaymentPostHook->postProcess();
   }


### PR DESCRIPTION
## Overview

This PR is to fix the behaviour when sign up for membership with non-payment plan. 

With ME extension installed:  When a new membership is created with a Single payment (non-payment plan) and record contribution status to pending then the membership will be created and the status of membership will be ACTIVE. 

Then when the payment is recorded, so and the end date will be updated as CiviCRM default behavior will see that  the membership has been paid to the  active membership so it them membership got renewed automatically.  

So this PR is to prevent it happens on when sign up the membership on non-payment plan. 

## Before

When create a membership with Single payment (non-payment plan), the membership status will be set as ACTIVE so 

## After

When create a membership with Single payment (non-payment plan), the membership status will be set as Pending as default by CiviCRM.  