### PR TITLE
IO-122: Update schedule API response and payment plan toggler UI

### DIFF
--- a/CRM/MembershipExtras/API/PaymentSchedule/Base.php
+++ b/CRM/MembershipExtras/API/PaymentSchedule/Base.php
@@ -69,10 +69,9 @@ abstract class CRM_MembershipExtras_API_PaymentSchedule_Base {
    *
    * @param array $instalments
    *
-   * @return array
    * @throws CiviCRM_API3_Exception
    */
-  public function formatInstalments(array $instalments) {
+  public function formatInstalments(array &$instalments) {
     $pendingStatusLabel = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => "contribution_status",
@@ -94,7 +93,7 @@ abstract class CRM_MembershipExtras_API_PaymentSchedule_Base {
       array_push($formattedInstalments, $formattedInstalment);
     }
 
-    return $formattedInstalments;
+    $instalments = $formattedInstalments;
   }
 
   protected function getMembershipTypeScheduleOptions($membershipType) {

--- a/CRM/MembershipExtras/DTO/ScheduleInstalmentAmount.php
+++ b/CRM/MembershipExtras/DTO/ScheduleInstalmentAmount.php
@@ -5,6 +5,7 @@ class CRM_MembershipExtras_DTO_ScheduleInstalmentAmount {
 
   private $amount;
   private $taxAmount;
+  private $totalAmount;
 
   /**
    * @return float
@@ -32,6 +33,20 @@ class CRM_MembershipExtras_DTO_ScheduleInstalmentAmount {
    */
   public function setTaxAmount(float $taxAmount) {
     $this->taxAmount = $taxAmount;
+  }
+
+  /**
+   * @return float
+   */
+  public function getTotalAmount() {
+    return $this->totalAmount;
+  }
+
+  /**
+   * @param float $totalAmount
+   */
+  public function setTotalAmount(float $totalAmount) {
+    $this->totalAmount = $totalAmount;
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -93,7 +93,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
     $instalment->setInstalmentDate($startDate);
     $instalment->setInstalmentAmount($instalmentAmount);
 
-    $instalments[] = $instalment;
+    $instalments['instalments'][] = $instalment;
     $noOfInstalment = $this->getInstalmentsNumber($this->membershipTypes[0], $this->schedule, $this->startDate);
     if ($noOfInstalment > 1) {
       $nextInstalmentDate = $startDate->format('Y-m-d');
@@ -108,9 +108,11 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
         $followingInstalment = new CRM_MembershipExtras_DTO_ScheduleInstalment();
         $followingInstalment->setInstalmentDate($instalmentDate);
         $followingInstalment->setInstalmentAmount($instalmentAmount);
-        array_push($instalments, $followingInstalment);
+        array_push($instalments['instalments'], $followingInstalment);
       }
     }
+
+    $instalments['total_amount'] = $this->getInstalmentsTotalAmount($instalments['instalments']);
 
     return $instalments;
   }
@@ -150,9 +152,11 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
     $divisor = $this->getInstalmentsNumber($this->membershipTypes[0], $this->schedule, $this->startDate);
     $amount = MoneyUtilities::roundToPrecision($instalmentAmount->getCalculator()->getAmount() / $divisor, 2);
     $taxAmount = MoneyUtilities::roundToPrecision($instalmentAmount->getCalculator()->getTaxAmount() / $divisor, 2);
+    $totalAmount = MoneyUtilities::roundToPrecision($instalmentAmount->getCalculator()->getTotalAmount() / $divisor, 2);
     $instalment = new CRM_MembershipExtras_DTO_ScheduleInstalmentAmount();
     $instalment->setAmount($amount);
     $instalment->setTaxAmount($taxAmount);
+    $instalment->setTotalAmount($totalAmount);
 
     return $instalment;
   }
@@ -255,6 +259,17 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
         throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::SAME_PERIOD_START_DAY));
       }
     }
+  }
+
+  /**
+   * Gets instalment total amount
+   */
+  private function getInstalmentsTotalAmount(array $instalments) {
+    $totalAmount = 0.0;
+    foreach ($instalments as $instalment) {
+      $totalAmount += $instalment->getInstalmentAmount()->getTotalAmount();
+    }
+    return $totalAmount;
   }
 
   /**

--- a/api/v3/PaymentSchedule/Getbymembershiptype.php
+++ b/api/v3/PaymentSchedule/Getbymembershiptype.php
@@ -53,10 +53,9 @@ function _civicrm_api3_payment_schedule_getbymembershiptype_spec(&$spec) {
  * @throws Exception
  */
 function civicrm_api3_payment_schedule_getbymembershiptype($params) {
-
   $membershipTypeSchedule = new CRM_MembershipExtras_API_PaymentSchedule_MembershipType($params);
-  $instalments = $membershipTypeSchedule->getPaymentSchedule();
-  $formattedInstalments = $membershipTypeSchedule->formatInstalments($instalments);
+  $schedule = $membershipTypeSchedule->getPaymentSchedule();
+  $membershipTypeSchedule->formatInstalments($schedule['instalments']);
 
-  return civicrm_api3_create_success($formattedInstalments, $params);
+  return civicrm_api3_create_success($schedule, $params);
 }

--- a/api/v3/PaymentSchedule/Getbypricefieldvalues.php
+++ b/api/v3/PaymentSchedule/Getbypricefieldvalues.php
@@ -52,14 +52,12 @@ function _civicrm_api3_payment_schedule_getbypriceset_spec(&$spec) {
  * @throws Exception
  */
 function civicrm_api3_payment_schedule_getbypricefieldvalues($params) {
-
   if (!array_key_exists('IN', $params['price_field_values'])) {
     throw new API_Exception('The price_field_values parameter only supports the IN operator');
   }
-
   $priceValuesPaymentSchedule = new CRM_MembershipExtras_API_PaymentSchedule_PriceValues($params);
-  $instalments = $priceValuesPaymentSchedule->getPaymentSchedule();
-  $formattedInstalments = $priceValuesPaymentSchedule->formatInstalments($instalments);
+  $schedule = $priceValuesPaymentSchedule->getPaymentSchedule();
+  $priceValuesPaymentSchedule->formatInstalments($schedule['instalments']);
 
-  return civicrm_api3_create_success($formattedInstalments, $params);
+  return civicrm_api3_create_success($schedule, $params);
 }

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -4,6 +4,7 @@
   (function ($) {
     {/literal}
     const togglerValue = '{$contribution_type_toggle}';
+    const currencySymbol = '{$currency_symbol}';
     {literal}
 
     /**
@@ -139,7 +140,7 @@
       CRM.api3('PaymentSchedule', apiAction, params).then(function(data) {
         if (data.is_error === 0) {
           drawTable(data);
-          updateTotalAmount(data);
+          updateTotalAmount(data.values.total_amount, isPriceSet);
         } else {
           CRM.alert(data.error_message, 'Error', 'error');
         }
@@ -199,11 +200,13 @@
     }
 
     /**
-     * Update total amount
+     * Updates total amount based and also updated price value if is price set amount
      */
-    function updateTotalAmount(data) {
-      $totalAmount = data.values.total_amount;
-      $('#total_amount').val($totalAmount);
+    function updateTotalAmount(totalAmount, isPriceSet) {
+      $('#total_amount').val(CRM.formatMoney(totalAmount, true));
+      if (isPriceSet) {
+        $('#pricevalue').html(currencySymbol + ' ' + CRM.formatMoney(totalAmount, true));
+      }
     }
 
     /**

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -65,6 +65,9 @@
         let isPriceSet = isPriceSetSelected();
         if (isPriceSet) {
           let selectedPriceFieldValues = getSelectedPriceFieldValues();
+          if (jQuery.isEmptyObject(selectedPriceFieldValues)) {
+            return;
+          }
           let params = {};
           params.price_field_values = {'IN' : selectedPriceFieldValues};
           CRM.api3('PaymentSchedule', 'getscheduleoptionsbypricefieldvalues', params).then(function (result) {
@@ -89,7 +92,7 @@
         }
       });
 
-      $('#payment_plan_schedule, #payment_instrument_id').change(() => {
+      $('#payment_plan_schedule, #payment_instrument_id, #start_date, #end_date').change(() => {
         if ($('#payment_plan_schedule_row').is(":hidden")) {
           return;
         }
@@ -124,6 +127,9 @@
       let apiAction;
       if (isPriceSet) {
         let selectedPriceFieldValues = getSelectedPriceFieldValues();
+        if (jQuery.isEmptyObject(selectedPriceFieldValues)) {
+          return;
+        }
         params.price_field_values = {'IN' : selectedPriceFieldValues};
         apiAction = 'getByPriceFieldValues';
       } else {

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -116,7 +116,6 @@
     function generateInstalmentSchedule(isPriceSet) {
       let schedule = $('#payment_plan_schedule').val();
       let params = {
-        "sequential": 1,
         "schedule": schedule,
         "start_date" : $('#start_date').val(),
         "end_date" : $('#end_date').val(),
@@ -134,6 +133,7 @@
       CRM.api3('PaymentSchedule', apiAction, params).then(function(data) {
         if (data.is_error === 0) {
           drawTable(data);
+          updateTotalAmount(data);
         } else {
           CRM.alert(data.error_message, 'Error', 'error');
         }
@@ -193,13 +193,21 @@
     }
 
     /**
+     * Update total amount
+     */
+    function updateTotalAmount(data) {
+      $totalAmount = data.values.total_amount;
+      $('#total_amount').val($totalAmount);
+    }
+
+    /**
      * Draws instalment table based on given data return from PaymentSchedule API
      *
      * @param data
      */
     function drawTable(data) {
       $('#instalment_row_table tbody td').remove();
-      let rows = data.values;
+      let rows = data.values.instalments;
       rows.forEach(drawRow);
     }
 

--- a/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/MembershipTypeTest.php
@@ -42,9 +42,9 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
    */
   public function testGetMonthlyInstalmentsForRollingMembershipType() {
     $paymentSchedule = $this->mockRollingMembershipTypeSchedule(Schedule::MONTHLY);
-    $instalments = $paymentSchedule->getPaymentSchedule();
-    $this->assertNotEmpty($instalments);
-    $this->assertCount(12, $instalments);
+    $schedule = $paymentSchedule->getPaymentSchedule();
+    $this->assertNotEmpty($schedule);
+    $this->assertCount(12, $schedule['instalments']);
   }
 
   /**
@@ -55,9 +55,9 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
    */
   public function testGetQuarterlyInstalmentsForRollingMembershipType() {
     $paymentSchedule = $this->mockRollingMembershipTypeSchedule(Schedule::QUARTERLY);
-    $instalments = $paymentSchedule->getPaymentSchedule();
-    $this->assertNotEmpty($instalments);
-    $this->assertCount(4, $instalments);
+    $schedule = $paymentSchedule->getPaymentSchedule();
+    $this->assertNotEmpty($schedule);
+    $this->assertCount(4, $schedule['instalments']);
   }
 
   /**
@@ -68,9 +68,9 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
    */
   public function testGetAnnualInstalmentsForRollingMembershipType() {
     $paymentSchedule = $this->mockRollingMembershipTypeSchedule(Schedule::ANNUAL);
-    $instalments = $paymentSchedule->getPaymentSchedule();
-    $this->assertNotEmpty($instalments);
-    $this->assertCount(1, $instalments);
+    $schedule = $paymentSchedule->getPaymentSchedule();
+    $this->assertNotEmpty($schedule);
+    $this->assertCount(1, $schedule['instalments']);
   }
 
   /**
@@ -81,14 +81,14 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
    */
   public function testFormatInstalments() {
     $paymentSchedule = $this->mockRollingMembershipTypeSchedule(Schedule::ANNUAL);
-    $instalments = $paymentSchedule->getPaymentSchedule();
+    $schedule = $paymentSchedule->getPaymentSchedule();
     $pendingStatusLabel = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => "contribution_status",
       'name' => "pending",
     ])['values'][0]['label'];
-    $formattedInstalments = $paymentSchedule->formatInstalments($instalments);
-    foreach ($formattedInstalments as $formattedInstalment) {
+    $paymentSchedule->formatInstalments($schedule['instalments']);
+    foreach ($schedule['instalments'] as $formattedInstalment) {
       $this->assertEquals($pendingStatusLabel, $formattedInstalment['instalment_status']);
     }
   }
@@ -101,9 +101,9 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
    */
   public function testGetAnnualInstalmentsForFixedMembershipType() {
     $paymentSchedule = $this->mockFixedMembershipTypeSchedule(Schedule::ANNUAL);
-    $instalments = $paymentSchedule->getPaymentSchedule();
-    $this->assertNotEmpty($instalments);
-    $this->assertCount(1, $instalments);
+    $schedule = $paymentSchedule->getPaymentSchedule();
+    $this->assertNotEmpty($schedule);
+    $this->assertCount(1, $schedule['instalments']);
   }
 
   private function mockRollingMembershipTypeSchedule($schedule) {

--- a/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/PriceValuesTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/PriceValuesTest.php
@@ -41,11 +41,11 @@ class CRM_MembershipExtras_API_PaymentSchedule_PriceValuesTest extends BaseHeadl
 
     $paymentSchedule = new CRM_MembershipExtras_API_PaymentSchedule_PriceValues($params);
 
-    $instalments = $paymentSchedule->getPaymentSchedule();
+    $schedule = $paymentSchedule->getPaymentSchedule();
 
-    $this->assertNotEmpty($instalments);
+    $this->assertNotEmpty($schedule);
     $totalAmount = 0;
-    foreach ($instalments as $instalment) {
+    foreach ($schedule['instalments'] as $instalment) {
       $totalAmount += $instalment->getInstalmentAmount()->getAmount();
     }
 


### PR DESCRIPTION
## Overview

This PR changes Payment Schedule API response to include the calculation for total instalments amount for the schedule.

The total amount will be set to two different places when schedule instalments is generated. 

- Total amount field which is hidden as this field will be processed by CiviCRM once the form is submitted
- Price value (Total amount) text when price set is being used. 

The PR also updates payment plan toggler UI that includes:

- Handles new response from Payment Schedule API.
- Adds event handler when start date and end date is changed.
- Adds validate to check if selected price values is empty to prevent receiving error from the API if the price value is empty. 

The PR also includes the unit tests for testing calculation of total amount for fixed membership type, rolling membership type, price field value

## Before

The gift shows that the schedule prices do not equal to total price on price value total amount
![Peek 2021-02-05 15-18](https://user-images.githubusercontent.com/208713/107052761-f1ed2180-67c5-11eb-9246-f9660f47edd6.gif)

The gift shows the error message when non the price values are selected
![Peek 2021-02-05 15-20](https://user-images.githubusercontent.com/208713/107052801-fd404d00-67c5-11eb-8329-5e86062ca61f.gif)


## After

The gift shows that the schedule prices (pro rated price in this case) do not equal to total price on price value total amount
![Peek 2021-02-05 15-21](https://user-images.githubusercontent.com/208713/107052810-fe717a00-67c5-11eb-9481-bb3f691220ff.gif)

The gift shows that no error message appears when none of the price value is selected. 
![Peek 2021-02-05 15-22](https://user-images.githubusercontent.com/208713/107052858-0df0c300-67c6-11eb-89e8-195a8e059978.gif)

## Technical Details

This section shows that JSON response looks like before and after this PR. 

The response only provides instalments which have already formatted.  
```
{

    "is_error": 0,
    "version": 3,
    "count": 1,
    "id": 0,
    "values": [
        {
            "instalment_no": 1,
            "instalment_date": "1st July 2020",
            "instalment_tax_amount": "£180",
            "instalment_amount": "£900",
            "instalment_status": "Pending"
        }
    ]
}

```

After this PR. 

JSON response if sequential =  0 on the request. 
```
{

    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": {
        "instalments": [
            {
                "instalment_no": 1,
                "instalment_date": "1st July 2020",
                "instalment_tax_amount": "£180",
                "instalment_amount": "£900",
                "instalment_status": "Pending"
            }
        ],
        "total_amount": 1080
    }
}
```
JSON response if sequential =  1 on the request. 
```
{

    "is_error": 0,
    "version": 3,
    "count": 2,
    "values": [
        [
            {
                "instalment_no": 1,
                "instalment_date": "1st July 2020",
                "instalment_tax_amount": "£180",
                "instalment_amount": "£900",
                "instalment_status": "Pending"
            }
        ],
        1080
    ]
}
```

The reason that total_amount should return to in the response because 

- We should avoid any calculation in the UI
- It is easier to test the calculation in different scenarios in the back end. 