### PR TITLE
IO-73: Fix upgraded membership financial values in next period tab screen

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -357,10 +357,22 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
         $upgradedMembershipTypeId = $autoUpgradableMembershipChecker->calculateMembershipTypeToUpgradeTo($relatedMembershipId);
 
         if (!empty($upgradedMembershipTypeId)) {
-          $nextLineItem['label'] = civicrm_api3('MembershipType', 'getvalue', [
-            'return' => 'name',
+          $membershipType = civicrm_api3('MembershipType', 'get', [
+            'sequential' => 1,
+            'return' => ['name', 'minimum_fee', 'financial_type_id'],
             'id' => $upgradedMembershipTypeId,
           ]);
+
+          if (!empty($membershipType['values'][0])) {
+            $membershipType = $membershipType['values'][0];
+            $nextLineItem['label'] = $membershipType['name'];
+            $nextLineItem['line_total'] = MoneyUtilities::roundToCurrencyPrecision($membershipType['minimum_fee'] / $installments);
+            $nextLineItem['financial_type'] = $this->getFinancialTypeName($membershipType['financial_type_id']);
+            $nextLineItem['tax_rate'] = $this->getTaxRateForFinancialType($membershipType['financial_type_id']);
+            $nextLineItem['tax_amount'] = MoneyUtilities::roundToCurrencyPrecision(
+              $nextLineItem['line_total'] * $nextLineItem['tax_rate'] / 100
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## Before

In the membership is going to be upgraded next year, then it will only show the correct label in "next period" tab inside "manage instalments" screen, but the rest of the financial values such as the financial type, amount and tax amount will keep referring to the current line item values.

Yearly Payment Plan
![2020-11-13 01_12_42-Window](https://user-images.githubusercontent.com/6275540/99008081-272efe00-254e-11eb-8800-9e57a737fe16.png)
![2020-11-13 01_12_49-Window](https://user-images.githubusercontent.com/6275540/99008095-301fcf80-254e-11eb-8b2b-2ff5b3c0fd91.png)


Monthly Payment Plan
![2020-11-13 01_12_59-Window](https://user-images.githubusercontent.com/6275540/99008105-3615b080-254e-11eb-80b5-46fdbaf83780.png)
![2020-11-13 01_13_06-Window](https://user-images.githubusercontent.com/6275540/99008110-38780a80-254e-11eb-8be0-216dde5ea2a4.png)


## After

Yearly Payment Plan
![2020-11-13 01_11_14-Window](https://user-images.githubusercontent.com/6275540/99008183-59406000-254e-11eb-9afd-4480b3c07806.png)
![2020-11-13 01_11_25-Window](https://user-images.githubusercontent.com/6275540/99008189-5c3b5080-254e-11eb-87d6-872d94105ab4.png)


Monthly Payment Plan
![2020-11-13 01_11_39-Window](https://user-images.githubusercontent.com/6275540/99008196-5f364100-254e-11eb-8165-b1bd89d1bf7f.png)
![2020-11-13 01_11_47-Window](https://user-images.githubusercontent.com/6275540/99008201-61000480-254e-11eb-9f10-cc3b3898ae15.png)


hence that the new membership type in the screenshots above has the total price of 100$ and tax rate of 20%
