### PR TITLE
MAE-447: Calculate Start Date From Previous End Date on Manual Renewal

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
@@ -114,7 +114,7 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
         continue;
       }
 
-      $previousEndDate = MembershipEndDateCalculator::calculatePreviousEndDate($line['api.Membership.get']['values'][0]['id']);
+      $previousEndDate = MembershipEndDateCalculator::calculatePreviousEndDate($line['entity_id']);
       $endDate = new DateTime($previousEndDate);
 
       if (!isset($latestEndDate)) {

--- a/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreator.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_MembershipExtras_Service_ManualPaymentProcessors as ManualPaymentProcessors;
+use CRM_MembershipExtras_Service_MembershipEndDateCalculator as MembershipEndDateCalculator;
 
 class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator {
 
@@ -12,7 +13,7 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
 
   private $calculateAutorenewalFlag = FALSE;
 
-  public function __construct($recurContributionID){
+  public function __construct($recurContributionID) {
     $this->recurContributionID = $recurContributionID;
     $this->previousPeriodFieldID = $this->getCustomFieldID('related_payment_plan_periods', 'previous_period');
     $this->setRecurContribution();
@@ -25,11 +26,11 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
       'id' => $this->recurContributionID,
     ]);
     if ($recurContribution['count'] < 1) {
-      $this->recurContribution =  NULL;
+      $this->recurContribution = NULL;
       return;
     }
 
-    $this->recurContribution =  $recurContribution['values'][0];
+    $this->recurContribution = $recurContribution['values'][0];
   }
 
   /**
@@ -69,16 +70,20 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
       ]);
       $lineItemsFilterParams = [
         'sequential' => 1,
-        'return' => ['entity_table', 'entity_id', 'price_field_id',
-          'label', 'qty', 'unit_price', 'line_total', 'participant_count', 'id',
-          'price_field_value_id', 'financial_type_id', 'non_deductible_amount', 'tax_amount'],
+        'return' => [
+          'entity_table', 'entity_id', 'price_field_id', 'label', 'qty',
+          'unit_price', 'line_total', 'participant_count', 'id',
+          'price_field_value_id', 'financial_type_id', 'non_deductible_amount',
+          'tax_amount',
+        ],
         'contribution_id' => $lastContributionId,
         'api.Membership.get' => ['id' => '$value.entity_id'],
         'options' => ['limit' => 0],
       ];
 
       $lastContributionLineItems = civicrm_api3('LineItem', 'get', $lineItemsFilterParams);
-    } catch (CiviCRM_API3_Exception $exception) {
+    }
+    catch (CiviCRM_API3_Exception $exception) {
       return [];
     }
 
@@ -102,24 +107,28 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
    * @throws \Exception
    */
   private function getEarliestMembershipStartDate($lineItems) {
-    $earliestDate = NULL;
+    $latestEndDate = NULL;
 
     foreach ($lineItems as $line) {
       if ($line['entity_table'] !== 'civicrm_membership') {
         continue;
       }
 
-      $startDate = new DateTime($line['api.Membership.get']['values'][0]['start_date']);
+      $previousEndDate = MembershipEndDateCalculator::calculatePreviousEndDate($line['api.Membership.get']['values'][0]['id']);
+      $endDate = new DateTime($previousEndDate);
 
-      if (!isset($earliestDate)) {
-        $earliestDate = $startDate;
-      } elseif ($earliestDate > $startDate) {
-        $earliestDate = $startDate;
+      if (!isset($latestEndDate)) {
+        $latestEndDate = $endDate;
+      }
+      elseif ($latestEndDate < $endDate) {
+        $latestEndDate = $endDate;
       }
     }
 
-    if ($earliestDate) {
-      return $earliestDate->format('Y-m-d');
+    if ($latestEndDate) {
+      $latestEndDate->add(new DateInterval('P1D'));
+
+      return $latestEndDate->format('Y-m-d');
     }
 
     return NULL;

--- a/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
@@ -9,15 +9,15 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
    * Calculates the membership new end date
    * for renewal.
    *
-   * @param int $membershipId
+   * @param int $membershipID
    *
    * @return string
    * @throws \CiviCRM_API3_Exception
    * @throws \CiviCRM_API3_Exception|\Exception
    */
-  public static function calculate($membershipId) {
+  public static function calculate($membershipID) {
     $newEndDate = 'null';
-    $membershipDetails = self::getMembership($membershipId);
+    $membershipDetails = self::getMembership($membershipID);
     $interval = self::getMembershipPeriodInterval($membershipDetails);
     if (!empty($interval)) {
       $currentEndDate = new DateTime($membershipDetails['end_date']);
@@ -40,7 +40,6 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
     $previousEndDate = 'null';
     $membershipDetails = self::getMembership($membershipID);
     $interval = self::getMembershipPeriodInterval($membershipDetails);
-
     if (!empty($interval)) {
       $currentEndDate = new DateTime($membershipDetails['end_date']);
       $currentEndDate->sub(new DateInterval($interval));

--- a/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipEndDateCalculator.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * Class CRM_MembershipExtras_Service_MembershipEndDateCalculator.
+ */
 class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
 
   /**
@@ -9,15 +12,68 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
    * @param int $membershipId
    *
    * @return string
+   * @throws \CiviCRM_API3_Exception
+   * @throws \CiviCRM_API3_Exception|\Exception
    */
   public static function calculate($membershipId) {
-    $membershipDetails = civicrm_api3('Membership', 'get', [
+    $newEndDate = 'null';
+    $membershipDetails = self::getMembership($membershipId);
+    $interval = self::getMembershipPeriodInterval($membershipDetails);
+    if (!empty($interval)) {
+      $currentEndDate = new DateTime($membershipDetails['end_date']);
+      $currentEndDate->add(new DateInterval($interval));
+      $newEndDate = $currentEndDate->format('Ymd');
+    }
+
+    return $newEndDate;
+  }
+
+  /**
+   * Calculates the previous end date for the given membership.
+   *
+   * @param int $membershipID
+   *
+   * @return string
+   * @throws \CiviCRM_API3_Exception|\Exception
+   */
+  public static function calculatePreviousEndDate($membershipID) {
+    $previousEndDate = 'null';
+    $membershipDetails = self::getMembership($membershipID);
+    $interval = self::getMembershipPeriodInterval($membershipDetails);
+
+    if (!empty($interval)) {
+      $currentEndDate = new DateTime($membershipDetails['end_date']);
+      $currentEndDate->sub(new DateInterval($interval));
+      $previousEndDate = $currentEndDate->format('Ymd');
+    }
+
+    return $previousEndDate;
+  }
+
+  /**
+   * Obtains information of the membership with the given ID.
+   *
+   * @param int $membershipID
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getMembership($membershipID) {
+    return civicrm_api3('Membership', 'get', [
       'sequential' => 1,
       'return' => ['end_date', 'membership_type_id.duration_unit', 'membership_type_id.duration_interval'],
-      'id' => $membershipId,
+      'id' => $membershipID,
     ])['values'][0];
+  }
 
-    $currentEndDate = new DateTime($membershipDetails['end_date']);
+  /**
+   * Calculates the period string to be used to calculate membership end date.
+   *
+   * @param array $membershipDetails
+   *
+   * @return string|null
+   */
+  private static function getMembershipPeriodInterval(array $membershipDetails) {
     switch ($membershipDetails['membership_type_id.duration_unit']) {
       case 'month':
         $interval = 'P' . $membershipDetails['membership_type_id.duration_interval'] . 'M';
@@ -36,13 +92,7 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculator {
         break;
     }
 
-    $newEndDate = 'null';
-    if (!empty($interval)) {
-      $currentEndDate->add(new DateInterval($interval));
-      $newEndDate = $currentEndDate->format('Ymd');
-    }
-
-    return $newEndDate;
+    return $interval;
   }
 
 }

--- a/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreatorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreatorTest.php
@@ -1,0 +1,263 @@
+<?php
+
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_MembershipExtras_Test_Fabricator_LineItem as LineItemFabricator;
+use CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator as RecurringLineItemCreator;
+
+/**
+ * Class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreatorTest.
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreatorTest extends BaseHeadlessTest {
+
+  /**
+   * Creates a contact.
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createContact() {
+    return ContactFabricator::fabricate();
+  }
+
+  /**
+   * Creates a membership type with the given params.
+   *
+   * @param array $params
+   *
+   * @return \stdClass
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembershipType($params) {
+    $membershipType = MembershipTypeFabricator::fabricate($params);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $result = new stdClass();
+    $result->membershipType = $membershipType;
+    $result->priceFieldValue = $priceFieldValue;
+
+    return $result;
+  }
+
+  /**
+   * Creates a recurring contribution with the given parameters.
+   *
+   * @param array $params
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createRecurringContribution($params) {
+    return RecurringContributionFabricator::fabricate($params);
+  }
+
+  /**
+   * Creates a contribution with the given parameters and line items.
+   *
+   * @param array $contributionParams
+   * @param array $lineItems
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createContribution($contributionParams, $lineItems) {
+    $contribution = ContributionFabricator::fabricate($contributionParams);
+
+    foreach ($lineItems as &$line) {
+      $line['contribution_id'] = $contribution['id'];
+
+      if ($line['entity_table'] === 'civicrm_contribution') {
+        $line['line_item']['entity_id'] = $contribution['id'];
+      }
+
+      if ($line['entity_table'] === 'civicrm_membership') {
+        $membershipID = $this->createMembership($line, $contribution);
+        $line['entity_id'] = $membershipID;
+      }
+
+      LineItemFabricator::fabricate($line);
+    }
+  }
+
+  /**
+   * Creates a membership with the given parameters.
+   *
+   * @param array $lineItem
+   * @param array $contribution
+   *
+   * @return mixed
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function createMembership($lineItem, $contribution) {
+    $priceFieldValue = $this->getPriceFieldValue($lineItem['price_field_value_id']);
+
+    return $membershipCreateResult = MembershipFabricator::fabricate([
+      'contact_id' => $contribution['contact_id'],
+      'membership_type_id' => $priceFieldValue['membership_type_id'],
+      'join_date' => CRM_Utils_Array::value('join_date', $lineItem, date('Y-m-d')),
+      'start_date' => CRM_Utils_Array::value('start_date', $lineItem, date('Y-m-d')),
+      'end_date' => CRM_Utils_Array::value('end_date', $lineItem, NULL),
+      'contribution_recur_id' => $contribution['contribution_recur_id'],
+      'financial_type_id' => $lineItem['financial_type_id'],
+      'skipLineItem' => 1,
+    ]);
+  }
+
+  /**
+   * Obtains data for price field value identified with given ID.
+   *
+   * @param int $priceFieldValueID
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private static function getPriceFieldValue($priceFieldValueID) {
+    return civicrm_api3('PriceFieldValue', 'getsingle', [
+      'id' => $priceFieldValueID,
+    ]);
+  }
+
+  public function testLineItemCreation() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 18,
+      'duration_unit' => 'month',
+    ]);
+    $addOnMembershipType = $this->createMembershipType([
+      'name' => 'Add-on Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 120,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+    $secondAddOnMembershipType = $this->createMembershipType([
+      'name' => 'Second Add-on Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 180,
+      'duration_interval' => 6,
+      'duration_unit' => 'month',
+    ]);
+
+    $contact = $this->createContact();
+    $startDate = date('Y-m-d');
+    $recurringContribution = $this->createRecurringContribution([
+      'sequential' => 1,
+      'contact_id' => $contact['id'],
+      'amount' => 0,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'auto_renew' => 1,
+      'cycle_day' => 1,
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'EFT',
+      'start_date' => $startDate,
+    ]);
+
+    $contributionParams = [
+      'is_pay_later' => TRUE,
+      'skipLineItem' => 1,
+      'skipCleanMoney' => TRUE,
+      'receive_date' => $startDate,
+      'contribution_recur_id' => $recurringContribution['id'],
+      'contact_id' => $recurringContribution['contact_id'],
+      'fee_amount' => 0,
+      'net_amount' => "{$recurringContribution['amount']}",
+      'total_amount' => "{$recurringContribution['amount']}",
+      'payment_instrument_id' => 'EFT',
+      'financial_type_id' => 'Member Dues',
+      'contribution_status_id' => 'Pending',
+    ];
+    $lineItems = [
+      [
+        'entity_table' => 'civicrm_membership',
+        'price_field_id' => $mainMembershipType->priceFieldValue['price_field_id'],
+        'price_field_value_id' => $mainMembershipType->priceFieldValue['id'],
+        'label' => $mainMembershipType->membershipType['name'],
+        'qty' => 1,
+        'unit_price' => $mainMembershipType->priceFieldValue['amount'] / 12,
+        'line_total' => $mainMembershipType->priceFieldValue['amount'] / 12,
+        'financial_type_id' => 'Member Dues',
+        'non_deductible_amount' => 0,
+        'auto_renew' => 0,
+        'start_date' => $startDate,
+      ],
+      [
+        'entity_table' => 'civicrm_membership',
+        'price_field_id' => $addOnMembershipType->priceFieldValue['price_field_id'],
+        'price_field_value_id' => $addOnMembershipType->priceFieldValue['id'],
+        'label' => $addOnMembershipType->membershipType['name'],
+        'qty' => 1,
+        'unit_price' => $addOnMembershipType->priceFieldValue['amount'] / 12,
+        'line_total' => $addOnMembershipType->priceFieldValue['amount'] / 12,
+        'financial_type_id' => 'Member Dues',
+        'non_deductible_amount' => 0,
+        'auto_renew' => 1,
+        'start_date' => $startDate,
+      ],
+      [
+        'entity_table' => 'civicrm_membership',
+        'price_field_id' => $secondAddOnMembershipType->priceFieldValue['price_field_id'],
+        'price_field_value_id' => $secondAddOnMembershipType->priceFieldValue['id'],
+        'label' => $secondAddOnMembershipType->membershipType['name'],
+        'qty' => 1,
+        'unit_price' => $secondAddOnMembershipType->priceFieldValue['amount'] / 12,
+        'line_total' => $secondAddOnMembershipType->priceFieldValue['amount'] / 12,
+        'financial_type_id' => 'Member Dues',
+        'non_deductible_amount' => 0,
+        'auto_renew' => 0,
+        'start_date' => $startDate,
+      ],
+    ];
+    $this->createContribution($contributionParams, $lineItems);
+
+    $lineItemCreator = new RecurringLineItemCreator($recurringContribution['id']);
+    $lineItemCreator->create();
+
+    $lineItems = $this->getRecurringContributionLines($recurringContribution['id']);
+    $this->assertEquals(3, count($lineItems));
+
+    foreach ($lineItems as $line) {
+      $this->assertEquals($startDate . ' 00:00:00', $line['start_date']);
+    }
+  }
+
+  /**
+   * Obtains recurring line items for the recurring contribution.
+   *
+   * @param int $recurringContributionID
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getRecurringContributionLines($recurringContributionID) {
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $recurringContributionID,
+      'api.LineItem.getsingle' => [
+        'id' => '$value.line_item_id',
+        'entity_table' => ['IS NOT NULL' => 1],
+        'entity_id' => ['IS NOT NULL' => 1],
+      ],
+    ]);
+    if ($result['count'] > 0) {
+      return $result['values'];
+    }
+
+    return [];
+  }
+
+}

--- a/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreatorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/RecurringContributionLineItemCreatorTest.php
@@ -79,8 +79,8 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
       }
 
       if ($line['entity_table'] === 'civicrm_membership') {
-        $membershipID = $this->createMembership($line, $contribution);
-        $line['entity_id'] = $membershipID;
+        $membership = $this->createMembership($line, $contribution);
+        $line['entity_id'] = $membership['id'];
       }
 
       LineItemFabricator::fabricate($line);
@@ -99,7 +99,7 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
   private function createMembership($lineItem, $contribution) {
     $priceFieldValue = $this->getPriceFieldValue($lineItem['price_field_value_id']);
 
-    return $membershipCreateResult = MembershipFabricator::fabricate([
+    return MembershipFabricator::fabricate([
       'contact_id' => $contribution['contact_id'],
       'membership_type_id' => $priceFieldValue['membership_type_id'],
       'join_date' => CRM_Utils_Array::value('join_date', $lineItem, date('Y-m-d')),
@@ -126,28 +126,6 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
   }
 
   public function testLineItemCreation() {
-    $mainMembershipType = $this->createMembershipType([
-      'name' => 'Main Rolling Membership',
-      'period_type' => 'rolling',
-      'minimum_fee' => 60,
-      'duration_interval' => 18,
-      'duration_unit' => 'month',
-    ]);
-    $addOnMembershipType = $this->createMembershipType([
-      'name' => 'Add-on Rolling Membership',
-      'period_type' => 'rolling',
-      'minimum_fee' => 120,
-      'duration_interval' => 12,
-      'duration_unit' => 'month',
-    ]);
-    $secondAddOnMembershipType = $this->createMembershipType([
-      'name' => 'Second Add-on Rolling Membership',
-      'period_type' => 'rolling',
-      'minimum_fee' => 180,
-      'duration_interval' => 6,
-      'duration_unit' => 'month',
-    ]);
-
     $contact = $this->createContact();
     $startDate = date('Y-m-d');
     $recurringContribution = $this->createRecurringContribution([
@@ -181,6 +159,29 @@ class CRM_MembershipExtras_Hook_PostProcess_RecurringContributionLineItemCreator
       'financial_type_id' => 'Member Dues',
       'contribution_status_id' => 'Pending',
     ];
+
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 18,
+      'duration_unit' => 'month',
+    ]);
+    $addOnMembershipType = $this->createMembershipType([
+      'name' => 'Add-on Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 120,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+    $secondAddOnMembershipType = $this->createMembershipType([
+      'name' => 'Second Add-on Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 180,
+      'duration_interval' => 6,
+      'duration_unit' => 'month',
+    ]);
+
     $lineItems = [
       [
         'entity_table' => 'civicrm_membership',

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipEndDateCalculatorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipEndDateCalculatorTest.php
@@ -1,0 +1,143 @@
+<?php
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_MembershipExtras_Service_MembershipEndDateCalculator as MembershipEndDateCalculator;
+
+/**
+ * Class CRM_MembershipExtras_Service_MembershipEndDateCalculatorTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Service_MembershipEndDateCalculatorTest extends BaseHeadlessTest {
+
+  /**
+   * List of scenarios with rolling membership to be tested.
+   *
+   * @var array
+   */
+  private $rollingMembershipScenarios = [];
+
+  /**
+   * List of scenarios with fixed membership to be tested.
+   *
+   * @var array
+   */
+  private $fixedMembershipScenarios = [];
+
+  public function setUp() {
+    $this->rollingMembershipScenarios = [
+      'normal year 01/01 => 12/31' => [
+        'duration_interval' => 12,
+        'duration_unit' => 'month',
+        'start_date' => '2001-01-01',
+        'expected_next_end_date' => '20021231',
+        'expected_previous_end_date' => '20001231',
+      ],
+      'leap year 01/01 => 12/31' => [
+        'duration_interval' => 12,
+        'duration_unit' => 'month',
+        'start_date' => '2020-01-01',
+        'expected_next_end_date' => '20211231',
+        'expected_previous_end_date' => '20191231',
+      ],
+      'normal year 01/06 => 05/30' => [
+        'duration_interval' => 12,
+        'duration_unit' => 'month',
+        'start_date' => '2001-06-01',
+        'expected_next_end_date' => '20030531',
+        'expected_previous_end_date' => '20010531',
+      ],
+      'current date' => [
+        'duration_interval' => 12,
+        'duration_unit' => 'month',
+        'start_date' => date('Ymd'),
+        'expected_next_end_date' => date('Ymd', strtotime('+2 years -1 day')),
+        'expected_previous_end_date' => date('Ymd', strtotime('-1 day')),
+      ],
+    ];
+
+    $this->fixedMembershipScenarios = [
+      'fixed 01/01 => 12/31' => [
+        'fixed_period_start_day' => '0101',
+        'fixed_period_rollover_day' => '1231',
+        'start_date' => '2001-01-01',
+        'expected_next_end_date' => '20021231',
+        'expected_previous_end_date' => '20001231',
+      ],
+      'fixed 12/01 => 11/30' => [
+        'fixed_period_start_day' => '1201',
+        'fixed_period_rollover_day' => '1130',
+        'start_date' => '2001-01-01',
+        'expected_next_end_date' => '20021130',
+        'expected_previous_end_date' => '20001130',
+      ],
+      'current date 01/01 => 12/31' => [
+        'fixed_period_start_day' => '0101',
+        'fixed_period_rollover_day' => '1231',
+        'start_date' => date('Y-m-d'),
+        'expected_next_end_date' => date('Y1231', strtotime('+1 year')),
+        'expected_previous_end_date' => date('Y1231', strtotime('-1 year')),
+      ],
+    ];
+  }
+
+  public function testRollingMembershipsEndDateCalculation() {
+    $contact = ContactFabricator::fabricate();
+
+    foreach ($this->rollingMembershipScenarios as $scenarioName => $scenario) {
+      $membershiptType = MembershipTypeFabricator::fabricate([
+        'name' => 'Main Rolling Membership - ' . $scenarioName,
+        'period_type' => 'rolling',
+        'minimum_fee' => 60,
+        'duration_interval' => $scenario['duration_interval'],
+        'duration_unit' => $scenario['duration_unit'],
+      ]);
+      $membership = MembershipFabricator::fabricate([
+        'contact_id' => $contact['id'],
+        'membership_type_id' => $membershiptType['id'],
+        'join_date' => $scenario['start_date'],
+        'start_date' => $scenario['start_date'],
+        'financial_type_id' => 'Member Dues',
+        'skipLineItem' => 1,
+      ]);
+
+      $nextEndDate = MembershipEndDateCalculator::calculate($membership['id']);
+      $this->assertEquals($scenario['expected_next_end_date'], $nextEndDate, "Failed calculating next end date for scenario $scenarioName!");
+
+      $previousEndDate = MembershipEndDateCalculator::calculatePreviousEndDate($membership['id']);
+      $this->assertEquals($scenario['expected_previous_end_date'], $previousEndDate, "Failed calculating previous end date for scenario $scenarioName!");
+    }
+  }
+
+  public function testFixedMembershipsEndDateCalculation() {
+    $contact = ContactFabricator::fabricate();
+
+    foreach ($this->fixedMembershipScenarios as $scenarioName => $scenario) {
+      $membershiptType = MembershipTypeFabricator::fabricate([
+        'name' => 'Test Fixed Membership',
+        'period_type' => 'fixed',
+        'minimum_fee' => 0,
+        'duration_unit' => 'year',
+        'duration_interval' => 1,
+        'fixed_period_start_day' => $scenario['fixed_period_start_day'],
+        'fixed_period_rollover_day' => $scenario['fixed_period_rollover_day'],
+      ]);
+      $membership = MembershipFabricator::fabricate([
+        'contact_id' => $contact['id'],
+        'membership_type_id' => $membershiptType['id'],
+        'join_date' => $scenario['start_date'],
+        'start_date' => $scenario['start_date'],
+        'financial_type_id' => 'Member Dues',
+        'skipLineItem' => 1,
+      ]);
+
+      $nextEndDate = MembershipEndDateCalculator::calculate($membership['id']);
+      $this->assertEquals($scenario['expected_next_end_date'], $nextEndDate, "Failed calculating next end date for $scenarioName!");
+
+      $previousEndDate = MembershipEndDateCalculator::calculatePreviousEndDate($membership['id']);
+      $this->assertEquals($scenario['expected_previous_end_date'], $previousEndDate, "Failed calculating previous end date for $scenarioName!");
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
When a membership is manually renewed and changed to a payment plan, the membership end date is increased by a year as expected. But manage instalment start date is using previous year start date still.

## Before
The start date used on recurring line items was the original start date of the membership, which did not change as CiviCRM core only changes it if there is a gap in the membership's history.

## After
Used the membership's end date to calculate the projected start date by subtracting the appropriate number of periods as per the membership type's configuration.
