### PR TITLE
MAE-283: Prevent Membership Extension on Bulk Contribution Update

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -104,11 +104,11 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    * @throws \CRM_Core_Exception
    */
   private function isBulkStatusUpdate() {
-    $q = CRM_Utils_Request::retrieve('q', 'String');
     $statusNext = CRM_Utils_Request::retrieve('_qf_Status_next', 'String');
     $contributionStatusID = CRM_Utils_Request::retrieve('contribution_status_id', 'String');
+    $currentPath = CRM_Utils_System::currentPath();
 
-    if ($q === 'civicrm/contribute/search' && $statusNext === 'Update Pending Status' && !empty($contributionStatusID)) {
+    if (stripos($currentPath, 'civicrm/contribute/search') !== FALSE && $statusNext === 'Update Pending Status' && !empty($contributionStatusID)) {
       return TRUE;
     }
 

--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -216,8 +216,9 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
       'id' => $membershipID,
       'options' => ['limit' => 0],
     ]);
-    if (isset($membership['contribution_recur_id']) && !empty($membership['contribution_recur_id'])) {
-      return $membership['contribution_recur_id'];
+    $recurringContributionID = CRM_Utils_Array::value('contribution_recur_id', $membership, NULL);
+    if (!empty($recurringContributionID)) {
+      return $recurringContributionID;
     }
 
     $result = civicrm_api3('LineItem', 'get', [

--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -51,7 +51,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    * Preprocesses parameters used for Membership operations.
    */
   public function preProcess() {
-    if ($this->paymentContributionID || $this->isRecordingPayment()) {
+    if ($this->paymentContributionID || $this->isRecordingPayment() || $this->isBulkStatusUpdate()) {
       $this->preventExtendingPaymentPlanMembership();
     }
 
@@ -97,13 +97,31 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
     return FALSE;
   }
 
+  /**
+   * Checks the request to see if a bulk status update is being done.
+   *
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  private function isBulkStatusUpdate() {
+    $q = CRM_Utils_Request::retrieve('q', 'String');
+    $statusNext = CRM_Utils_Request::retrieve('_qf_Status_next', 'String');
+    $contributionStatusID = CRM_Utils_Request::retrieve('contribution_status_id', 'String');
+
+    if ($q === 'civicrm/contribute/search' && $statusNext === 'Update Pending Status' && !empty($contributionStatusID)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
   private function parsePaymentRecordingInformation() {
     $recordPaymentEntryURL = CRM_Utils_Request::retrieve('entryURL', 'String');
     $recordPaymentEntryURL = html_entity_decode($recordPaymentEntryURL);
 
     $urlParts = parse_url($recordPaymentEntryURL);
 
-    if(!empty($urlParts['query'])) {
+    if (!empty($urlParts['query'])) {
       parse_str($urlParts['query'], $urlParams);
       return $urlParams;
     }
@@ -137,7 +155,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    * @return bool
    */
   private function isOfflinePaymentPlanMembership() {
-    $recContributionID = $this->getPaymentRecurringContributionID();
+    $recContributionID = $this->getMembershipRecurringContributionID();
 
     if ($recContributionID === NULL) {
       return FALSE;
@@ -176,10 +194,70 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    *   The recurring contribution ID or NULL
    *   if no recurring contribution exist.
    */
-  private function getPaymentRecurringContributionID() {
+  private function getMembershipRecurringContributionID() {
+    if (!empty($this->paymentContributionID)) {
+      return $this->getRecurringContributionIDFromContributionID($this->paymentContributionID);
+    }
+
+    return $this->getRecurringContributionFromMembership($this->id);
+  }
+
+  /**
+   * Obtains recurring contribution from the membership.
+   *
+   * @param $membershipID
+   *
+   * @return mixed|null
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getRecurringContributionFromMembership($membershipID) {
+    $membership = civicrm_api3('Membership', 'getsingle', [
+      'sequential' => 1,
+      'id' => $membershipID,
+      'options' => ['limit' => 0],
+    ]);
+    if (isset($membership['contribution_recur_id']) && !empty($membership['contribution_recur_id'])) {
+      return $membership['contribution_recur_id'];
+    }
+
+    $result = civicrm_api3('LineItem', 'get', [
+      'sequential' => 1,
+      'entity_id' => $membershipID,
+      'contribution_id' => ['IS NULL' => 1],
+      'options' => ['limit' => 0],
+      'api.ContributionRecurLineItem.get' => [
+        'sequential' => 1,
+        'line_item_id' => '$value.id',
+        'options' => ['limit' => 0],
+      ],
+    ]);
+
+    if ($result['count'] < 1) {
+      return NULL;
+    }
+
+    $line = $result['values'][0];
+    if ($line['api.ContributionRecurLineItem.get']['count'] < 1) {
+      return NULL;
+    }
+
+    $recurringLine = $line['api.ContributionRecurLineItem.get']['values'][0];
+
+    return $recurringLine['contribution_recur_id'];
+  }
+
+  /**
+   * Obtains recurring contribution ID from the contribution.
+   *
+   * @param int $contributionID
+   *
+   * @return int|null
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getRecurringContributionIDFromContributionID($contributionID) {
     $paymentContribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
-      'id' => $this->paymentContributionID,
+      'id' => $contributionID,
       'return' => ['id', 'contribution_recur_id'],
     ]);
 
@@ -220,7 +298,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    * complete the first payment.
    */
   public function extendPendingPaymentPlanMembershipOnRenewal() {
-    $pendingStatusValue =  civicrm_api3('OptionValue', 'getvalue', [
+    $pendingStatusValue = civicrm_api3('OptionValue', 'getvalue', [
       'return' => 'value',
       'option_group_id' => 'contribution_status',
       'name' => 'Pending',
@@ -258,23 +336,24 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    */
   private function startDateSetInForm() {
     try {
-      $startDateFromForm =  CRM_Utils_Request::retrieve('start_date', 'Date');
-    } catch (CRM_Core_Exception $e) {
-      return false;
+      $startDateFromForm = CRM_Utils_Request::retrieve('start_date', 'Date');
+    }
+    catch (CRM_Core_Exception $e) {
+      return FALSE;
     }
 
     if (empty($startDateFromForm)) {
-      return false;
+      return FALSE;
     }
 
     $formDate = new Date($startDateFromForm);
     $paramsDate = new Date($this->params['start_date']);
 
     if ($formDate === $paramsDate) {
-      return true;
+      return TRUE;
     }
 
-    return false;
+    return FALSE;
   }
 
   /**
@@ -288,7 +367,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
         'sequential' => 1,
         'id' => $this->id,
       ]);
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return '';
     }
 

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
@@ -1,0 +1,278 @@
+<?php
+
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder as PaymentPlanMembershipOrder;
+use CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder as PaymentPlanOrderFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_MembershipExtras_Hook_Pre_MembershipEdit as MembershipEditHook;
+
+/**
+ * Class CRM_MembershipExtras_Hook_Pre_MembershipEditTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest {
+
+  /**
+   * Helper function to create memberships and its default price field value.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  /**
+   * Creates a payment plan with the given mebership type.
+   *
+   * @param $membershipType
+   *
+   * @return array
+   */
+  private function createPaymentPlan($membershipType) {
+    $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year -1 month'));
+    $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
+    $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
+    $paymentPlanMembershipOrder->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $membershipType->priceFieldValue['price_field_id'],
+      'price_field_value_id' => $membershipType->priceFieldValue['id'],
+      'label' => $membershipType->membershipType['name'],
+      'qty' => 1,
+      'unit_price' => $membershipType->priceFieldValue['amount'],
+      'line_total' => $membershipType->priceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+      'auto_renew' => 1,
+    ];
+
+    return PaymentPlanOrderFabricator::fabricate($paymentPlanMembershipOrder);
+  }
+
+  /**
+   * Obtains memberships set to auto-renew for payment plan.
+   *
+   * @param int $paymentPlanID
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPaymentPlanRenewableMemberships($paymentPlanID) {
+    return civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $paymentPlanID,
+    ])['values'];
+  }
+
+  /**
+   * Returns list of contributions associated to given recurring contribution.
+   *
+   * @param int $paymentPlanID
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPaymentPlanContributions($paymentPlanID) {
+    return civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $paymentPlanID,
+      'options' => ['limit' => 0],
+    ])['values'];
+  }
+
+  public function testPreventExtendingPaymentPlanMembershipAfterContributionEdit() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlan = $this->createPaymentPlan($mainMembershipType);
+    $contributions = $this->getPaymentPlanContributions($paymentPlan['id']);
+    $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
+    $membershipParams = array_shift($memberships);
+    $membershipParams['end_date'] = date('Y-m-d');
+
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id']);
+    $hook->preProcess();
+
+    $this->assertTrue(!isset($membership['end_date']));
+  }
+
+  public function testPreventExtendingPaymentPlanMembershipOnRecordingPayment() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlan = $this->createPaymentPlan($mainMembershipType);
+    $contributions = $this->getPaymentPlanContributions($paymentPlan['id']);
+    $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
+    $membershipParams = array_shift($memberships);
+    $membershipParams['end_date'] = date('Y-m-d');
+
+    $_REQUEST['entryURL'] = 'action=add&id=' . $contributions[0]['id'];
+    $_REQUEST['_qf_AdditionalPayment_upload'] = 'Record Payment';
+
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL);
+    $hook->preProcess();
+
+    $this->assertTrue(!isset($membership['end_date']));
+  }
+
+  public function testPreventExtendingPaymentPlanMembershipOnBulkStatusUpdate() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlan = $this->createPaymentPlan($mainMembershipType);
+    $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
+    $membershipParams = array_shift($memberships);
+    $membershipParams['end_date'] = date('Y-m-d');
+
+    $_REQUEST['q'] = 'civicrm/contribute/search';
+    $_REQUEST['_qf_Status_next'] = 'Update Pending Status';
+    $_REQUEST['contribution_status_id'] = '1';
+
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL);
+    $hook->preProcess();
+
+    $this->assertTrue(!isset($membership['end_date']));
+  }
+
+  public function testMembershipNotInPaymentPlanIsNotPreventedFromExtending() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+    $contact = ContactFabricator::fabricate();
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $mainMembershipType->membershipType['id'],
+      'join_date' => date('Y-m-d'),
+      'start_date' => date('Y-m-d'),
+      'financial_type_id' => 'Member Dues',
+      'skipLineItem' => 0,
+    ]);
+    $payment = ContributionFabricator::fabricate([
+      'is_pay_later' => TRUE,
+      'skipLineItem' => 1,
+      'skipCleanMoney' => TRUE,
+      'receive_date' => date('Y-m-d'),
+      'contact_id' => $contact['id'],
+      'fee_amount' => 0,
+      'net_amount' => "{$mainMembershipType->priceFieldValue['amount']}",
+      'total_amount' => "{$mainMembershipType->priceFieldValue['amount']}",
+      'payment_instrument_id' => 'EFT',
+      'financial_type_id' => 'Member Dues',
+    ]);
+    LineItemFabricator::fabricate([
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['id'],
+      'contribution_id' => $payment['id'],
+      'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+      'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+      'label' => $mainMembershipType->membershipType['name'],
+      'qty' => 1,
+      'unit_price' => $mainMembershipType->priceFieldValue['amount'],
+      'line_total' => $mainMembershipType->priceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+      'auto_renew' => 0,
+    ]);
+
+    $newEndDate = date('Y-m-d', strtotime($membership['end_date'] . '+2 years'));
+    $membership['end_date'] = $newEndDate;
+    $hook = new MembershipEditHook($membership['id'], $membership, $payment['id']);
+    $hook->preProcess();
+
+    $this->assertEquals($newEndDate, $membership['end_date']);
+  }
+
+  public function testExtendPendingPaymentPlanMembershipOnRenewal() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlan = $this->createPaymentPlan($mainMembershipType);
+    $contributions = $this->getPaymentPlanContributions($paymentPlan['id']);
+    $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
+    $membershipParams = array_shift($memberships);
+    $membershipEndDate = $membershipParams['end_date'];
+
+    $_REQUEST['action'] = CRM_Core_Action::RENEW;
+    $_REQUEST['contribution_status_id'] = civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => 'contribution_status',
+      'name' => 'Pending',
+    ]);
+    $_REQUEST['installments'] = $paymentPlan['installments'];
+    $_REQUEST['record_contribution'] = 1;
+    $_REQUEST['contribution_type_toggle'] = 'payment_plan';
+
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id']);
+    $hook->preProcess();
+
+    $this->assertEquals(
+      date('Y-m-d', strtotime($membershipEndDate . ' +12 months')),
+      date('Y-m-d', strtotime($membershipParams['end_date']))
+    );
+  }
+
+  public function testVerifyMembershipStartDate() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlan = $this->createPaymentPlan($mainMembershipType);
+    $contributions = $this->getPaymentPlanContributions($paymentPlan['id']);
+    $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
+    $membershipParams = array_shift($memberships);
+    $originalStartDate = $membershipParams['start_date'];
+    $membershipParams['start_date'] = date('Y-m-d', strtotime('+1000 years'));
+
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id']);
+    $hook->preProcess();
+
+    $this->assertEquals($originalStartDate, $membershipParams['start_date']);
+  }
+
+}


### PR DESCRIPTION
## Overview
Membership end date is being updated to next period after doing contribution bulk action 'Updating Pending Contribution Status'.

## Before
When updating contributions in bulk, CiviCRM will set the num_terms parameter which, in their own words, is used as a "special sauce" to cause the memberships related to the contributions to be extended. Furthermore, this extension is calculated in the membership API call, before hitting the BAO.

https://github.com/civicrm/civicrm-core/blob/master/api/v3/Membership.php#L106-L108

## After
Neutralized CiviCRM API's special sauce, by implementing a pre hook on the membership entity that will unset the end date if it detects a bulk contribution status update is being done.

