### PR TITLE
MAE-381:  Quarterly instalment schedule

### DIFF
--- a/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalmentCalculator.php
+++ b/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalmentCalculator.php
@@ -3,5 +3,6 @@ class CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalmentCalculator e
   const ONE_YEAR_DURATION = "All membership types must have a duration of one year!";
   const PERIOD_TYPE = "All membership types must have same period type.";
   const SAME_PERIOD_START_DAY = "All Membership types must have same period start day";
+  const QUARTERLY_NOT_SUPPORT = "Quarterly instalments for fixed period membership types are not supported.";
 
 }

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -216,17 +216,17 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
         $fixedPeriodStartDays[] = $membershipType->fixed_period_start_day;
       }
       if ($membershipType->duration_unit != 'year' || $membershipType->duration_interval != 1) {
-        throw new InvalidMembershipTypeInstalmentCalculator(InvalidMembershipTypeInstalmentCalculator::ONE_YEAR_DURATION);
+        throw new InvalidMembershipTypeInstalmentCalculator(ts(InvalidMembershipTypeInstalmentCalculator::ONE_YEAR_DURATION));
       }
     }
 
     $fixedPeriodStartDays = array_unique($fixedPeriodStartDays);
     if (!empty($fixedPeriodStartDays) && count($fixedPeriodStartDays) != 1) {
-      throw new InvalidMembershipTypeInstalmentCalculator(InvalidMembershipTypeInstalmentCalculator::SAME_PERIOD_START_DAY);
+      throw new InvalidMembershipTypeInstalmentCalculator(ts(InvalidMembershipTypeInstalmentCalculator::SAME_PERIOD_START_DAY));
     }
 
     if (in_array('fixed', $periodTypes) && in_array('rolling', $periodTypes)) {
-      throw new InvalidMembershipTypeInstalmentCalculator(InvalidMembershipTypeInstalmentCalculator::PERIOD_TYPE);
+      throw new InvalidMembershipTypeInstalmentCalculator(ts(InvalidMembershipTypeInstalmentCalculator::PERIOD_TYPE));
     }
   }
 

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -225,7 +225,13 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
       throw new InvalidMembershipTypeInstalmentCalculator(ts(InvalidMembershipTypeInstalmentCalculator::SAME_PERIOD_START_DAY));
     }
 
-    if (in_array('fixed', $periodTypes) && in_array('rolling', $periodTypes)) {
+    $hasFixedMembershipType = in_array('fixed', $periodTypes);
+
+    if ($hasFixedMembershipType && $this->schedule == self::QUARTERLY) {
+      throw new InvalidMembershipTypeInstalmentCalculator(ts(InvalidMembershipTypeInstalmentCalculator::QUARTERLY_NOT_SUPPORT));
+    }
+
+    if ($hasFixedMembershipType && in_array('rolling', $periodTypes)) {
       throw new InvalidMembershipTypeInstalmentCalculator(ts(InvalidMembershipTypeInstalmentCalculator::PERIOD_TYPE));
     }
   }

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -93,7 +93,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
       for ($i = 1; $i < $noOfInstalment; $i++) {
         $intervalSpec = 'P1M';
         if ($this->schedule == self::QUARTERLY) {
-          $intervalSpec = 'P4M';
+          $intervalSpec = 'P3M';
         }
         $instalmentDate = new DateTime($nextInstalmentDate);
         $instalmentDate->add(new DateInterval($intervalSpec));


### PR DESCRIPTION
## Overview

This PR adds additional tests for quarterly instalment as well as more tests for rolling period membership types to API layer and validation to handle when fixed period membership type and quarterly schedule are passed to schedule instalment class

This PR also adds localisation tag for exception messages. 

