### PR TITLE
ASESPRT-316: Hide inactive memberships in manage installments screen

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -123,6 +123,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
   private function setAllMembershipTypes() {
     $result = civicrm_api3('MembershipType', 'get', [
       'options' => ['limit' => 0],
+      'is_active' => 1,
     ]);
 
     if ($result['count'] > 0) {


### PR DESCRIPTION
## Before

Inactive memberships will appear in the manage instalments screen in both current and next instalments tabs : 

![2021-01-21 17_20_42-Membership Types _ compuvag5one](https://user-images.githubusercontent.com/6275540/105387216-38ab1b00-5c0d-11eb-9953-91b7ab888dbc.png)


![2021-01-21 17_21_40-fdsfds fsddfs _ compuvag5one](https://user-images.githubusercontent.com/6275540/105387234-3c3ea200-5c0d-11eb-9e7b-f1817f944fb3.png)



## After

Inactive memberships are no longer appear in manage instalments screen  : 

![2021-01-21 17_23_06-fdsfds fsddfs _ compuvag5one](https://user-images.githubusercontent.com/6275540/105387417-6db76d80-5c0d-11eb-9e8a-13b1be571882.png)





