### PR TITLE
MAE-400: Fix Receive Date on Fixed Single Installment Renewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlan.php
@@ -123,7 +123,11 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
    */
   public function renew() {
     $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate();
-    $this->paymentPlanStartDate = $this->calculateNoInstallmentsPaymentPlanStartDate();
+
+    $this->paymentPlanStartDate = $this->membershipsStartDate;
+    if (!$this->areAnyMembershipsFixed()) {
+      $this->paymentPlanStartDate = $this->calculateNoInstallmentsPaymentPlanStartDate();
+    }
 
     $this->endCurrentLineItemsAndCreateNewOnesForNextPeriod($this->currentRecurContributionID);
     $this->updateRecurringContributionAmount($this->currentRecurContributionID);
@@ -133,6 +137,28 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
 
     $this->recordPaymentPlanFirstContribution();
     $this->renewPaymentPlanMemberships($this->currentRecurContributionID);
+  }
+
+  /**
+   * Checks if any of the memberships in the plan are fixed.
+   *
+   * @return bool
+   */
+  private function areAnyMembershipsFixed() {
+    $currentPeriodLines = $this->getRecurringContributionLineItemsToBeRenewed($this->currentRecurContributionID);
+
+    foreach ($currentPeriodLines as $lineItem) {
+      if ($lineItem['entity_table'] != 'civicrm_membership') {
+        continue;
+      }
+
+      if ($lineItem['period_type'] === 'fixed') {
+        return TRUE;
+      }
+
+    }
+
+    return FALSE;
   }
 
   /**
@@ -238,9 +264,10 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan extends 
   protected function getRecurringContributionLineItemsToBeRenewed($recurringContributionID) {
     if (!isset($this->linesToBeRenewed[$recurringContributionID])) {
       $q = '
-      SELECT msl.*, li.*, m.end_date AS memberhsip_end_date
+      SELECT msl.*, li.*, m.end_date AS memberhsip_end_date, cmt.period_type
       FROM membershipextras_subscription_line msl, civicrm_line_item li
       LEFT JOIN civicrm_membership m ON li.entity_id = m.id
+      LEFT JOIN civicrm_membership_type cmt on m.membership_type_id = cmt.id
       WHERE msl.line_item_id = li.id
       AND msl.contribution_recur_id = %1
       AND msl.auto_renew = 1

--- a/CRM/MembershipExtras/Test/Fabricator/Base.php
+++ b/CRM/MembershipExtras/Test/Fabricator/Base.php
@@ -33,10 +33,29 @@ abstract class CRM_MembershipExtras_Test_Fabricator_Base {
       throw new \Exception('Entity name cannot be empty!');
     }
 
-    $params = array_merge(static::$defaultParams, $params);
-    $result = civicrm_api3(static::$entityName, 'create', $params);
+    $defaultParams = static::getDefaultParameters();
+    $params = array_merge($defaultParams, $params);
+
+    try {
+      $result = civicrm_api3(static::$entityName, 'create', $params);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      throw new Exception('Found exception fabricating ' . static::$entityName . ': ' . $e->getMessage() . "\n\n" . print_r($e->getExtraParams(), TRUE));
+    }
+    catch (Exception $e) {
+      throw new Exception('Found exception fabricating ' . static::$entityName . ': ' . $e->getMessage());
+    }
 
     return array_shift($result['values']);
+  }
+
+  /**
+   * Returns default list of parameters to create an instance of the entity.
+   *
+   * @return array
+   */
+  public static function getDefaultParameters() {
+    return static::$defaultParams;
   }
 
 }

--- a/CRM/MembershipExtras/Test/Fabricator/Contribution.php
+++ b/CRM/MembershipExtras/Test/Fabricator/Contribution.php
@@ -14,6 +14,21 @@ class CRM_MembershipExtras_Test_Fabricator_Contribution extends BaseFabricator {
   protected static $entityName = 'Contribution';
 
   /**
+   * Default parameters to be used when creating a contribution.
+   *
+   * @var array
+   */
+  protected static $defaultParams = [
+    'fee_amount' => 0,
+    'net_amount' => 120,
+    'total_amount' => 120,
+    'receive_date' => '2018-01-01',
+    'is_pay_later' => TRUE,
+    'skipLineItem' => 1,
+    'skipCleanMoney' => TRUE,
+  ];
+
+  /**
    * Fabricates a contribution with given parameters.
    *
    * @param array $params
@@ -34,6 +49,67 @@ class CRM_MembershipExtras_Test_Fabricator_Contribution extends BaseFabricator {
     }
 
     return $contribution;
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getDefaultParameters() {
+    self::$defaultParams['payment_instrument_id'] = self::getEftPaymentInstrumentID();
+    self::$defaultParams['financial_type_id'] = self::getMemberDuesFinancialTypeID();
+    self::$defaultParams['contribution_status_id'] = self::getContributionPendingStatusValue();
+
+    return parent::getDefaultParameters();
+  }
+
+  /**
+   * Obtains value for EFT payment instrument option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getEftPaymentInstrumentID() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'payment_instrument',
+      'label' => 'EFT',
+    ]);
+  }
+
+  /**
+   * Obtains ID of 'Member Dues' Financial Type.
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getMemberDuesFinancialTypeID() {
+    $result = civicrm_api3('FinancialType', 'get', [
+      'sequential' => 1,
+      'name' => 'Member Dues',
+      'options' => ['limit' => 1],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values'])['id'];
+    }
+
+    return 0;
+  }
+
+  /**
+   * Obtains value for the 'Pending' contribution status option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getContributionPendingStatusValue() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'contribution_status',
+      'name' => 'Pending',
+    ]);
   }
 
 }

--- a/CRM/MembershipExtras/Test/Fabricator/MembershipType.php
+++ b/CRM/MembershipExtras/Test/Fabricator/MembershipType.php
@@ -14,6 +14,7 @@ class CRM_MembershipExtras_Test_Fabricator_MembershipType extends BaseFabricator
    * @var array
    */
   protected static $defaultParams = [
+    'name' => 'Test Membership Type',
     'duration_unit' => 'year',
     'period_type' => 'fixed',
     'duration_interval' => 1,

--- a/CRM/MembershipExtras/Test/Fabricator/RecurringContribution.php
+++ b/CRM/MembershipExtras/Test/Fabricator/RecurringContribution.php
@@ -1,5 +1,6 @@
 <?php
 use CRM_MembershipExtras_Test_Fabricator_Base as BaseFabricator;
+use CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution as OfflineRecurringContributionPaymentProcessor;
 
 /**
  * Class CRM_MembershipExtras_Test_Fabricator_RecurringContribution.
@@ -13,5 +14,90 @@ class CRM_MembershipExtras_Test_Fabricator_RecurringContribution extends BaseFab
    * @var string
    */
   protected static $entityName = 'ContributionRecur';
+
+  /**
+   * Default parameters to create a recurring contribution.
+   *
+   * @var array
+   */
+  protected static $defaultParams = [
+    'amount' => 0,
+    'frequency_unit' => 'year',
+    'frequency_interval' => 1,
+    'installments' => 1,
+    'contribution_status_id' => 'Pending',
+    'is_test' => 0,
+    'auto_renew' => 1,
+    'cycle_day' => 1,
+    'start_date' => '2018-01-01',
+  ];
+
+  /**
+   * @inheritDoc
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getDefaultParameters() {
+    self::$defaultParams['payment_processor_id'] = self::getPayLaterProcessorID();
+    self::$defaultParams['financial_type_id'] = self::getMemberDuesFinancialTypeID();
+    self::$defaultParams['payment_instrument_id'] = self::getEftPaymentInstrumentID();
+
+    return parent::getDefaultParameters();
+  }
+
+  /**
+   * Obtains the ID of the pay later payment processor.
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getPayLaterProcessorID() {
+    $result = civicrm_api3('PaymentProcessor', 'get', [
+      'sequential' => 1,
+      'name' => OfflineRecurringContributionPaymentProcessor::NAME,
+      'is_test' => '0',
+      'options' => ['limit' => 1],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values'])['id'];
+    }
+
+    return 0;
+  }
+
+  /**
+   * Obtains ID of 'Member Dues' Financial Type.
+   *
+   * @return int
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getMemberDuesFinancialTypeID() {
+    $result = civicrm_api3('FinancialType', 'get', [
+      'sequential' => 1,
+      'name' => 'Member Dues',
+      'options' => ['limit' => 1],
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values'])['id'];
+    }
+
+    return 0;
+  }
+
+  /**
+   * Obtains value for EFT payment instrument option value.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getEftPaymentInstrumentID() {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'payment_instrument',
+      'label' => 'EFT',
+    ]);
+  }
 
 }

--- a/CRM/MembershipExtras/Test/Fabricator/RecurringLineItem.php
+++ b/CRM/MembershipExtras/Test/Fabricator/RecurringLineItem.php
@@ -13,4 +13,18 @@ class CRM_MembershipExtras_Test_Fabricator_RecurringLineItem extends BaseFabrica
    */
   protected static $entityName = 'ContributionRecurLineItem';
 
+  /**
+   * List of default parameters used to create a line item.
+   *
+   * @var array
+   */
+  protected static $defaultParams = [
+    'entity_table' => '',
+    'label' => 'Test Line',
+    'qty' => 1,
+    'unit_price' => 120,
+    'line_total' => 120,
+    'non_deductible_amount' => 0,
+  ];
+
 }

--- a/tests/phpunit/BasePaymentPlanTest.php
+++ b/tests/phpunit/BasePaymentPlanTest.php
@@ -156,7 +156,10 @@ abstract class BasePaymentPlanTest extends BaseHeadlessTest {
     $contributions = $contributions = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
       'contribution_recur_id' => $recurringContributionID,
-      'options' => ['limit' => 0],
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id',
+      ],
     ]);
 
     if ($contributions['count'] > 0) {

--- a/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstallmentPlanTest.php
@@ -12,18 +12,28 @@ use CRM_MembershipExtras_Test_Fabricator_PriceFieldValue as PriceFieldValueFabri
  * @group headless
  */
 class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlanTest extends BasePaymentPlanTest {
-  private $zeroFeeMembershipType;
+
+  /**
+   * Data for the recurring contribution.
+   *
+   * @var array
+   */
   private $recurringContribution;
 
   public function testSingleInstallmentPlanWithMembershipWithZeroFeeAutoRenew() {
-    $this->setupRenewableSingleInstallmentPlanWithZeroMembershipFeeTestCase();
+    $startDate = '2018-01-01';
+    $calculatedEndDate = '2018-12-31';
+    $endDateAfterRenewal = '2019-12-31';
+
+    $this->setupRenewableSingleInstallmentPlanWithZeroMembershipFeeTestCase($startDate);
 
     $contributions = $this->getPaymentPlanContributions($this->recurringContribution['id']);
     $this->assertEquals(1, count($contributions));
+    $this->assertEquals('2018-01-01 00:00:00', $contributions[0]['receive_date']);
 
     $memberships = $this->getPaymentPlanMemberships();
     foreach ($memberships as $membership) {
-      $this->assertEquals('2018-12-31', $membership['end_date']);
+      $this->assertEquals($calculatedEndDate, $membership['end_date']);
     }
 
     $renewer = new CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan();
@@ -31,23 +41,55 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlanTest exte
 
     $contributions = $this->getPaymentPlanContributions($this->recurringContribution['id']);
     $this->assertEquals(2, count($contributions));
+    $this->assertEquals('2019-01-01 00:00:00', $contributions[1]['receive_date']);
 
     $memberships = $this->getPaymentPlanMemberships();
     foreach ($memberships as $membership) {
-      $this->assertEquals('2019-12-31', $membership['end_date']);
+      $this->assertEquals($endDateAfterRenewal, $membership['end_date']);
     }
   }
 
   /**
    * Sets up a scenario with a single installment plan with zero value fee.
    *
+   * @param string $startDate
+   *
    * @throws \CiviCRM_API3_Exception
    */
-  private function setupRenewableSingleInstallmentPlanWithZeroMembershipFeeTestCase() {
+  private function setupRenewableSingleInstallmentPlanWithZeroMembershipFeeTestCase($startDate) {
     $this->contact = ContactFabricator::fabricate();
 
-    $this->createRequiredEntities();
-    $this->setUpDefaultPaymentPlanParameters();
+    $zeroFeeMembershipType = $this->createZeroFeeMembershipType();
+    $this->createPriceFieldForMembershipType($zeroFeeMembershipType);
+    $this->setUpDefaultPaymentPlanParameters($startDate);
+
+    $priceFieldValue = $this->getDefaultPriceFieldValueID($zeroFeeMembershipType->id);
+    $this->lineItemsParams = [
+      [
+        'entity_table' => 'civicrm_membership',
+        'price_field_id' => $priceFieldValue['price_field_id'],
+        'label' => 'Membership subscription',
+        'qty' => 1,
+        'unit_price' => 0,
+        'line_total' => 0,
+        'price_field_value_id' => $priceFieldValue['id'],
+        'financial_type_id' => $this->memberDuesFinancialType['id'],
+        'non_deductible_amount' => 0,
+        'start_date' => $startDate,
+        'join_date' => $startDate,
+        'end_date' => '',
+      ],
+      [
+        'entity_table' => '',
+        'price_field_id' => $priceFieldValue['price_field_id'],
+        'label' => 'Other fee',
+        'qty' => 1,
+        'unit_price' => 120,
+        'line_total' => 120,
+        'financial_type_id' => $this->memberDuesFinancialType['id'],
+        'non_deductible_amount' => 0,
+      ],
+    ];
 
     $this->recurringContribution = PaymentPlanOrderFabricator::fabricate(
       $this->recurringContributionParams,
@@ -56,8 +98,11 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlanTest exte
     );
   }
 
-  private function createRequiredEntities() {
-    $this->zeroFeeMembershipType = MembershipTypeFabricator::fabricate(
+  /**
+   * Creates a zero fee membership type.
+   */
+  private function createZeroFeeMembershipType() {
+    return MembershipTypeFabricator::fabricate(
       [
         'name' => 'Test Rolling Membership',
         'period_type' => 'rolling',
@@ -67,16 +112,26 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlanTest exte
       ],
       TRUE
     );
+  }
+
+  /**
+   * Create a price field and price field value for the membership type.
+   *
+   * @param $membershipType
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createPriceFieldForMembershipType($membershipType) {
     $priceField = PriceFieldFabricator::fabricate([
-      'name' => 'default_price_set',
-      'label' => 'Member Dues',
+      'name' => 'test_field_' . time(),
+      'label' => 'Field ' . time(),
       'price_set_id' => $this->defaultMembershipsPriceSet['id'],
     ]);
     PriceFieldValueFabricator::fabricate([
-      'label' => $this->zeroFeeMembershipType->name,
-      'amount' => $this->zeroFeeMembershipType->minimum_fee,
+      'label' => $membershipType->name,
+      'amount' => $membershipType->minimum_fee,
       'price_field_id' => $priceField['id'],
-      'membership_type_id' => $this->zeroFeeMembershipType->id,
+      'membership_type_id' => $membershipType->id,
       'financial_type_id' => $this->memberDuesFinancialType['id'],
     ]);
   }
@@ -84,67 +139,26 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlanTest exte
   /**
    * Builds default parameters that will be used to create the payment plan.
    *
+   * @param string $startDate
+   *
    * @throws \CiviCRM_API3_Exception
    */
-  private function setUpDefaultPaymentPlanParameters() {
-    $this->recurringContributionParams = [
-      'sequential' => 1,
-      'contact_id' => $this->contact['id'],
-      'amount' => 0,
-      'frequency_unit' => 'year',
-      'frequency_interval' => 1,
-      'installments' => 1,
-      'contribution_status_id' => 'Pending',
-      'is_test' => 0,
-      'auto_renew' => 1,
-      'cycle_day' => 1,
-      'payment_processor_id' => $this->getPayLaterProcessorID()['id'],
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-      'payment_instrument_id' => $this->eftPaymentInstrumentID,
-      'start_date' => '2018-01-01',
-    ];
+  private function setUpDefaultPaymentPlanParameters($startDate) {
+    $this->recurringContributionParams = CRM_MembershipExtras_Test_Fabricator_RecurringContribution::getDefaultParameters();
+    $this->recurringContributionParams['contact_id'] = $this->contact['id'];
+    $this->recurringContributionParams['start_date'] = $startDate;
 
-    $this->contributionParams = [
-      'contact_id' => $this->contact['id'],
-      'fee_amount' => 0,
-      'net_amount' => 120,
-      'total_amount' => 120,
-      'receive_date' => '2018-01-01',
-      'payment_instrument_id' => $this->eftPaymentInstrumentID,
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-      'contribution_status_id' => $this->contributionPendingStatusValue,
-      'is_pay_later' => TRUE,
-      'skipLineItem' => 1,
-      'skipCleanMoney' => TRUE,
-    ];
-
-    $priceFieldValue = $this->getDefaultPriceFieldValueID($this->zeroFeeMembershipType->id);
-    $this->lineItemsParams[] = [
-      'entity_table' => 'civicrm_membership',
-      'price_field_id' => $priceFieldValue['price_field_id'],
-      'label' => 'Membership subscription',
-      'qty' => 1,
-      'unit_price' => 0,
-      'line_total' => 0,
-      'price_field_value_id' => $priceFieldValue['id'],
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-      'non_deductible_amount' => 0,
-      'start_date' => '2018-01-01',
-      'join_date' => '2018-01-01',
-      'end_date' => '',
-    ];
-    $this->lineItemsParams[] = [
-      'entity_table' => '',
-      'price_field_id' => $priceFieldValue['price_field_id'],
-      'label' => 'Other fee',
-      'qty' => 1,
-      'unit_price' => 120,
-      'line_total' => 120,
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-      'non_deductible_amount' => 0,
-    ];
+    $this->contributionParams = CRM_MembershipExtras_Test_Fabricator_Contribution::getDefaultParameters();
+    $this->contributionParams['contact_id'] = $this->contact['id'];
+    $this->contributionParams['receive_date'] = $startDate;
   }
 
+  /**
+   * Returns list of memberships associated to the payment plan.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
   private function getPaymentPlanMemberships() {
     $lineItems = civicrm_api3('ContributionRecurLineItem', 'get', [
       'sequential' => 1,
@@ -169,6 +183,106 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlanTest exte
     }
 
     return $memberships;
+  }
+
+  public function testDatesOfRenewalOfFixedMemberships() {
+    $startDate = '2019-07-01';
+    $endDate = '2019-11-30';
+    $fixedStartDate = '1201';
+    $fixedEndDate = '1130';
+    $receiveDateAfterRenewal = '2019-12-01';
+    $endDateAfterRenewal = '2020-11-30';
+
+    $this->setupRenewableSingleInstallmentPlanWithFixedMembership($startDate, $fixedStartDate, $fixedEndDate);
+
+    $contributions = $this->getPaymentPlanContributions($this->recurringContribution['id']);
+    $this->assertEquals(1, count($contributions));
+    $this->assertEquals($startDate . ' 00:00:00', $contributions[0]['receive_date']);
+
+    $memberships = $this->getPaymentPlanMemberships();
+    foreach ($memberships as $membership) {
+      $this->assertEquals($startDate, $membership['join_date']);
+      $this->assertEquals($startDate, $membership['start_date']);
+      $this->assertEquals($endDate, $membership['end_date']);
+    }
+
+    $renewer = new CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstallmentPlan();
+    $renewer->run();
+
+    $contributions = $this->getPaymentPlanContributions($this->recurringContribution['id']);
+    $this->assertEquals(2, count($contributions));
+    $this->assertEquals($receiveDateAfterRenewal . ' 00:00:00', $contributions[1]['receive_date']);
+
+    $memberships = $this->getPaymentPlanMemberships();
+    foreach ($memberships as $membership) {
+      $this->assertEquals($startDate, $membership['join_date']);
+      $this->assertEquals($startDate, $membership['start_date']);
+      $this->assertEquals($endDateAfterRenewal, $membership['end_date']);
+    }
+  }
+
+  /**
+   * Sets up a single installment plan with a fixed membership.
+   *
+   * @param string $startDate
+   * @param string $fixedStartDate
+   * @param string $fixedEndDate
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function setupRenewableSingleInstallmentPlanWithFixedMembership($startDate, $fixedStartDate, $fixedEndDate) {
+    $this->contact = ContactFabricator::fabricate();
+
+    $fixedMembershipType = $this->createFixedMembershipType($fixedStartDate, $fixedEndDate);
+    $this->createPriceFieldForMembershipType($fixedMembershipType);
+    $this->setUpDefaultPaymentPlanParameters($startDate);
+
+    $priceFieldValue = $this->getDefaultPriceFieldValueID($fixedMembershipType->id);
+    $this->lineItemsParams = [
+      [
+        'entity_table' => 'civicrm_membership',
+        'price_field_id' => $priceFieldValue['price_field_id'],
+        'label' => 'Membership subscription',
+        'qty' => 1,
+        'unit_price' => 0,
+        'line_total' => 0,
+        'price_field_value_id' => $priceFieldValue['id'],
+        'financial_type_id' => $this->memberDuesFinancialType['id'],
+        'non_deductible_amount' => 0,
+        'start_date' => $startDate,
+        'join_date' => $startDate,
+        'end_date' => '',
+      ],
+    ];
+
+    $this->recurringContribution = PaymentPlanOrderFabricator::fabricate(
+      $this->recurringContributionParams,
+      $this->lineItemsParams,
+      $this->contributionParams
+    );
+  }
+
+  /**
+   * Creates a fixed membership type within the given start and end dates.
+   *
+   * @param $from
+   * @param $to
+   *
+   * @return \CRM_Member_BAO_MembershipType
+   */
+  private function createFixedMembershipType($from, $to) {
+    return MembershipTypeFabricator::fabricate(
+      [
+        'name' => 'Test Rolling Membership',
+        'period_type' => 'fixed',
+        'minimum_fee' => 0,
+        'duration_unit' => 'year',
+        'duration_interval' => 1,
+        'fixed_period_start_day' => $from,
+        'fixed_period_rollover_day' => $to,
+      ],
+      TRUE
+    );
   }
 
 }


### PR DESCRIPTION
## Overview
If you create a new fixed membership to a contact with Auto-renew set, payment plan 1 installment and with the 
following dates:
- Member Since - 1 July 2019
- Member Start - 1 July 2019
- Member End Date - 30/11/2019 (Auto-filled)
- Payment Received Date - 1 July 2019

After renewing, the dates will get updated to:
- Member Since - 1 July 2019 - Correct
- Member Start - 1 July 2019  - Correct
- Member End Date - 30/11/2020 - Correct
- New Contribution Date - 1 July 2019 - Incorrect

New contribution date should be 1 Dec 2019

## Before
When renewing a payment plan with a single installment, the new recieve date is calculated from the initial cycle day of the payment plan, which was the 1st of july (day 182 of the year). Thus, all contribution recieve dates are calculated to be on that day of the corresponding year.

## After
Fixed by setting the contribution's receive date as the memberships' calculated start date if there is at least one fixed membership in the payment plan. For the evaluated scenario, this would mean the recieve date of the new contribution would be 1st of Dec, 2019.

## Notes
Added a test to verify the scenario.