### PR TITLE
MAE-384: Bump version and release info for 2.4.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -8,15 +8,15 @@
     <author>Compucorp Ltd.</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2020-07-17</releaseDate>
-  <version>2.3.0</version>
+  <releaseDate>2020-09-08</releaseDate>
+  <version>2.4.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.24</ver>
+    <ver>5.28</ver>
   </compatibility>
   <comments>
     Supported CiviCRM versions  :
-    - 5.24.6
+    - 5.28.3
   </comments>
   <civix>
     <namespace>CRM/MembershipExtras</namespace>


### PR DESCRIPTION
Updating release info for Membershipextras product suite release version 2.4.0

