### PR TITLE
MAE-364: Change currency variable from currency to currency_symbol

### DIFF
--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -12,7 +12,7 @@
     const membershipextrasAllMembershipData = {$allMembershipInfo};
     const membershipextrasTaxRatesStr = '{$taxRates}';
     const membershipextrasTaxTerm = '{$taxTerm}';
-    const membershipextrasCurrency = '{$currency}';
+    const membershipextrasCurrency = '{$currency_symbol}';
     {literal}
     const membershipextrasTaxRates = membershipextrasTaxRatesStr !== ''
       ? JSON.parse(membershipextrasTaxRatesStr)


### PR DESCRIPTION
## Overview

Since CiviCRM 5.25, CiviCRM has changed the currency variable on Membership Form from $currency to $currency_symfol. (see https://github.com/civicrm/civicrm-core/commit/9d3a6f9fa2edf78b14ae35bc045f587b1570883d)

Since Membership Payment Plan screen relies on the currency symbol assign to the membership form.  The variable would need to be updated on Payment Plan Toggle as well. 

## Before

![Screenshot from 2020-09-03 13-55-50](https://user-images.githubusercontent.com/208713/92117569-3cb8d680-eded-11ea-9868-13abd1bd2369.png)

## After

![screenshot-compuclient local-2020 09 03-13_56_56 (1)](https://user-images.githubusercontent.com/208713/92118533-848c2d80-edee-11ea-91e1-852c168c955e.png)

