### PR TITLE
IO-132: Fix Auto-renewal Job

### DIFF
--- a/CRM/MembershipExtras/Hook/CustomDispatch/PostOfflineAutoRenewal.php
+++ b/CRM/MembershipExtras/Hook/CustomDispatch/PostOfflineAutoRenewal.php
@@ -46,9 +46,9 @@ class CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewal {
     $nullObject = CRM_Utils_Hook::$_nullObject;
     CRM_Utils_Hook::singleton()->invoke(
       ['membershipId', 'recurContributionId', 'previousRecurContributionId'],
-      $nullObject,
-      $this->newRecurringContributionID,
-      $this->currentRecurContributionID,
+      $this->membershipID,
+      $this->recurringContributionID,
+      $this->previousRecurringContributionID,
       $nullObject, $nullObject, $nullObject,
       'membershipextras_postOfflineAutoRenewal'
     );

--- a/tests/phpunit/CRM/MembershipExtras/Hook/CustomDispatch/CalculateContributionReceiveDateTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/CustomDispatch/CalculateContributionReceiveDateTest.php
@@ -1,0 +1,81 @@
+<?php
+use Civi\Test\HookInterface;
+
+/**
+ * Class CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDateTest.
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDateTest extends BaseHeadlessTest implements HookInterface {
+
+  /**
+   * Number of instalment in the payment plan.
+   *
+   * @var int
+   */
+  private $contributionNumber;
+
+  /**
+   * Receive date being used for the instalmen.
+   *
+   * @var string
+   */
+  private $receiveDate;
+
+  /**
+   * List of parameters being used to create the contribution.
+   *
+   * @var array
+   */
+  private $params;
+
+  /**
+   * Another date.
+   *
+   * @var string
+   */
+  private $newReceiveDate;
+
+  /**
+   * Another array of params.
+   *
+   * @var array
+   */
+  private $newParams;
+
+  public function testHookDispatchInputPassThroughToImplementationsAndParameterModification() {
+    $this->contributionNumber = 1;
+    $this->receiveDate = '2020-01-01';
+    $this->params = [1, 2, 3, 4];
+
+    $this->newReceiveDate = '2021-12-31';
+    $this->newParams = [5, 6, 7, 8];
+
+    $dispatcher = new CRM_MembershipExtras_Hook_CustomDispatch_CalculateContributionReceiveDate(
+      $this->contributionNumber,
+      $this->receiveDate,
+      $this->params
+    );
+    $dispatcher->dispatch();
+
+    $this->assertEquals($this->newReceiveDate, $this->receiveDate);
+    $this->assertEquals($this->newParams, $this->params);
+  }
+
+  /**
+   * Implements calculateContributionReceiveDate hook for testing.
+   *
+   * @param $instalmentNumber
+   * @param $receiveDate
+   * @param $params
+   */
+  public function hook_membershipextras_calculateContributionReceiveDate($instalmentNumber, &$receiveDate, &$params) {
+    $this->assertEquals($this->contributionNumber, $instalmentNumber);
+    $this->assertEquals($this->receiveDate, $receiveDate);
+    $this->assertEquals($this->params, $params);
+
+    $receiveDate = $this->newReceiveDate;
+    $params = $this->newParams;
+  }
+
+}

--- a/tests/phpunit/CRM/MembershipExtras/Hook/CustomDispatch/PostOfflineAutoRenewalTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/CustomDispatch/PostOfflineAutoRenewalTest.php
@@ -1,0 +1,58 @@
+<?php
+use Civi\Test\HookInterface;
+
+/**
+ * Class CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewalTest.
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewalTest extends BaseHeadlessTest implements HookInterface {
+
+  /**
+   * An integer, represents the ID of a membership.
+   *
+   * @var int
+   */
+  private $membershipId;
+
+  /**
+   * An integer representing the ID of a recurring contribution.
+   *
+   * @var int
+   */
+  private $recurringContributionId;
+
+  /**
+   * An integer, represents the ID of a recurring conribution.
+   *
+   * @var int
+   */
+  private $previousRecurringId;
+
+  public function testHookDispatchInputPassThroughToImplementations() {
+    $this->membershipId = 1;
+    $this->recurringContributionId = 2;
+    $this->previousRecurringId = 3;
+
+    $dispatcher = new CRM_MembershipExtras_Hook_CustomDispatch_PostOfflineAutoRenewal(
+      $this->membershipId,
+      $this->recurringContributionId,
+      $this->previousRecurringId
+    );
+    $dispatcher->dispatch();
+  }
+
+  /**
+   * Implements calculateContributionReceiveDate hook for testing.
+   *
+   * @param int $membershipId
+   * @param int $recurringContributionId
+   * @param int $previousRecurrId
+   */
+  public function hook_membershipextras_postOfflineAutoRenewal($membershipId, $recurringContributionId, $previousRecurrId) {
+    $this->assertEquals($this->membershipId, $membershipId);
+    $this->assertEquals($this->recurringContributionId, $recurringContributionId);
+    $this->assertEquals($this->previousRecurringId, $previousRecurrId);
+  }
+
+}


### PR DESCRIPTION
## Overview
Auto-renewal jobs are failing when there were plans to renew, with the message `Failure, Error message: Errors found on auto-renewals: An error occurred renewing a payment plan with id (X):  is not of type String`.

## Before
There was a bug on the PostOfflineAutorenewa hook dispatch class, that was using class attributes that didn't exist to be sent as the hook's inputs. Thus all were null on every dispatch, causing a query that used them to fail.

## After
Updated the attribute names. Also added tests to verify inputs to the dispatch class arrive ok to the hook's implementation methods.
