### PR TITLE
MAE-416: Update CiviCRM and specify Drupal version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.75 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.24.6
+          version: 5.28.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Overview

Currently, when workflow for testing is run. A Drupal site will be created with civibuild was failing due to the recent change on Civibuild 

![Screenshot from 2020-11-27 15-13-42](https://user-images.githubusercontent.com/208713/100464291-3f158e80-30c5-11eb-9961-c1cf75b992be.png)


The reason if the failing is because of a patch for mysql 8 was not properly applied at this point https://github.com/civicrm/civicrm-buildkit/blob/7461255fc26317979c3261e9318d60bbb88bfcd0/src/civibuild.lib.sh#L1051 due to the recent change at https://github.com/drupal/drupal/commit/e1892643309aef2eebbbf646ac568795a8849f85#diff-b63d2c77d41d9f57dc94ede9c21dccd6dacfc89e4e977100af9a447b935c422dR365-R371

A specific Drupal version must be defined to CiviBuild so mysql/database.inc file version will be compatible with the patch. 

This PR is not just for fixing this issue, CiviCRM version is also updated to match the current version of Compuclient. 
