### PR TITLE
MAE-379: Create Instalment Schedule view

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
@@ -1,16 +1,12 @@
 <?php
 
+use CRM_MembershipExtras_ExtensionUtil as E;
+
 /**
  * Implements form changes needed to be done to add payment plan as an option to
  * pay for a membership.
  */
 class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan {
-
-  const DEFAULT_INSTALLMENTS_NUMBER = 12;
-
-  const DEFAULT_INSTALLMENTS_FREQUENCY = 1;
-
-  const DEFAULT_INSTALLMENTS_FREQUENCY_UNIT = 'month';
 
   /**
    * @var string
@@ -50,24 +46,10 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan {
       return;
     }
 
-    $paymentToggler = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String', $this->form, FALSE);
+    $paymentToggler =
+      CRM_Utils_Request::retrieve('contribution_type_toggle', 'String', $this->form, FALSE);
     $this->form->assign('contribution_type_toggle', $paymentToggler ?: 'contribution');
-
-    $this->form->add('text', 'installments', ts('Number of Instalments'), '', FALSE);
-    $this->form->addRule('installments', ts('Instalments must be a number.'), 'numeric');
-    $this->form->setDefaults(['installments' => self::DEFAULT_INSTALLMENTS_NUMBER]);
-
-    $this->form->add('text', 'installments_frequency', ts('Interval'), '', FALSE);
-    $this->form->addRule('installments_frequency', ts('Instalments must be a number.'), 'numeric');
-    $this->form->setDefaults(['installments_frequency' => self::DEFAULT_INSTALLMENTS_FREQUENCY]);
-
-    $this->form->add('select', 'installments_frequency_unit',
-      ts('Instalments Frequency Units'),
-      CRM_Core_OptionGroup::values('recur_frequency_units', FALSE, FALSE, TRUE),
-      FALSE
-    );
-    $this->form->setDefaults(['installments_frequency_unit' => self::DEFAULT_INSTALLMENTS_FREQUENCY_UNIT]);
-
+    $this->form->add('select', 'payment_plan_schedule', E::ts('Schedule'), [], TRUE);
     CRM_Core_Region::instance('page-body')->add([
       'template' => "{$this->templatePath}/CRM/Member/Form/PaymentPlanToggler.tpl",
     ]);

--- a/tests/phpunit/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlanTest.php
@@ -15,14 +15,14 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlanTest extends Base
     $this->membershipCreationForm->controller = $formController;
   }
 
-  public function testPaymentPlanTogglerGetsAddedToPayLaterMembershipCreationForm() {
+  public function testPaymentPlanTogglerGetsAddedToNotLiveMembershipCreationForm() {
     $this->membershipCreationForm->_mode = NULL;
 
     $mebershipBuildFormHook = new CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan($this->membershipCreationForm);
     $mebershipBuildFormHook->buildForm();
 
-    $installmentsField = $this->membershipCreationForm->getElement('installments');
-    $this->assertTrue(is_object($installmentsField));
+    $paymentPlanScheduleField = $this->membershipCreationForm->getElement('payment_plan_schedule');
+    $this->assertTrue(is_object($paymentPlanScheduleField));
   }
 
   public function testPaymentPlanTogglerIsNotAddedToCreditCardLiveMembershipCreationForm() {
@@ -32,7 +32,7 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlanTest extends Base
     $mebershipBuildFormHook->buildForm();
 
     $this->expectException(PEAR_Exception::class);
-    $this->membershipCreationForm->getElement('installments');
+    $this->membershipCreationForm->getElement('payment_plan_schedule');
   }
 
 }


### PR DESCRIPTION
## Overview
This PR is to change screen for the Payment Plan Instalment view from number of instalments to schedule.

This PR also removes a logic for the calculation of instalment as part of the UI changes and the schedule calculation will be done in the back end instead of being calculated on the front end and this will be done on the next tickets and pull requests. 

## Before
![Screenshot from 2020-09-08 16-05-39](https://user-images.githubusercontent.com/208713/93331745-b0f57000-f818-11ea-9d5d-648945d2ed54.png)

## After

![Screenshot from 2020-09-16 12-30-30](https://user-images.githubusercontent.com/208713/93331755-b3f06080-f818-11ea-9527-53088daa1758.png)

## Technical Details

The Schedule field options are displayed based on duration and period type, since the $allMembershipInfo variable does not contain these data, so we need to fetch the membership type details from API when the price set is selected.

There is one falling on a test as the instalment fields is no longer exist in the form and this one will be fixed on another ticket when creating a schedule view.   
