### PR TITLE
IO-73: Show upgraded membership in manage installments next period tab

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -347,7 +347,25 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       $conditions['end_date'] = ['IS NULL' => 1];
     }
 
-    return $this->getLineItems($conditions);
+    $nextLineItems = $this->getLineItems($conditions);
+
+    foreach ($nextLineItems as &$nextLineItem) {
+      if (!empty($nextLineItem['related_membership']['id'])) {
+        $relatedMembershipId = $nextLineItem['related_membership']['id'];
+
+        $autoUpgradableMembershipChecker = new CRM_MembershipExtras_Service_AutoUpgradableMembershipChecker();
+        $upgradedMembershipTypeId = $autoUpgradableMembershipChecker->calculateMembershipTypeToUpgradeTo($relatedMembershipId);
+
+        if (!empty($upgradedMembershipTypeId)) {
+          $nextLineItem['label'] = civicrm_api3('MembershipType', 'getvalue', [
+            'return' => 'name',
+            'id' => $upgradedMembershipTypeId,
+          ]);
+        }
+      }
+    }
+
+    return $nextLineItems;
   }
 
   /**


### PR DESCRIPTION
## Before
If we have an upgrade rule to upgrade the current membership of type A to a membership of Type B after the current term ends, then it should show that in the "next period" tab inside the manage instalments screen.

Here is an example where we have a membership of type `Student` that should be upgraded to `Student Upgrade` membership after 1 year.

![2020-11-04 13_20_36-Membership Automated Upgrade Rules _ me4test6](https://user-images.githubusercontent.com/6275540/98105485-fb49b380-1e8f-11eb-8e65-1bf7fe835d90.png)

![111111](https://user-images.githubusercontent.com/6275540/98105499-000e6780-1e90-11eb-9e9d-cd0047f96e52.gif)


## After

The next period tab showing to what type the membership should be upgraded to : 

![2222](https://user-images.githubusercontent.com/6275540/98105573-1a484580-1e90-11eb-8a59-69b9ce59b0a1.gif)


