### PR TITLE
MAE-380: Fix unit tests after merging workstream branch with master branch

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessor.php
@@ -33,7 +33,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor 
    * Processes the membership offline auto-renewal.
    */
   public function postProcess() {
-    if (!$this->isPaymentPlanWithAtLeastOneInstallment() ||  $this->isMembershipAlreadySetToAutoRenew()) {
+    if (!$this->isUsingPaymentPlanOption() ||  $this->isMembershipAlreadySetToAutoRenew()) {
       return;
     }
 
@@ -72,11 +72,11 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessor 
    *
    * @return bool
    */
-  private function isPaymentPlanWithAtLeastOneInstallment() {
-    $installmentsCount = $this->formSubmittedValues['installments'];
+  private function isUsingPaymentPlanOption() {
+    $paymentPlanSchdule = $this->formSubmittedValues['payment_plan_schedule'];
     $isSavingContribution = $this->formSubmittedValues['record_contribution'];
 
-    if ($isSavingContribution && $installmentsCount > 0) {
+    if ($isSavingContribution && !empty($paymentPlanSchdule)) {
       return TRUE;
     }
 

--- a/CRM/MembershipExtras/Test/Entity/PaymentPlanMembershipOrder.php
+++ b/CRM/MembershipExtras/Test/Entity/PaymentPlanMembershipOrder.php
@@ -39,4 +39,6 @@ class CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder {
 
   public $paymentProcessor;
 
+  public $autoRenew;
+
 }

--- a/CRM/MembershipExtras/Test/Fabricator/MembershipType.php
+++ b/CRM/MembershipExtras/Test/Fabricator/MembershipType.php
@@ -50,10 +50,6 @@ class CRM_MembershipExtras_Test_Fabricator_MembershipType extends BaseFabricator
 
     $membershipType = new MembershipType();
 
-    if (empty($params['name'])) {
-      $params['name'] = md5(mt_rand());
-    }
-
     foreach ($params as $property => $value) {
       $membershipType->$property = $value;
     }

--- a/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
+++ b/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
@@ -116,7 +116,7 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
       'installments' => $installments,
       'contribution_status_id' => self::$paymentPlanMembershipOrder->paymentPlanStatus,
       'is_test' => 0,
-      'auto_renew' => 1,
+      'auto_renew' => isset(self::$paymentPlanMembershipOrder->autoRenew) ? self::$paymentPlanMembershipOrder->autoRenew : 1,
       'cycle_day' => 1,
       'payment_processor_id' => self::$paymentPlanMembershipOrder->paymentProcessor,
       'financial_type_id' => self::$paymentPlanMembershipOrder->financialType,

--- a/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipOfflineAutoRenewProcessorTest.php
@@ -1,14 +1,10 @@
 <?php
 
-use CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder as PaymentPlanOrderFabricator;
-use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
-use CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution as OfflineRecurringContributionPaymentProcessor;
-use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
-use CRM_MembershipExtras_Test_Fabricator_PriceField as PriceFieldFabricator;
-use CRM_MembershipExtras_Test_Fabricator_PriceFieldValue as PriceFieldValueFabricator;
 
 /**
  * Class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessorTest
+ *
+ * @group headless
  */
 class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessorTest extends BaseHeadlessTest {
 
@@ -16,62 +12,33 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessorT
    * @var CRM_Member_Form
    */
   private $form;
-  /**
-   * @var array
-   */
-  private $contributionPendingStatusValue;
-  /**
-   * @var array
-   */
-  private $memberDuesFinancialType;
-  /**
-   * @var array
-   */
-  private $defaultMembershipsPriceSet;
-  /**
-   * @var array
-   */
-  private $contact;
+
   /**
    * @var array
    */
   private $membershipType;
+
   /**
-   * @var array
+   * @var mixed
    */
-  private $eftPaymentInstrumentID;
-  /**
-   * @var array
-   */
-  private $recurringContributionParams;
-  /**
-   * @var array
-   */
-  private $contributionParams;
+  private $membershipTypePriceFieldValue;
+
   /**
    * @var array
    */
   private $paymentPlan;
 
   /**
-   * @throws CiviCRM_API3_Exception
+   * @var CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder
    */
-  public function setUp() {
-    $this->setTestParameterValues();
-    $this->createRequiredTestEntities();
-    $this->setUpDefaultPaymentPlanParameters();
-  }
+  private $paymentPlanMembershipOrder;
 
   /**
    * @throws CiviCRM_API3_Exception
    */
   public function testPostProcessMembershipForm() {
+    $this->createPaymentPlanMembershipOrder();
     $this->setUpMembershipForm();
-    $this->paymentPlan = PaymentPlanOrderFabricator::fabricate(
-      $this->recurringContributionParams,
-      $this->lineItemsParams,
-      $this->contributionParams
-    );
     $this->simulateMembershipSignupForm();
 
     $this->assertEquals(0, $this->paymentPlan['auto_renew']);
@@ -97,22 +64,71 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessorT
     ]);
 
     $this->assertEquals(1, $contributionRecurLineItem['auto_renew']);
+  }
 
+  /**
+   * Fabricates payment plan membership order
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createPaymentPlanMembershipOrder() {
+    $this->membershipType = CRM_MembershipExtras_Test_Fabricator_MembershipType::fabricate([
+      'name' => 'Test Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 120,
+      'duration_interval' => 1,
+      'duration_unit' => 'year',
+    ]);
+
+    $this->membershipTypePriceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $this->membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $this->paymentPlanMembershipOrder = new CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder();
+    $this->paymentPlanMembershipOrder->autoRenew = 0;
+    $this->paymentPlanMembershipOrder->paymentPlanStatus = 'Pending';
+    $this->paymentPlanMembershipOrder->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $this->membershipTypePriceFieldValue['price_field_id'],
+      'price_field_value_id' => $this->membershipTypePriceFieldValue['id'],
+      'label' => $this->membershipType['name'],
+      'qty' => 1,
+      'unit_price' => $this->membershipTypePriceFieldValue['amount'],
+      'line_total' => $this->membershipTypePriceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+      'auto_renew' => 0,
+    ];
+
+    $this->paymentPlan =
+      CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder::fabricate($this->paymentPlanMembershipOrder);
+  }
+
+  /**
+   * Sets Membership Form
+   */
+  private function setUpMembershipForm() {
+    $controller = new CRM_Core_Controller();
+    $this->form = new CRM_Member_Form_Membership();
+    $this->form->controller = $controller;
   }
 
   /**
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws CiviCRM_API3_Exception
+   * @throws ReflectionException
    */
   private function simulateMembershipSignupForm() {
     $this->setFormMembershipIDs();
     $this->form->setVar('_submitValues', [
       'record_contribution' => 1,
-      'membership_type_id' => [$this->membershipType->id, $this->getDefaultPriceFieldValueID()],
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-      'payment_instrument_id' => $this->getEFTPaymentInstrumentID(),
-      'contribution_status_id' => $this->getPendingContributionStatusValue(),
-      'installments' => $this->recurringContributionParams['installments'],
+      'membership_type_id' => [$this->membershipType['id'], $this->membershipTypePriceFieldValue['id']],
+      'financial_type_id' => $this->paymentPlanMembershipOrder->financialType,
+      'payment_instrument_id' => $this->paymentPlanMembershipOrder->paymentMethod,
+      'contribution_status_id' => $this->paymentPlanMembershipOrder->paymentPlanStatus,
+      'payment_plan_schedule' => 'monthly',
     ]);
     $this->form->buildForm();
   }
@@ -136,217 +152,6 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipOfflineAutoRenewProcessorT
     $propertyReflection = $formReflection->getProperty('_membershipIDs');
     $propertyReflection->setAccessible(TRUE);
     $propertyReflection->setValue(new stdClass(), $membershipIDs);
-
-  }
-
-  /**
-   * Loads parameters required for the tests.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function setTestParameterValues() {
-    $this->contributionPendingStatusValue = $this->getPendingContributionStatusValue();
-    $this->memberDuesFinancialType = $this->getMembershipDuesFinancialType();
-    $this->eftPaymentInstrumentID = $this->getEFTPaymentInstrumentID();
-    $this->defaultMembershipsPriceSet = $this->getDefaultPriceSet();
-  }
-
-  /**
-   * Fabricates entities required for tests.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function createRequiredTestEntities() {
-    $this->contact = ContactFabricator::fabricate();
-
-    $this->membershipType = MembershipTypeFabricator::fabricate(
-      [
-        'name' => 'Test Rolling Membership',
-        'period_type' => 'rolling',
-        'minimum_fee' => 120,
-      ],
-      TRUE
-    );
-
-    $priceField = PriceFieldFabricator::fabricate([
-      'name' => 'default_price_set',
-      'label' => 'Member Dues',
-      'price_set_id' => $this->defaultMembershipsPriceSet['id'],
-    ]);
-
-    PriceFieldValueFabricator::fabricate([
-      'label' => $this->membershipType->name,
-      'amount' => $this->membershipType->minimum_fee,
-      'price_field_id' => $priceField['id'],
-      'membership_type_id' => $this->membershipType->id,
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-    ]);
-  }
-
-  /**
-   * @throws CiviCRM_API3_Exception
-   */
-  private function setUpDefaultPaymentPlanParameters() {
-    $this->recurringContributionParams = [
-      'sequential' => 1,
-      'contact_id' => $this->contact['id'],
-      'amount' => 0,
-      'frequency_unit' => 'month',
-      'frequency_interval' => 1,
-      'installments' => 12,
-      'contribution_status_id' => 'Pending',
-      'is_test' => 0,
-      'auto_renew' => 0,
-      'cycle_day' => 1,
-      'payment_processor_id' => $this->getPayLaterProcessorID()['id'],
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-      'payment_instrument_id' => $this->eftPaymentInstrumentID,
-      'start_date' => date('Y-m-d'),
-    ];
-
-    $this->contributionParams = [
-      'contact_id' => $this->contact['id'],
-      'fee_amount' => 0,
-      'net_amount' => 120,
-      'total_amount' => 120,
-      'receive_date' => date('Y-m-d'),
-      'payment_instrument_id' => $this->eftPaymentInstrumentID,
-      'financial_type_id' => $this->memberDuesFinancialType['id'],
-      'contribution_status_id' => $this->contributionPendingStatusValue,
-      'is_pay_later' => TRUE,
-      'skipLineItem' => 1,
-      'skipCleanMoney' => TRUE,
-    ];
-
-    $priceFieldValue = $this->getDefaultPriceFieldValueID($this->membershipType->id);
-    $this->lineItemsParams[] = [
-      'entity_table' => 'civicrm_membership',
-      'price_field_id' => $priceFieldValue['price_field_id'],
-      'label' => 'Membership subscription',
-      'qty' => 1,
-      'unit_price' => 120,
-      'line_total' => 120,
-      'price_field_value_id' => $priceFieldValue['id'],
-      'financial_type_id' => $this->getMembershipDuesFinancialType()['id'],
-      'non_deductible_amount' => 0,
-    ];
-  }
-
-  /**
-   * Obtains default payment processor used for offline recurring contributions.
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getPayLaterProcessorID() {
-    $result = civicrm_api3('PaymentProcessor', 'get', [
-      'sequential' => 1,
-      'name' => OfflineRecurringContributionPaymentProcessor::NAME,
-      'is_test' => '0',
-      'options' => ['limit' => 1],
-    ]);
-
-    if ($result['count'] > 0) {
-      return array_shift($result['values']);
-    }
-
-    return [];
-  }
-
-  /**
-   * Gets the default price field value
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getDefaultPriceFieldValueID() {
-    $result = civicrm_api3('PriceFieldValue', 'get', [
-      'sequential' => 1,
-      'price_field_id.price_set_id.name' => 'default_membership_type_amount',
-    ]);
-
-    if ($result['count'] > 0) {
-      return array_shift($result['values']);
-    }
-
-    return [];
-  }
-
-  /**
-   * Obtains value for EFT payment instrument option value.
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getEFTPaymentInstrumentID() {
-    return civicrm_api3('OptionValue', 'getvalue', [
-      'return' => 'value',
-      'option_group_id' => 'payment_instrument',
-      'label' => 'EFT',
-    ]);
-  }
-
-  /**
-   * Obtains value for the 'Pending' contribution status option value.
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getPendingContributionStatusValue() {
-    return civicrm_api3('OptionValue', 'getvalue', [
-      'return' => 'value',
-      'option_group_id' => 'contribution_status',
-      'name' => 'Pending',
-    ]);
-  }
-
-  /**
-   * Obtains 'Membership Dues' financial type.
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getMembershipDuesFinancialType() {
-    $result = civicrm_api3('FinancialType', 'get', [
-      'sequential' => 1,
-      'name' => 'Member Dues',
-      'options' => ['limit' => 1],
-    ]);
-
-    if ($result['count'] > 0) {
-      return array_shift($result['values']);
-    }
-
-    return [];
-  }
-
-  /**
-   * Obtains default price set for memberships.
-   *
-   * @return array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getDefaultPriceSet() {
-    $result = civicrm_api3('PriceSet', 'get', [
-      'sequential' => 1,
-      'name' => 'default_membership_type_amount',
-      'options' => ['limit' => 1],
-    ]);
-
-    if ($result['count'] > 0) {
-      return array_shift($result['values']);
-    }
-
-    return [];
-  }
-
-  /**
-   * Sets Membership Form
-   */
-  private function setUpMembershipForm() {
-    $controller = new CRM_Core_Controller();
-    $this->form = new CRM_Member_Form_Membership();
-    $this->form->controller = $controller;
   }
 
 }

--- a/tests/phpunit/api/v3/PaymentScheduleTest.php
+++ b/tests/phpunit/api/v3/PaymentScheduleTest.php
@@ -4,6 +4,8 @@ use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabrica
 
 /**
  * Class PaymentScheduleTest
+ *
+ * @group headless
  */
 class PaymentScheduleTest extends BaseHeadlessTest {
 
@@ -31,11 +33,11 @@ class PaymentScheduleTest extends BaseHeadlessTest {
       'duration_unit' => 'year',
       'minimum_fee' => 120,
       'duration_interval' => 1,
-    ], TRUE);
+    ]);
 
     $scheduleInstalment = civicrm_api3('PaymentSchedule', 'get', [
       'sequential' => 1,
-      'membership_type_id' => $membershipType->id,
+      'membership_type_id' => $membershipType['id'],
       'schedule' => 'monthly',
     ])['values'];
 
@@ -46,7 +48,7 @@ class PaymentScheduleTest extends BaseHeadlessTest {
     $expectedTaxAmount = $currencySymbol . 0;
 
     $startDate = CRM_Member_BAO_MembershipType::getDatesForMembershipType(
-      $membershipType->id,
+      $membershipType['id'],
       NULL,
       NULL,
       NULL


### PR DESCRIPTION
## Overview

The tests started failing when they are run against the work stream branch after it has merged with the master branch. 

The reason of the test failing is that, recently the Membership Type has been refactored to provide two methods for when creating the Membership Type (API or with BAO class). 

This PR is to fix unit tests related to MAE-380 as well as fix other failing tests as Payment plan form has changed in version 5 workstream. 

The PR also refactors some codes, including changing method name, remove duplicate code and modify  fabricator, fabricator entity for payment plan order 

## Before

Tests are failing when running tests after version 5 workstream branch merged with master branch. 

## After

Tests are passed when running tests after version 5 workstream branch merged with master branch. 

## Technical Details

There is a reason what worth explaining here why we would need to refactor payment plan order fabricator and its entity. Currently, payment plan order fabricator automatically set auto-renew = TRUE when fabricating a recurring contribution, recurring contribution line item. 

With currently design, it is impossible to set auto-renew value when fabricating payment plan order. The reason for setting auto-renew value MembershipOfflineAutoRenewProcessor PostProcess Hook can be used and ensure that the hook is set auto-renew value correctly when the form is summited. 
