### PR TITLE
IO-105: Fix Upgrade rules UI issues

### DIFF
--- a/CRM/MembershipExtras/Form/AutomatedUpgradeRule.php
+++ b/CRM/MembershipExtras/Form/AutomatedUpgradeRule.php
@@ -25,6 +25,10 @@ class CRM_MembershipExtras_Form_AutomatedUpgradeRule extends CRM_Core_Form {
 
     $title = $mode . ' Automated Membership Upgrade Rule';
     CRM_Utils_System::setTitle(ts($title));
+
+    $url = CRM_Utils_System::url('civicrm/admin/member/automated-upgrade-rules', 'reset=1');
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext($url);
   }
 
   /**

--- a/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.php
+++ b/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.php
@@ -16,6 +16,10 @@ class CRM_MembershipExtras_Form_AutomatedUpgradeRuleDelete extends CRM_Core_Form
     CRM_Utils_System::setTitle(ts('Delete Automated Membership Upgrade Rule'));
 
     $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+
+    $url = CRM_Utils_System::url('civicrm/admin/member/automated-upgrade-rules', 'reset=1');
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext($url);
   }
 
   /**

--- a/CRM/MembershipExtras/Page/AutomatedMembershipUpgradeRule.php
+++ b/CRM/MembershipExtras/Page/AutomatedMembershipUpgradeRule.php
@@ -55,7 +55,7 @@ class CRM_MembershipExtras_Page_AutomatedMembershipUpgradeRule extends CRM_Core_
     $rowValues['to_membership_label'] = $membershipIdsToLabelsMap[$rowValues['to_membership_type_id']];
 
     $periodLengthValues = PeriodUnitSelectValues::getAll();
-    $rowValues['held_for'] = $rowValues['period_length'] . ' ' . $periodLengthValues[$rowValues['period_length']];
+    $rowValues['held_for'] = $rowValues['period_length'] . ' ' . $periodLengthValues[$rowValues['period_length_unit']];
 
     $triggerDateTypeValues = TriggerDateTypeSelectValues::getAll();
     $rowValues['basis'] = $triggerDateTypeValues[$rowValues['upgrade_trigger_date_type']];

--- a/templates/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.tpl
+++ b/templates/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.tpl
@@ -2,7 +2,7 @@
   <div class="form-item">
     <div class="messages status no-popup">
       <div class="icon inform-icon"></div>
-        {ts}Are you sure you want to delete this membership automated upgrade rule?{/ts}
+        {ts}Are you sure you would like to delete the automated upgrade rule?{/ts}
     </div>
   </div>
   <div class="crm-submit-buttons">

--- a/tests/phpunit/CRM/MembershipExtras/BAO/AutoMembershipUpgradeRuleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/BAO/AutoMembershipUpgradeRuleTest.php
@@ -177,8 +177,8 @@ class CRM_MembershipExtras_BAO_AutoMembershipUpgradeRuleTest extends BaseHeadles
   public function testDeleteById() {
     $params['name'] = 'test_1';
     $params['label'] = 'Test 1';
-    $params['from_membership_type_id'] = $this->fromMembershipType->id;
-    $params['to_membership_type_id'] = $this->toMembershipType->id;
+    $params['from_membership_type_id'] = $this->fromMembershipType['id'];
+    $params['to_membership_type_id'] = $this->toMembershipType['id'];
     $params['upgrade_trigger_date_type'] = TriggerDateTypeSelectValues::MEMBER_SINCE;
     $params['period_length'] = PeriodUnitSelectValues::YEARS;
     $params['period_length_unit'] = 1;
@@ -187,8 +187,8 @@ class CRM_MembershipExtras_BAO_AutoMembershipUpgradeRuleTest extends BaseHeadles
     $params = [
       'name' => 'test_10',
       'label' => 'Test 10',
-      'from_membership_type_id' => $this->fromMembershipType->id,
-      'to_membership_type_id' => $this->toMembershipType->id,
+      'from_membership_type_id' => $this->fromMembershipType['id'],
+      'to_membership_type_id' => $this->toMembershipType['id'],
       'upgrade_trigger_date_type' => TriggerDateTypeSelectValues::MEMBER_SINCE,
       'period_length' => PeriodUnitSelectValues::YEARS,
       'period_length_unit' => 1,


### PR DESCRIPTION
## Overview
Fixing some UI issues related to upgrade rules functionality.

## Before

1- When trying to delete an upgrade rule, the following confirmation message appears : 

```Are you sure you want to delete this membership automated upgrade rule?```

but it should be : 

```Are you sure you would like to delete the automated upgrade rule?```



2- Clicking on `Cancel` button on create/update/delete forms returns to CiviCRM dashboard screen instead of the rules management screen.

3- Putting a value > 3 in  the "Held For" field will result in not showing the period unit but only its length.

![2020-10-30 01_10_59-Window](https://user-images.githubusercontent.com/6275540/97642027-e5ca2900-1a4c-11eb-86c1-75db1b60b301.png)


## After

1- 


![2020-10-30 01_08_40-Window](https://user-images.githubusercontent.com/6275540/97641826-7b18ed80-1a4c-11eb-8cf3-777e025160ee.png)

2- 

![3333333333](https://user-images.githubusercontent.com/6275540/97642008-dd71ee00-1a4c-11eb-8fac-f7d091fdded0.gif)


3- 

![2020-10-30 01_12_18-Window](https://user-images.githubusercontent.com/6275540/97642080-01cdca80-1a4d-11eb-955d-a2df4b851723.png)

