### PR TITLE
IO-126: Hook to Change Receive Date of Second Instalment

### DIFF
--- a/CRM/MembershipExtras/Hook/CustomDispatch/CalculateContributionReceiveDate.php
+++ b/CRM/MembershipExtras/Hook/CustomDispatch/CalculateContributionReceiveDate.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDate.
+ *
+ * Dispatches the hook to calculate instalment receive dates.
+ */
+class CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDate {
+
+  /**
+   * Number of instalment in the payment plan.
+   *
+   * @var int
+   */
+  private $contributionNumber;
+
+  /**
+   * Receive date being used for the instalmen.
+   *
+   * @var string
+   */
+  private $receiveDate;
+
+  /**
+   * List of parameters being used to create the contribution.
+   *
+   * @var array
+   */
+  private $params;
+
+  /**
+   * CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDate constructor.
+   *
+   * @param int $contributionNumber
+   * @param string $receiveDate
+   * @param array $params
+   */
+  public function __construct($contributionNumber, &$receiveDate, array &$params) {
+    $this->contributionNumber = $contributionNumber;
+    $this->receiveDate =& $receiveDate;
+    $this->params =& $params;
+  }
+
+  /**
+   * Dispatches the hook.
+   */
+  public function dispatch() {
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    CRM_Utils_Hook::singleton()->invoke(
+      ['contributionNumber', 'receiveDate', 'contributionCreationParams'],
+      $this->contributionNumber,
+      $this->receiveDate,
+      $this->params,
+      $nullObject, $nullObject, $nullObject,
+      'membershipextras_calculateContributionReceiveDate'
+    );
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/CustomDispatch/PostOfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Hook/CustomDispatch/PostOfflineAutoRenewal.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewal
+ */
+class CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewal {
+
+  /**
+   * Membership ID.
+   *
+   * @var int
+   */
+  private $membershipID;
+
+  /**
+   * New recurring contribution ID.
+   *
+   * @var int
+   */
+  private $recurringContributionID;
+
+  /**
+   * Previous recurring contribution.
+   *
+   * @var int
+   */
+  private $previousRecurringContributionID;
+
+  /**
+   * CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewal constructor.
+   *
+   * @param int $membershipID
+   * @param int $recurContributionId
+   * @param int $previousRecurContributionId
+   */
+  public function __construct($membershipID, &$recurContributionId, &$previousRecurContributionId) {
+    $this->membershipID = $membershipID ?: CRM_Utils_Hook::$_nullObject;
+    $this->recurringContributionID =& $recurContributionId;
+    $this->previousRecurringContributionID =& $previousRecurContributionId;
+  }
+
+  /**
+   * Dispatches hook.
+   */
+  public function dispatch() {
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    CRM_Utils_Hook::singleton()->invoke(
+      ['membershipId', 'recurContributionId', 'previousRecurContributionId'],
+      $nullObject,
+      $this->newRecurringContributionID,
+      $this->currentRecurContributionID,
+      $nullObject, $nullObject, $nullObject,
+      'membershipextras_postOfflineAutoRenewal'
+    );
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
@@ -120,11 +120,13 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
   private function dispatchReceiveDateCalculationHook() {
     $nullObject = CRM_Utils_Hook::$_nullObject;
     $receiveDate = $this->params['receive_date'];
+    $instalment = 1;
+
     CRM_Utils_Hook::singleton()->invoke(
-      ['receiveDate', 'contributionCreationParams'],
+      ['contributionNumber', 'receiveDate', 'contributionCreationParams'],
+      $instalment,
       $receiveDate,
       $this->params,
-      $nullObject,
       $nullObject, $nullObject, $nullObject,
       'membershipextras_calculateContributionReceiveDate'
     );

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
+use CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDate as CalculateContributionReceiveDateDispatcher;
 
 class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
 
@@ -118,18 +119,10 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor {
    * receive date.
    */
   private function dispatchReceiveDateCalculationHook() {
-    $nullObject = CRM_Utils_Hook::$_nullObject;
     $receiveDate = $this->params['receive_date'];
-    $instalment = 1;
 
-    CRM_Utils_Hook::singleton()->invoke(
-      ['contributionNumber', 'receiveDate', 'contributionCreationParams'],
-      $instalment,
-      $receiveDate,
-      $this->params,
-      $nullObject, $nullObject, $nullObject,
-      'membershipextras_calculateContributionReceiveDate'
-    );
+    $dispatcher = new CalculateContributionReceiveDateDispatcher(1, $receiveDate, $this->params);
+    $dispatcher->dispatch();
 
     $this->params['receive_date'] = $receiveDate;
   }

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -2,6 +2,7 @@
 use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
 use CRM_MembershipExtras_Service_MembershipEndDateCalculator as MembershipEndDateCalculator;
 use CRM_MembershipExtras_SettingsManager as SettingsManager;
+use CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewal as PostOfflineAutoRenewalDispatcher;
 
 /**
  * Renews a payment plan.
@@ -255,15 +256,8 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    * Dispatches postOfflineAutoRenewal hook for the recurring contribution.
    */
   private function dispatchMembershipRenewalHook() {
-    $nullObject = CRM_Utils_Hook::$_nullObject;
-    CRM_Utils_Hook::singleton()->invoke(
-      ['membershipId', 'recurContributionId', 'previousRecurContributionId'],
-      $nullObject,
-      $this->newRecurringContributionID,
-      $this->currentRecurContributionID,
-      $nullObject, $nullObject, $nullObject,
-      'membershipextras_postOfflineAutoRenewal'
-    );
+    $dispatcher = new PostOfflineAutoRenewalDispatcher(NULL, $this->newRecurringContributionID, $this->currentRecurContributionID);
+    $dispatcher->dispatch();
   }
 
   /**

--- a/CRM/MembershipExtras/Service/InstallmentReceiveDateCalculator.php
+++ b/CRM/MembershipExtras/Service/InstallmentReceiveDateCalculator.php
@@ -18,9 +18,16 @@ class CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator {
    */
   private $startDate;
 
-  public function __construct($recurContribution) {
-    $this->recurContribution = $recurContribution;
-    $this->startDate = $this->recurContribution['start_date'];
+  /**
+   * CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator constructor.
+   *
+   * @param array $recurContribution
+   */
+  public function __construct($recurContribution = []) {
+    if (!empty($recurContribution)) {
+      $this->recurContribution = $recurContribution;
+      $this->startDate = $this->recurContribution['start_date'];
+    }
   }
 
   /**
@@ -40,7 +47,7 @@ class CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator {
    * The linked recurring contribution details is the base
    * for this calculation.
    *
-   * @param int
+   * @param int $contributionNumber
    *   The number of the installment contribution.
    *
    * @return string
@@ -100,7 +107,7 @@ class CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator {
    *
    * @return DateTime
    */
-  private function getSameDayNextMonth(DateTime $startDate, $numberOfMonthsToAdd = 1) {
+  public function getSameDayNextMonth(DateTime $startDate, $numberOfMonthsToAdd = 1) {
     $startDateDay = (int) $startDate->format('j');
     $startDateMonth = (int) $startDate->format('n');
     $startDateYear = (int) $startDate->format('Y');
@@ -154,6 +161,7 @@ class CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator {
         $interval = "P{$daysToAddOrSubtract}D";
         $receiveDate->{$op}(new DateInterval($interval));
         break;
+
       case 'month':
         $receiveDate = $this->changeDayOfMonthInDate($receiveDate, $currentCycleDay);
         break;

--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -33,10 +33,9 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
   private $contributionPendingStatusValue;
 
   /**
-   * @var InstallmentReceiveDateCalculator
+   * @var \CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator
    */
   private $receiveDateCalculator;
-
 
   public function __construct($currentRecurContributionId) {
     $this->setCurrentRecurContribution($currentRecurContributionId);
@@ -53,7 +52,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
    * @param int $currentRecurContributionId
    */
   private function setCurrentRecurContribution($currentRecurContributionId) {
-    $this->currentRecurContribution =  civicrm_api3('ContributionRecur', 'get', [
+    $this->currentRecurContribution = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,
       'id' => $currentRecurContributionId,
     ])['values'][0];
@@ -65,9 +64,11 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
   private function setLastContribution() {
     $contribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
-      'return' => ['currency', 'contribution_source', 'net_amount',
-        'contact_id', 'fee_amount', 'total_amount', 'payment_instrument_id',
-        'is_test', 'tax_amount', 'contribution_recur_id', 'financial_type_id'],
+      'return' => [
+        'currency', 'contribution_source', 'net_amount', 'contact_id',
+        'fee_amount', 'total_amount', 'payment_instrument_id', 'is_test',
+        'tax_amount', 'contribution_recur_id', 'financial_type_id',
+      ],
       'contribution_recur_id' => $this->currentRecurContribution['id'],
       'options' => ['limit' => 1, 'sort' => 'id DESC'],
     ])['values'][0];
@@ -92,7 +93,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
    * Sets $currentRecurContribution
    */
   private function setContributionPendingStatusValue() {
-    $this->contributionPendingStatusValue =  civicrm_api3('OptionValue', 'getvalue', [
+    $this->contributionPendingStatusValue = civicrm_api3('OptionValue', 'getvalue', [
       'return' => 'value',
       'option_group_id' => 'contribution_status',
       'name' => 'Pending',
@@ -105,7 +106,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
    */
   public function createRemainingInstalmentContributionsUpfront() {
     $installmentsCount = (int) $this->currentRecurContribution['installments'];
-    for($contributionNumber = 2; $contributionNumber <= $installmentsCount; $contributionNumber++) {
+    for ($contributionNumber = 2; $contributionNumber <= $installmentsCount; $contributionNumber++) {
       $this->createContribution($contributionNumber);
     }
   }
@@ -125,7 +126,6 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
     $this->createLineItems($contribution);
   }
 
-
   /**
    * Records the membership contribution and its
    * related entities using the specified parameters
@@ -136,6 +136,8 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
    */
   private function recordMembershipContribution($contributionNumber) {
     $params = $this->buildContributionParams($contributionNumber);
+    $this->dispatchReceiveDateCalculationHook($contributionNumber, $params);
+
     $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
     $contributionSoftParams = CRM_Utils_Array::value('soft_credit', $params);
@@ -175,7 +177,7 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
    * @return array
    */
   private function buildContributionParams($contributionNumber) {
-    $params =  [
+    $params = [
       'currency' => $this->lastContribution['currency'],
       'source' => $this->lastContribution['contribution_source'],
       'contact_id' => $this->lastContribution['contact_id'],
@@ -205,6 +207,28 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
   }
 
   /**
+   * Dispatches hook so other extensions may change each contribution's receive
+   * date.
+   *
+   * @param int $contributionNumber
+   * @param array $params
+   */
+  private function dispatchReceiveDateCalculationHook($contributionNumber, &$params) {
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    $receiveDate = $params['receive_date'];
+    CRM_Utils_Hook::singleton()->invoke(
+      ['contributionNumber', 'receiveDate', 'contributionCreationParams'],
+      $contributionNumber,
+      $receiveDate,
+      $params,
+      $nullObject, $nullObject, $nullObject,
+      'membershipextras_calculateContributionReceiveDate'
+    );
+
+    $params['receive_date'] = $receiveDate;
+  }
+
+  /**
    * Copies the contribution custom field values from
    * the first contribution to the specified upfront contribution
    *
@@ -227,7 +251,6 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
     civicrm_api3('Contribution', 'create', $customParams);
   }
 
-
   /**
    * Creates the contribution line items.
    *
@@ -240,12 +263,12 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
       'contribution_id' => $this->lastContribution['id'],
     ])['values'];
 
-    foreach($lineItems as $lineItem) {
+    foreach ($lineItems as $lineItem) {
       $entityID = $lineItem['entity_id'];
       if ($lineItem['entity_table'] === 'civicrm_contribution') {
         $entityID = $contribution->id;
       }
-      
+
       $lineItemParms = [
         'entity_table' => $lineItem['entity_table'],
         'entity_id' => $entityID,

--- a/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstallmentsHandler.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_MembershipExtras_Service_InstallmentReceiveDateCalculator as InstallmentReceiveDateCalculator;
+use CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDate as CalculateContributionReceiveDateDispatcher;
 
 class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
 
@@ -214,16 +215,10 @@ class CRM_MembershipExtras_Service_MembershipInstallmentsHandler {
    * @param array $params
    */
   private function dispatchReceiveDateCalculationHook($contributionNumber, &$params) {
-    $nullObject = CRM_Utils_Hook::$_nullObject;
     $receiveDate = $params['receive_date'];
-    CRM_Utils_Hook::singleton()->invoke(
-      ['contributionNumber', 'receiveDate', 'contributionCreationParams'],
-      $contributionNumber,
-      $receiveDate,
-      $params,
-      $nullObject, $nullObject, $nullObject,
-      'membershipextras_calculateContributionReceiveDate'
-    );
+
+    $dispatcher = new CalculateContributionReceiveDateDispatcher($contributionNumber, $receiveDate, $params);
+    $dispatcher->dispatch();
 
     $params['receive_date'] = $receiveDate;
   }

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -466,7 +466,7 @@ function membershipextras_civicrm_alterMailParams(&$params, $context) {
 /**
  * Implements hook to calculate receive date for first instalment.
  */
-function membershipextras_membershipextras_calculateContributionReceiveDate(&$receiveDate, &$contributionCreationParams) {
+function membershipextras_membershipextras_calculateContributionReceiveDate($instalment, &$receiveDate, &$contributionCreationParams) {
   if (isset($contributionCreationParams['test_receive_date_calculation_hook'])) {
     $receiveDate = $contributionCreationParams['test_receive_date_calculation_hook'];
   }

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -462,12 +462,3 @@ function membershipextras_civicrm_alterMailParams(&$params, $context) {
   $alterMailParamsHook = new CRM_MembershipExtras_Hook_Alter_MailParamsHandler($params);
   $alterMailParamsHook->handle();
 }
-
-/**
- * Implements hook to calculate receive date for first instalment.
- */
-function membershipextras_membershipextras_calculateContributionReceiveDate($instalment, &$receiveDate, &$contributionCreationParams) {
-  if (isset($contributionCreationParams['test_receive_date_calculation_hook'])) {
-    $receiveDate = $contributionCreationParams['test_receive_date_calculation_hook'];
-  }
-}

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessorTest.php
@@ -1,6 +1,6 @@
 <?php
 use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
-use \Civi\Test\HookInterface;
+use Civi\Test\HookInterface;
 
 /**
  * Class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessorTest.php
@@ -1,12 +1,13 @@
 <?php
 use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use \Civi\Test\HookInterface;
 
 /**
  * Class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest
  *
  * @group headless
  */
-class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends BaseHeadlessTest {
+class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends BaseHeadlessTest implements HookInterface {
 
   public function testMonthlyCycleDayIsCalculatedFromReceiveDate() {
     $_REQUEST['installments'] = 12;
@@ -111,6 +112,19 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends Ba
 
     $this->assertEquals($newReceiveDate . ' 00:00:00', $recurringContribution['start_date']);
     $this->assertEquals('27', $recurringContribution['cycle_day']);
+  }
+
+  /**
+   * Implements calculateContributionReceiveDate hook for testing.
+   *
+   * @param $instalment
+   * @param $receiveDate
+   * @param $contributionCreationParams
+   */
+  public function hook_membershipextras_calculateContributionReceiveDate($instalment, &$receiveDate, &$contributionCreationParams) {
+    if (isset($contributionCreationParams['test_receive_date_calculation_hook'])) {
+      $receiveDate = $contributionCreationParams['test_receive_date_calculation_hook'];
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
Direct debit extension needs to be able to change the receive date of the second instalment according to its specified business rules, and every instalment after that, so that the receive dates of each contribution match the available payment collection dates configured in Direct Debit.

## Before
Only the receive date for the first instalment could be updated by other extensions.

## After
Added hook when creating the rest of instalments in the payment plan so other extensions can update the receive dates as needed.
