### PR TITLE
MAE-397: Fix Membership Deletion

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
+++ b/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
@@ -51,10 +51,18 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
   }
 
   private function setRelatedRecurContributionId() {
-    $this->relatedRecurContributionId = civicrm_api3('Contribution', 'getvalue', [
+    $this->relatedRecurContributionId = NULL;
+
+    $result = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
       'id' => $this->membershipPayment->contribution_id,
       'return' => 'contribution_recur_id',
+      'options' => ['limit' => 0],
     ]);
+    if ($result['count'] > 0) {
+      $contribution = array_shift($result['values']);
+      $this->relatedRecurContributionId = $contribution['contribution_recur_id'];
+    }
   }
 
   private function setMembership() {
@@ -146,7 +154,7 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
 
     if ($entityID && $entityTable == 'civicrm_membership' && $entityID != $this->membershipPayment->membership_id) {
       $sql = "
-        UPDATE civicrm_line_item 
+        UPDATE civicrm_line_item
         SET entity_table = 'civicrm_membership', entity_id = %1
         WHERE id = %2
       ";

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Post/MembershipPaymentTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Post/MembershipPaymentTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Contribution as ContributionFabricator;
+
+class CRM_MembershipExtras_Hook_Post_MembershipPaymentTest extends BaseHeadlessTest {
+
+  /**
+   * Ovject for the membership payment.
+   *
+   * @var \CRM_Member_DAO_MembershipPayment
+   */
+  private $membershipPayment;
+
+  /**
+   * Sets up common data for all the tests.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function setUp() {
+    $contact = ContactFabricator::fabricate();
+    $membershipType = MembershipTypeFabricator::fabricate([
+      'name' => 'Test Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 120,
+    ], TRUE);
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $membershipType->id,
+      'join_date' => date('YmdHis'),
+      'start_date' => date('YmdHis'),
+    ]);
+
+    $financialType = $this->getMembershipDuesFinancialType();
+    $contribution = ContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'financial_type_id' => $financialType['id'],
+      'total_amount' => 120,
+    ]);
+
+    $membershipPayment = new CRM_Member_DAO_MembershipPayment();
+    $membershipPayment->contribution_id = $contribution['id'];
+    $membershipPayment->membership_id = $membership['id'];
+    $membershipPayment->save();
+
+    $this->membershipPayment = $membershipPayment;
+  }
+
+  public function testPostDeleteHookDoesntTriggerExceptionsWhenContributionsHaveAlreadyBeenDeleted() {
+    civicrm_api3('Contribution', 'delete', [
+      'id' => $this->membershipPayment->contribution_id,
+    ]);
+
+    $membershipPaymentPostHook = new CRM_MembershipExtras_Hook_Post_MembershipPayment(
+      'delete',
+      $this->membershipPayment->id,
+      $this->membershipPayment
+    );
+    $membershipPaymentPostHook->postProcess();
+
+    $this->assertTrue(TRUE);
+  }
+
+  /**
+   * Obtains 'Membership Dues' financial type.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getMembershipDuesFinancialType() {
+    $result = civicrm_api3('FinancialType', 'get', [
+      'sequential' => 1,
+      'name' => 'Member Dues',
+      'options' => ['limit' => 1],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+}


### PR DESCRIPTION
## Overview
When you try to delete a membership, a popup is shown to confirm the deletion. After confirming, popup keeps on running on the same page and no deletion is happens.

## Before
As part of the membership deletion process, all contributions related to the membership are deleted to. After deletion, a post hook is triggered, which in turn executes our Post membership payment hook. This hook used a getvalue API call on the Contribution's entity to obtain the related recurring contribution, however, by this time related contributions had already been deleted. Thus an exception was thrown by the API call.

## After
Changed the API call from getvalue to get, so we can check the count before trying to access the value for recurring contribution ID.

