### PR TITLE
MAR-387: Fix Renewal of Single Installment Plan with 0 Fee Membership

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -201,9 +201,9 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
    */
   private function duplicateSubscriptionLine($line, DateTime $startDate) {
     $lineItemParams = $line['api.LineItem.getsingle'];
-    $lineItemParams['unit_price'] = $this->calculateLineItemUnitPrice($lineItemParams);
-    $lineItemParams['line_total'] = MoneyUtilities::roundToCurrencyPrecision($lineItemParams['unit_price'] * $lineItemParams['qty']);
-    $lineItemParams['tax_amount'] = $this->calculateLineItemTaxAmount($lineItemParams['line_total'], $lineItemParams['financial_type_id']);
+    $lineItemParams['unit_price'] = $this->calculateLineItemUnitPrice($lineItemParams) ?: 0;
+    $lineItemParams['line_total'] = MoneyUtilities::roundToCurrencyPrecision($lineItemParams['unit_price'] * $lineItemParams['qty']) ?: 0;
+    $lineItemParams['tax_amount'] = $this->calculateLineItemTaxAmount($lineItemParams['line_total'], $lineItemParams['financial_type_id']) ?: 0;
     unset($lineItemParams['id']);
 
     $newLineItem = civicrm_api3('LineItem', 'create', $lineItemParams);


### PR DESCRIPTION
## Overview
Memberships set up with a minimum fee of £0 or set up with a price set which includes a line item with a fee of £0 should be able to be auto-renewed.

## Before
When renewing a payment plan with single installments, the old line items associated to the payment plan need to be ended, and any lines set to auto-renew are duplicated for the new period. On this duplication, if a line had 0 value, the price was calculated in a way tht resulted in being a 0 floating point value.

When trying to create the line item, an exception was being thrown by CiviCRM core. line_total is set to be a required field, and this value is only accepted if it is not empty, the integer 0, or the string '0'. Since we were using a floating point value, CiviCRM failed to validate the value was set, and threw the exception.

## After
Fixed by setting price, line total and tax value to integer 0 if it is any empty value (including floating point '0.0').
