### PR TITLE
IO-28: Add membership auto upgrade rules managment screen

### DIFF
--- a/CRM/MembershipExtras/BAO/AutoMembershipUpgradeRule.php
+++ b/CRM/MembershipExtras/BAO/AutoMembershipUpgradeRule.php
@@ -51,4 +51,10 @@ class CRM_MembershipExtras_BAO_AutoMembershipUpgradeRule extends CRM_MembershipE
     return $upgradeRule;
   }
 
+  public static function deleteById($id) {
+    $obj = new self();
+    $obj->id = $id;
+    $obj->delete();
+  }
+
 }

--- a/CRM/MembershipExtras/Form/AutomatedUpgradeRule.php
+++ b/CRM/MembershipExtras/Form/AutomatedUpgradeRule.php
@@ -16,9 +16,15 @@ class CRM_MembershipExtras_Form_AutomatedUpgradeRule extends CRM_Core_Form {
    * @inheritdoc
    */
   public function preProcess() {
-    CRM_Utils_System::setTitle(ts('New Automated Membership Upgrade Rule'));
-
     $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+
+    $mode = 'New';
+    if ($this->id) {
+      $mode = 'Edit';
+    }
+
+    $title = $mode . ' Automated Membership Upgrade Rule';
+    CRM_Utils_System::setTitle(ts($title));
   }
 
   /**
@@ -167,6 +173,10 @@ class CRM_MembershipExtras_Form_AutomatedUpgradeRule extends CRM_Core_Form {
     $params['is_active'] = CRM_Utils_Array::value('is_active', $submittedValues, FALSE);
 
     CRM_MembershipExtras_BAO_AutoMembershipUpgradeRule::create($params);
+
+    CRM_Core_Session::setStatus(ts('The membership automated upgrade rule has been saved.'), ts('Saved'), 'success');
+    $returnURL = CRM_Utils_System::url('civicrm/admin/member/automated-upgrade-rules', 'reset=1');
+    CRM_Utils_System::redirect($returnURL);
   }
 
 }

--- a/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.php
+++ b/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.php
@@ -1,0 +1,51 @@
+<?php
+
+class CRM_MembershipExtras_Form_AutomatedUpgradeRuleDelete extends CRM_Core_Form {
+
+  /**
+   * Upgrade rule id
+   *
+   * @var int
+   */
+  private $id;
+
+  /**
+   * @inheritdoc
+   */
+  public function preProcess() {
+    CRM_Utils_System::setTitle(ts('Delete Automated Membership Upgrade Rule'));
+
+    $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function buildQuickForm() {
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => ts('Delete'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function postProcess() {
+    if (!empty($this->id)) {
+      CRM_MembershipExtras_BAO_AutoMembershipUpgradeRule::deleteById($this->id);
+
+      CRM_Core_Session::setStatus(ts('Selected membership automated upgrade rule has been deleted.'), ts('Record Deleted'), 'success');
+      $returnURL = CRM_Utils_System::url('civicrm/admin/member/automated-upgrade-rules', 'reset=1');
+      CRM_Utils_System::redirect($returnURL);
+    }
+  }
+
+}

--- a/CRM/MembershipExtras/Page/AutomatedMembershipUpgradeRule.php
+++ b/CRM/MembershipExtras/Page/AutomatedMembershipUpgradeRule.php
@@ -1,0 +1,147 @@
+<?php
+
+use CRM_MembershipExtras_SelectValues_AutoMembershipUpgradeRules_PeriodUnit as PeriodUnitSelectValues;
+use CRM_MembershipExtras_SelectValues_AutoMembershipUpgradeRules_TriggerDateType as TriggerDateTypeSelectValues;
+
+class CRM_MembershipExtras_Page_AutomatedMembershipUpgradeRule extends CRM_Core_Page {
+
+  private $links = [];
+
+  private $membershipIdsToLabelsMap;
+
+  /**
+   * @inheritdoc
+   */
+  public function run() {
+    $this->browse();
+
+    parent::run();
+  }
+
+  public function browse() {
+    $upgradeRules = new CRM_MembershipExtras_BAO_AutoMembershipUpgradeRule();
+    $upgradeRules->orderBy('weight');
+    $upgradeRules->find();
+    $rows = [];
+    while ($upgradeRules->fetch()) {
+      $rows[$upgradeRules->id] = [];
+      CRM_Core_DAO::storeValues($upgradeRules, $rows[$upgradeRules->id]);
+
+      $rows[$upgradeRules->id] = $this->updateRowLabels($rows[$upgradeRules->id]);
+
+      $rows[$upgradeRules->id]['action'] = CRM_Core_Action::formLink(
+        $this->generateActionLinks(),
+        $this->calculateLinksMask($upgradeRules),
+        ['id' => $upgradeRules->id]
+      );
+    }
+
+    $returnURL = CRM_Utils_System::url('civicrm/admin/member/automated-upgrade-rules');
+    CRM_Utils_Weight::addOrder($rows, 'CRM_MembershipExtras_DAO_AutoMembershipUpgradeRule', 'id', $returnURL);
+
+    $this->assign('rows', $rows);
+  }
+
+  /**
+   * Updates list view row values
+   * to human-readable values.
+   *
+   * @param $rowValues
+   * @return mixed
+   */
+  private function updateRowLabels($rowValues) {
+    $membershipIdsToLabelsMap = $this->getMembershipIdsToLabelsMap();
+    $rowValues['from_membership_label'] = $membershipIdsToLabelsMap[$rowValues['from_membership_type_id']];
+    $rowValues['to_membership_label'] = $membershipIdsToLabelsMap[$rowValues['to_membership_type_id']];
+
+    $periodLengthValues = PeriodUnitSelectValues::getAll();
+    $rowValues['held_for'] = $rowValues['period_length'] . ' ' . $periodLengthValues[$rowValues['period_length']];
+
+    $triggerDateTypeValues = TriggerDateTypeSelectValues::getAll();
+    $rowValues['basis'] = $triggerDateTypeValues[$rowValues['upgrade_trigger_date_type']];
+
+    $rowValues['filter_group_label'] = '';
+    if (!empty($rowValues['filter_group'])) {
+      $rowValues['filter_group_label'] = $this->getGroupTitleById($rowValues['filter_group']);
+    }
+
+    return $rowValues;
+  }
+
+  private function getMembershipIdsToLabelsMap() {
+    if (!empty($this->membershipIdsToLabelsMap)) {
+      return $this->membershipIdsToLabelsMap;
+    }
+
+    $this->membershipIdsToLabelsMap = [];
+    $membershipTypes = civicrm_api3('MembershipType', 'get', [
+      'sequential' => 1,
+      'return' => ['id', 'name'],
+      'options' => ['limit' => 0],
+    ]);
+
+    if (!empty($membershipTypes['values'])) {
+      foreach ($membershipTypes['values'] as $membershipType) {
+        $this->membershipIdsToLabelsMap[$membershipType['id']] = $membershipType['name'];
+      }
+    }
+
+    return $this->membershipIdsToLabelsMap;
+  }
+
+  private function getGroupTitleById($groupId) {
+    $group = civicrm_api3('Group', 'get', [
+      'sequential' => 1,
+      'return' => ['title'],
+      'id' => $groupId,
+    ]);
+
+    $groupTitle = '';
+    if (!empty($group['values'][0])) {
+      $groupTitle = $group['values'][0]['title'];
+    }
+
+    return $groupTitle;
+  }
+
+  private function generateActionLinks() {
+    if (empty($this->links)) {
+      $this->links = [
+        CRM_Core_Action::UPDATE  => [
+          'name'  => ts('Edit'),
+          'url'   => 'civicrm/admin/member/automated-upgrade-rules/add',
+          'qs'    => 'id=%%id%%&reset=1',
+        ],
+        CRM_Core_Action::ENABLE  => [
+          'name'  => ts('Enable'),
+          'class' => 'crm-enable-disable',
+        ],
+        CRM_Core_Action::DISABLE => [
+          'name'  => ts('Disable'),
+          'class' => 'crm-enable-disable',
+        ],
+        CRM_Core_Action::DELETE => [
+          'name' => ts('Delete'),
+          'url' => 'civicrm/admin/member/automated-upgrade-rules/delete',
+          'qs' => 'id=%%id%%',
+        ],
+      ];
+    }
+
+    return $this->links;
+  }
+
+  private function calculateLinksMask($upgradeRule) {
+    $mask = array_sum(array_keys($this->generateActionLinks()));
+
+    if ($upgradeRule->is_active) {
+      $mask -= CRM_Core_Action::ENABLE;
+    }
+    else {
+      $mask -= CRM_Core_Action::DISABLE;
+    }
+
+    return $mask;
+  }
+
+}

--- a/CRM/MembershipExtras/SelectValues/AutoMembershipUpgradeRules/PeriodUnit.php
+++ b/CRM/MembershipExtras/SelectValues/AutoMembershipUpgradeRules/PeriodUnit.php
@@ -10,9 +10,9 @@ class CRM_MembershipExtras_SelectValues_AutoMembershipUpgradeRules_PeriodUnit im
 
   public static function getAll() {
     return [
-      self::YEARS => 'Years',
-      self::MONTHS => 'Months',
-      self::DAYS => 'Days',
+      self::YEARS => 'Year(s)',
+      self::MONTHS => 'Month(s)',
+      self::DAYS => 'Day(s)',
     ];
   }
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -131,15 +131,24 @@ function membershipextras_civicrm_alterSettingsFolders(&$metaDataFolders = NULL)
  */
 function membershipextras_civicrm_navigationMenu(&$menu) {
   $paymentPlanSettingsMenuItem = [
-    'name' => ts('payment_plan_settings'),
+    'name' => 'payment_plan_settings',
     'label' => ts('Payment Plan Settings'),
     'url' => 'civicrm/admin/payment_plan_settings',
     'permission' => 'administer CiviCRM',
     'operator' => NULL,
     'separator' => NULL,
   ];
-
   _membershipextras_civix_insert_navigation_menu($menu, 'Administer/', $paymentPlanSettingsMenuItem);
+
+  $automatedMembershipUpgradeRulesMenuItem = [
+    'name' => 'automated_membership_upgrade_rules',
+    'label' => ts('Membership Automated Upgrade Rules'),
+    'url' => 'civicrm/admin/member/automated-upgrade-rules?reset=1',
+    'permission' => 'administer CiviCRM',
+    'operator' => NULL,
+    'separator' => 2,
+  ];
+  _membershipextras_civix_insert_navigation_menu($menu, 'Administer/CiviMember', $automatedMembershipUpgradeRulesMenuItem);
 }
 
 /**
@@ -233,7 +242,7 @@ function membershipextras_civicrm_preSave_civicrm_membership($dao) {
 }
 
 /**
- * Implements hook_civicrm_post()
+ * Implements hook_civicrm_post().
  */
 function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName === 'EntityFinancialTrxn') {
@@ -253,7 +262,7 @@ function membershipextras_civicrm_post($op, $objectName, $objectId, &$objectRef)
 }
 
 /**
- * Implements hook_civicrm_postProcess()
+ * Implements hook_civicrm_postProcess().
  */
 function membershipextras_civicrm_postProcess($formName, &$form) {
   $isAddAction = $form->getAction() & CRM_Core_Action::ADD;
@@ -283,7 +292,7 @@ function membershipextras_civicrm_postProcess($formName, &$form) {
 }
 
 /**
- * Implements hook_civicrm_buildForm()
+ * Implements hook_civicrm_buildForm().
  */
 function membershipextras_civicrm_buildForm($formName, &$form) {
   if ($formName === 'CRM_Member_Form_Membership' && ($form->getAction() & CRM_Core_Action::UPDATE)) {
@@ -327,7 +336,7 @@ function membershipextras_civicrm_buildForm($formName, &$form) {
 }
 
 /**
- * Implements hrcore_civicrm_pageRun.
+ * Implements hrcore_civicrm_pageRun().
  *
  * @link https://docs.civicrm.org/dev/en/master/hooks/hook_civicrm_pageRun/
  */
@@ -335,7 +344,7 @@ function membershipextras_civicrm_pageRun($page) {
   $hooks = [
     new CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate(),
     new CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate(),
-    new CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate()
+    new CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate(),
   ];
   foreach ($hooks as $hook) {
     $hook->handle($page);
@@ -363,7 +372,7 @@ function membershipextras_civicrm_pageRun($page) {
 }
 
 /**
- * Implements hook_civicrm_validateForm()
+ * Implements hook_civicrm_validateForm().
  */
 function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   $formAction = $form->getAction();
@@ -375,7 +384,8 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
     if ($contributionIsPaymentPlan) {
       $paymentPlanValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($form, $fields, $errors);
       $paymentPlanValidateHook->validate();
-    } else {
+    }
+    else {
       $contributionValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipContribution($form, $fields, $errors);
       $contributionValidateHook->validate();
     }
@@ -389,7 +399,7 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
 }
 
 /**
- * Implements hook_civicrm_alterCalculatedMembershipStatus()
+ * Implements hook_civicrm_alterCalculatedMembershipStatus().
  */
 function membershipextras_civicrm_alterCalculatedMembershipStatus(&$calculatedStatus, $arguments, $membership) {
   $alterMembershipStatusHook = new CRM_MembershipExtras_Hook_Alter_CalculatedMembershipStatus();
@@ -397,7 +407,7 @@ function membershipextras_civicrm_alterCalculatedMembershipStatus(&$calculatedSt
 }
 
 /**
- * Implements hook_civicrm_links()
+ * Implements hook_civicrm_links().
  */
 function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
   if ($op == 'contribution.selector.recurring' && $objectName == 'Contribution') {
@@ -418,17 +428,17 @@ function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$
 }
 
 /**
- * Implements hook_civicrm_alterContent()
+ * Implements hook_civicrm_alterContent().
  */
 function membershipextras_civicrm_alterContent(&$content, $context, $tplName, &$object) {
   if ($tplName == 'CRM/Member/Page/Tab.tpl') {
-    $memberTabPage  = new CRM_MembershipExtras_Hook_AlterContent_MemberTabPage($content);
+    $memberTabPage = new CRM_MembershipExtras_Hook_AlterContent_MemberTabPage($content);
     $memberTabPage->alterContent();
   }
 }
 
 /**
- * Implements hook_civicrm_entityTypes()
+ * Implements hook_civicrm_entityTypes().
  */
 function membershipextras_civicrm_entityTypes(&$entityTypes) {
   return _membershipextras_civix_civicrm_entityTypes($entityTypes);

--- a/templates/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.tpl
+++ b/templates/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.tpl
@@ -1,0 +1,11 @@
+<div class="crm-block crm-form-block">
+  <div class="form-item">
+    <div class="messages status no-popup">
+      <div class="icon inform-icon"></div>
+        {ts}Are you sure you want to delete this membership automated upgrade rule?{/ts}
+    </div>
+  </div>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+</div>

--- a/templates/CRM/MembershipExtras/Page/AutomatedMembershipUpgradeRule.tpl
+++ b/templates/CRM/MembershipExtras/Page/AutomatedMembershipUpgradeRule.tpl
@@ -1,0 +1,44 @@
+<div class="action-link">
+    {crmButton p='civicrm/admin/member/automated-upgrade-rules/add?rest=1' icon="plus-circle"}{ts}Add Rule{/ts}{/crmButton}
+</div>
+
+{if $rows}
+  <div class="crm-content-block crm-block">
+      {strip}
+        {include file="CRM/common/enableDisableApi.tpl"}
+        <table id="options" class="row-highlight">
+          <thead>
+          <tr>
+            <th>{ts}Label{/ts}</th>
+            <th>{ts}From Membership{/ts}</th>
+            <th>{ts}Held For{/ts}</th>
+            <th>{ts}Basis{/ts}</th>
+            <th>{ts}To Membership{/ts}</th>
+            <th>{ts}Filter Group{/ts}</th>
+            <th>{ts}Order{/ts}</th>
+            <th>{ts}Enabled?{/ts}</th>
+            <th></th>
+          </tr>
+          </thead>
+            {foreach from=$rows item=row}
+              <tr id="auto_membership_upgrade_rule-{$row.id}" class="crm-entity {cycle values='odd-row,even-row'} {$row.class} crm-auto-membership-upgrade-rule {if NOT $row.is_active} disabled{/if}">
+                <td>{$row.label}</td>
+                <td>{$row.from_membership_label}</td>
+                <td>{$row.held_for}</td>
+                <td>{$row.basis}</td>
+                <td>{$row.to_membership_label}</td>
+                <td>{$row.filter_group_label}</td>
+                <td class="nowrap crmf-weight">{$row.weight}</td>
+                <td class="crmf-is_active">{if $row.is_active eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+                <td>{$row.action|replace:'xx':$row.id}</td>
+              </tr>
+            {/foreach}
+        </table>
+      {/strip}
+  </div>
+{else}
+  <div class="messages status no-popup">
+    <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>
+      {capture assign=crmURL}{crmURL p='civicrm/admin/member/automated-upgrade-rules/add?rest=1'}{/capture}{ts 1=$crmURL}There are no any membership automated upgrade rule configured. You can add one <a href='%1'>from here</a>.{/ts}
+  </div>
+{/if}

--- a/tests/phpunit/CRM/MembershipExtras/BAO/AutoMembershipUpgradeRuleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/BAO/AutoMembershipUpgradeRuleTest.php
@@ -174,4 +174,33 @@ class CRM_MembershipExtras_BAO_AutoMembershipUpgradeRuleTest extends BaseHeadles
     }
   }
 
+  public function testDeleteById() {
+    $params['name'] = 'test_1';
+    $params['label'] = 'Test 1';
+    $params['from_membership_type_id'] = $this->fromMembershipType->id;
+    $params['to_membership_type_id'] = $this->toMembershipType->id;
+    $params['upgrade_trigger_date_type'] = TriggerDateTypeSelectValues::MEMBER_SINCE;
+    $params['period_length'] = PeriodUnitSelectValues::YEARS;
+    $params['period_length_unit'] = 1;
+    $params['filter_group'] = $this->group['id'];
+    $params['is_active'] = 1;
+    $params = [
+      'name' => 'test_10',
+      'label' => 'Test 10',
+      'from_membership_type_id' => $this->fromMembershipType->id,
+      'to_membership_type_id' => $this->toMembershipType->id,
+      'upgrade_trigger_date_type' => TriggerDateTypeSelectValues::MEMBER_SINCE,
+      'period_length' => PeriodUnitSelectValues::YEARS,
+      'period_length_unit' => 1,
+      'filter_group' => $this->group['id'],
+      'is_active' => 1,
+    ];
+    $newUpgradeRule = AutoMembershipUpgradeRule::create($params);
+
+    AutoMembershipUpgradeRule::deleteById($newUpgradeRule->id);
+
+    $deletedUpgradeRule = AutoMembershipUpgradeRule::getById($newUpgradeRule->id);
+    $this->assertEquals(0, $deletedUpgradeRule->N);
+  }
+
 }

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -7,9 +7,21 @@
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/admin/member/automated-upgrade-rules</path>
+    <page_callback>CRM_MembershipExtras_Page_AutomatedMembershipUpgradeRule</page_callback>
+    <title>Membership Automated Upgrade Rules</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+  <item>
     <path>civicrm/admin/member/automated-upgrade-rules/add</path>
     <page_callback>CRM_MembershipExtras_Form_AutomatedUpgradeRule</page_callback>
     <title>New Automated Membership Upgrade Rule</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/admin/member/automated-upgrade-rules/delete</path>
+    <page_callback>CRM_MembershipExtras_Form_AutomatedUpgradeRuleDelete</page_callback>
+    <title>Delete Automated Membership Upgrade Rule</title>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>


### PR DESCRIPTION
## Overview
Adds a management screen to view membership automated upgrade rules with the ability to disable, enable, delete or edit anyone or change its order. 

## Before
We had form to add upgrade rules and to edit them but can only be viewed by accessing the URL directly, and there was no place to view the list of rules added or to quickly disable/enable, edit or delete them.

## After
A new management screen is added with action links to manage these rules, which is accessible from **Administer >> CiviMember >> Membership automated upgrade rules** menu item. the user should have "administer CiviCRM" permission to be able to access it or perform any operation on any rule.

![2020-10-15 18_36_10-Settings - Cleanup Caches and Update Paths _ me4test6](https://user-images.githubusercontent.com/6275540/96152705-be2f7880-0f04-11eb-937f-f893b12e446f.png)


![2020-10-14 21_49_14-Window](https://user-images.githubusercontent.com/6275540/96033795-3ea09b80-0e69-11eb-9268-3a2cbebbc673.png)


![daadgg](https://user-images.githubusercontent.com/6275540/96033805-42342280-0e69-11eb-9d76-d57dd89ab73c.gif)


