### PR TITLE
BASW-289: Avoid Saving End Date for Lifetime Memberships

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -63,6 +63,13 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
   private $membershipsCache = [];
 
   /**
+   * Maps membership types to memberships that have been loaded.
+   *
+   * @var array
+   */
+  private $membershipTypesCache = [];
+
+  /**
    * @inheritdoc
    */
   public function __construct($title = NULL, $mode = NULL) {
@@ -165,19 +172,23 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
    * @return array
    */
   private function getMembershipTypeFromMembershipID($membershipID) {
-    try {
-      $result = civicrm_api3('Membership', 'getsingle', [
-        'id' => $membershipID,
-        'api.MembershipType.getsingle' => [
-          'id' => '$value.membership_type_id',
-        ],
-      ]);
+    if (!isset($this->membershipTypesCache[$membershipID])) {
+      try {
+        $result = civicrm_api3('Membership', 'getsingle', [
+          'id' => $membershipID,
+          'api.MembershipType.getsingle' => [
+            'id' => '$value.membership_type_id',
+          ],
+        ]);
 
-      return $result['api.MembershipType.getsingle'];
+        $this->membershipTypesCache[$membershipID] = $result['api.MembershipType.getsingle'];
+      }
+      catch (Exception $e) {
+        return [];
+      }
     }
-    catch (Exception $e) {
-      return [];
-    }
+
+    return $this->membershipTypesCache[$membershipID];
   }
 
   private function getMembershipTypeFromPriceFieldValue($priceFieldValueId) {
@@ -405,6 +416,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
         'sequential' => 1,
         'id' => $membershipID,
       ]);
+      $membership['related_membership_type'] = $this->getMembershipTypeFromMembershipID($membershipID);
       $this->membershipsCache[$membershipID] = $membership;
     }
 

--- a/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
+++ b/templates/CRM/MembershipExtras/Page/CurrentPeriodTab.tpl
@@ -50,13 +50,15 @@
             {$currentItem.start_date|date_format:"%Y-%m-%d"|crmDate}
         </td>
         <td>
-            {if $currentItem.end_date}
-              {$currentItem.end_date|date_format:"%Y-%m-%d"|crmDate}
-            {elseif $currentItem.related_membership.end_date}
-                {$currentItem.related_membership.end_date|date_format:"%Y-%m-%d"|crmDate}
-            {else}
-                {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
-            {/if}
+          {if $currentItem.related_membership.related_membership_type.duration_unit == 'lifetime'}
+            -
+          {elseif $currentItem.end_date}
+            {$currentItem.end_date|date_format:"%Y-%m-%d"|crmDate}
+          {elseif $currentItem.related_membership.end_date}
+              {$currentItem.related_membership.end_date|date_format:"%Y-%m-%d"|crmDate}
+          {else}
+              {$periodEndDate|date_format:"%Y-%m-%d"|crmDate}
+          {/if}
         </td>
         {if $recurringContribution.auto_renew}
           <td>


### PR DESCRIPTION
## Overview
On our instalment management screen, we are able to specify start date and end date when adding a membership line. The start date and end date will control two things:

narrowing down the instalments that the new membership line should apply to
setting the start date and end date of the membership
We want to avoid setting the end date of life memberships but also not taking away the ability to perform point 1 and 2 for other memberships.

This was previously addressed in this PR https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/192 , but got reverted prior to a release.

## Before
Every membership added via the View/Modify Future Installments screen had an end date set when creating/updating.

![image](https://user-images.githubusercontent.com/21999940/99096531-5bcda480-25a4-11eb-86c6-812f61f82e3b.png)

## After
End date is only set for memberships that are not lifetime.

![image](https://user-images.githubusercontent.com/21999940/99096608-799b0980-25a4-11eb-801d-28da3bf5e8c7.png)
