### PR TITLE
MAE-352: Pro rated membership with price set

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
@@ -1,0 +1,111 @@
+<?php
+
+use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
+use CRM_MembershipExtras_Utils_InstalmentSchedule as InstalmentScheduleUtils;
+
+class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProcessor {
+
+  /**
+   * The number of instalments to be created.
+   *
+   * @var int
+   */
+  protected $instalmentsCount;
+
+  /**
+   * The frequency of the recurring contribution instalments.
+   *
+   * @var int
+   */
+  protected $instalmentsFrequency;
+
+  /**
+   * The frequency unit of the recurring contribution instalments.
+   *
+   * @var string
+   */
+  protected $instalmentsFrequencyUnit;
+
+  /**
+   * The selected payment plan schedule.
+   *
+   * @var string
+   */
+  protected $paymentPlanSchedule;
+
+  /**
+   * Membership ID is attached to an object either Contribution or Line Item.
+   *
+   * @var int
+   */
+  protected $membershipId;
+
+  /**
+   * The contribution or line item to-be-created parameters passed from the hook.
+   *
+   * @var array
+   */
+  protected $params;
+
+  /**
+   * Calculates tax amount for given amount.
+   *
+   * @param float $totalAmount
+   * @param string $financialType
+   *
+   * @return float
+   */
+  protected function calculateInstalmentTax($totalAmount, $financialType) {
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    $rate = CRM_Utils_Array::value($financialType, $taxRates, 0);
+
+    return MoneyUtilities::roundToCurrencyPrecision(
+      ($totalAmount * ($rate / 100)) / (1 + ($rate / 100))
+    );
+  }
+
+  /**
+   * Calculates single installment amount.
+   *
+   * @param float $amount
+   *
+   * @return float
+   */
+  protected function calculateSingleInstalmentAmount($amount) {
+    return MoneyUtilities::roundToCurrencyPrecision($amount / $this->instalmentsCount);
+  }
+
+  /**
+   * Checks if priceset was selected on the form to create the membership.
+   */
+  protected function isUsingPriceSet() {
+    $priceSetID = CRM_Utils_Request::retrieve('price_set_id', 'Int');
+
+    if (!empty($priceSetID)) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Asigns instalments count, instalments frequency,
+   * instalment frequency unit from payment plan schedule param
+   */
+  protected function assignInstalmentDetails() {
+    if (array_key_exists('membership_id', $this->params)) {
+      //Contribution object
+      $this->membershipId = $this->params['membership_id'];
+    }
+    else {
+      //LineItem object
+      $this->membershipId = $this->params['entity_id'];
+    }
+    $this->paymentPlanSchedule = CRM_Utils_Request::retrieve('payment_plan_schedule', 'String');
+    $instalmentDetails = InstalmentScheduleUtils::getInstalmentDetails($this->paymentPlanSchedule, $this->membershipId);
+    $this->instalmentsCount = $instalmentDetails['instalments_count'];
+    $this->instalmentsFrequency = $instalmentDetails['instalments_frequency'];
+    $this->instalmentsFrequencyUnit = $instalmentDetails['instalments_frequency_unit'];
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
@@ -2,6 +2,9 @@
 
 use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
 use CRM_MembershipExtras_Utils_InstalmentSchedule as InstalmentScheduleUtils;
+use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeAnnualCalculator as FixedPeriodTypeAnnualCalculator;
+use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeMonthlyCalculator as FixedPeriodTypeMonthlyCalculator;
+use CRM_MembershipExtras_Service_MembershipInstalmentAmount as InstalmentAmount;
 
 class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProcessor {
 
@@ -106,6 +109,26 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProce
     $this->instalmentsCount = $instalmentDetails['instalments_count'];
     $this->instalmentsFrequency = $instalmentDetails['instalments_frequency'];
     $this->instalmentsFrequencyUnit = $instalmentDetails['instalments_frequency_unit'];
+  }
+
+  /**
+   * Gets pro rated instalment amount
+   */
+  protected function getProRatedInstalmentAmount(array $membershipTypes, $membershipStartDate) {
+    if ($this->paymentPlanSchedule == CRM_MembershipExtras_Service_MembershipInstalmentsSchedule::MONTHLY) {
+      $fixedPeriodTypeMonthlyCalculator = new FixedPeriodTypeMonthlyCalculator($membershipTypes);
+      $fixedPeriodTypeMonthlyCalculator->setStartDate(new DateTime($membershipStartDate));
+      $instalmentAmount = new InstalmentAmount($fixedPeriodTypeMonthlyCalculator);
+    }
+    else {
+      $fixedPeriodTypeAnnualCalculator = new FixedPeriodTypeAnnualCalculator($membershipTypes);
+      $fixedPeriodTypeAnnualCalculator->setStartDate(new DateTime($membershipStartDate));
+      $instalmentAmount = new InstalmentAmount($fixedPeriodTypeAnnualCalculator);
+    }
+
+    $instalmentAmount->getCalculator()->calculate();
+
+    return $instalmentAmount;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
@@ -1,6 +1,10 @@
 <?php
 
 use CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProcessor as AbstractProcessor;
+use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeAnnualCalculator as FixedPeriodTypeAnnualCalculator;
+use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeMonthlyCalculator as FixedPeriodTypeMonthlyCalculator;
+use CRM_Member_BAO_MembershipType as MembershipType;
+use CRM_MembershipExtras_Service_MembershipInstalmentAmount as InstalmentAmount;
 
 class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem extends AbstractProcessor {
 
@@ -17,12 +21,61 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem exte
    * of the line item to be inline with the new contribution amount.
    */
   public function alterLineItemParameters() {
+    if (isset($this->params['membership_type_id'])) {
+      $lineItemMembershipType = CRM_Member_BAO_MembershipType::findById($this->params['membership_type_id']);
+      //We only pro rate line item if price set is used and price field membership period type is fixed
+      if ($this->isUsingPriceSet() && $lineItemMembershipType->period_type == 'fixed') {
+        $this->calculateProRataLineItemAmounts($lineItemMembershipType, $this->membershipId);
+      }
+      else {
+        $this->calculateLineItemAmounts();
+      }
+    }
+    else {
+      $this->calculateLineItemAmounts();
+    }
+  }
+
+  /**
+   * Calcuclates line item amounts and assign amounts to line item.
+   */
+  private function calculateLineItemAmounts() {
     $this->params['line_total'] = $this->calculateSingleInstalmentAmount($this->params['line_total']);
     $this->params['unit_price'] = $this->calculateSingleInstalmentAmount($this->params['unit_price']);
-
     if (!empty($this->params['tax_amount'])) {
       $this->params['tax_amount'] = $this->calculateSingleInstalmentAmount($this->params['tax_amount']);
     }
+  }
+
+  /**
+   * Calculates pro rata amounts for line item for fixed period membership type
+   *
+   * @param \CRM_Member_BAO_MembershipType $membershipType
+   * @param int $membershipId
+   *
+   */
+  private function calculateProRataLineItemAmounts(MembershipType $membershipType, int $membershipId) {
+    //Make sure we pro rated using line item total amount
+    $membershipType->minimum_fee = $this->params['unit_price'];
+    $membership = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'id' => $membershipId,
+    ])['values'][0];
+    if ($this->paymentPlanSchedule == CRM_MembershipExtras_Service_MembershipInstalmentsSchedule::MONTHLY) {
+      $fixedPeriodTypeMonthlyCalculator = new FixedPeriodTypeMonthlyCalculator([$membershipType]);
+      $fixedPeriodTypeMonthlyCalculator->setStartDate(new DateTime($membership['start_date']));
+      $instalmentAmount = new InstalmentAmount($fixedPeriodTypeMonthlyCalculator);
+    }
+    else {
+      $fixedPeriodTypeAnnualCalculator = new FixedPeriodTypeAnnualCalculator([$membershipType]);
+      $fixedPeriodTypeAnnualCalculator->setStartDate(new DateTime($membership['start_date']));
+      $instalmentAmount = new InstalmentAmount($fixedPeriodTypeAnnualCalculator);
+    }
+
+    $instalmentAmount->getCalculator()->calculate();
+    $this->params['line_total'] = $this->calculateSingleInstalmentAmount($instalmentAmount->getCalculator()->getAmount());
+    $this->params['unit_price'] = $this->calculateSingleInstalmentAmount($instalmentAmount->getCalculator()->getAmount());
+    $this->params['tax_amount'] = $this->calculateSingleInstalmentAmount($instalmentAmount->getCalculator()->getTaxAmount());
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
@@ -1,0 +1,28 @@
+<?php
+
+use CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProcessor as AbstractProcessor;
+
+class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem extends AbstractProcessor {
+
+  public function __construct(&$params) {
+    $this->params = &$params;
+    $this->assignInstalmentDetails();
+  }
+
+  /**
+   * Alters the contribution 'to be created' line item parameters
+   * before saving it.
+   *
+   * We here adjust the line total, unit price and tax amount
+   * of the line item to be inline with the new contribution amount.
+   */
+  public function alterLineItemParameters() {
+    $this->params['line_total'] = $this->calculateSingleInstalmentAmount($this->params['line_total']);
+    $this->params['unit_price'] = $this->calculateSingleInstalmentAmount($this->params['unit_price']);
+
+    if (!empty($this->params['tax_amount'])) {
+      $this->params['tax_amount'] = $this->calculateSingleInstalmentAmount($this->params['tax_amount']);
+    }
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
@@ -1,10 +1,7 @@
 <?php
 
 use CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProcessor as AbstractProcessor;
-use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeAnnualCalculator as FixedPeriodTypeAnnualCalculator;
-use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeMonthlyCalculator as FixedPeriodTypeMonthlyCalculator;
 use CRM_Member_BAO_MembershipType as MembershipType;
-use CRM_MembershipExtras_Service_MembershipInstalmentAmount as InstalmentAmount;
 
 class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem extends AbstractProcessor {
 
@@ -61,18 +58,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem exte
       'sequential' => 1,
       'id' => $membershipId,
     ])['values'][0];
-    if ($this->paymentPlanSchedule == CRM_MembershipExtras_Service_MembershipInstalmentsSchedule::MONTHLY) {
-      $fixedPeriodTypeMonthlyCalculator = new FixedPeriodTypeMonthlyCalculator([$membershipType]);
-      $fixedPeriodTypeMonthlyCalculator->setStartDate(new DateTime($membership['start_date']));
-      $instalmentAmount = new InstalmentAmount($fixedPeriodTypeMonthlyCalculator);
-    }
-    else {
-      $fixedPeriodTypeAnnualCalculator = new FixedPeriodTypeAnnualCalculator([$membershipType]);
-      $fixedPeriodTypeAnnualCalculator->setStartDate(new DateTime($membership['start_date']));
-      $instalmentAmount = new InstalmentAmount($fixedPeriodTypeAnnualCalculator);
-    }
-
-    $instalmentAmount->getCalculator()->calculate();
+    $instalmentAmount = $this->getProRatedInstalmentAmount([$membershipType], $membership['start_date']);
     $this->params['line_total'] = $this->calculateSingleInstalmentAmount($instalmentAmount->getCalculator()->getAmount());
     $this->params['unit_price'] = $this->calculateSingleInstalmentAmount($instalmentAmount->getCalculator()->getAmount());
     $this->params['tax_amount'] = $this->calculateSingleInstalmentAmount($instalmentAmount->getCalculator()->getTaxAmount());

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -185,7 +185,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   $isPaymentPlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanWithSchedule();
   $membershipContributionCreation = ($objectName === 'Contribution' && $op === 'create' && !empty($params['membership_id']));
   if ($membershipContributionCreation && $isPaymentPlanPayment && $isFirstPaymentPlanContribution) {
-    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
+    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution($params);
     $paymentPlanProcessor->createPaymentPlan();
     $paymentPlanProcessor->setContributionToPayLater();
     $isFirstPaymentPlanContribution = FALSE;
@@ -195,7 +195,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   $lineItemContributionCreation = $objectName === 'LineItem' && $op === 'create' && !empty($params['contribution_id']);
   $firstPaymentPlanContributionLineItemCreation = ($lineItemContributionCreation && (empty($firstPaymentPlanContributionId) || $firstPaymentPlanContributionId == $params['contribution_id']));
   if ($firstPaymentPlanContributionLineItemCreation && $isPaymentPlanPayment) {
-    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
+    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem($params);
     $paymentPlanProcessor->alterLineItemParameters();
     $firstPaymentPlanContributionId = $params['contribution_id'];
   }

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
 use Civi\Test\HookInterface;
 use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
@@ -13,6 +14,19 @@ use CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution as
 class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionTest extends BaseHeadlessTest implements HookInterface {
 
   use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
+
+  /**
+   * Implements calculateContributionReceiveDate hook for testing.
+   *
+   * @param $instalment
+   * @param $receiveDate
+   * @param $contributionCreationParams
+   */
+  public function hook_membershipextras_calculateContributionReceiveDate($instalment, &$receiveDate, &$contributionCreationParams) {
+    if (isset($contributionCreationParams['test_receive_date_calculation_hook'])) {
+      $receiveDate = $contributionCreationParams['test_receive_date_calculation_hook'];
+    }
+  }
 
   public function testMonthlyCycleDayIsCalculatedFromReceiveDate() {
     $_REQUEST['payment_plan_schedule'] = 'monthly';
@@ -125,51 +139,6 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionTe
   }
 
   /**
-   * Implements calculateContributionReceiveDate hook for testing.
-   *
-   * @param $instalment
-   * @param $receiveDate
-   * @param $contributionCreationParams
-   */
-  public function hook_membershipextras_calculateContributionReceiveDate($instalment, &$receiveDate, &$contributionCreationParams) {
-    if (isset($contributionCreationParams['test_receive_date_calculation_hook'])) {
-      $receiveDate = $contributionCreationParams['test_receive_date_calculation_hook'];
-    }
-  }
-
-  /**
-   * Obtains value for the given name option in the option group.
-   *
-   * @param string $name
-   * @param string $group
-   *
-   * @return array|string
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getOptionValue($name, $group) {
-    return civicrm_api3('OptionValue', 'getvalue', [
-      'return' => 'value',
-      'option_group_id' => $group,
-      'name' => $name,
-    ]);
-  }
-
-  /**
-   * Obtains ID for the given financial type name.
-   *
-   * @param $financialType
-   *
-   * @return int|array
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getFinancialTypeID($financialType) {
-    return civicrm_api3('FinancialType', 'getvalue', [
-      'return' => 'id',
-      'name' => $financialType,
-    ]);
-  }
-
-  /**
    * Tests create payment plan with month duration
    * for rolling membership type with monthly schedule
    */
@@ -260,11 +229,7 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionTe
    * @return mixed
    */
   private function getCreatedPaymentPlan(MembershipPaymentPlanProcessor $processor) {
-    $ref = new ReflectionObject($processor);
-    $recurringContributionProperty = $ref->getProperty('recurringContribution');
-    $recurringContributionProperty->setAccessible(TRUE);
-
-    return $recurringContributionProperty->getValue($processor);
+    return $processor->getRecurringContribution();
   }
 
   /**
@@ -335,6 +300,38 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionTe
       'membership_type_id' => $membershipTypeID,
       'join_date' => $startDate,
       'start_date' => $startDate,
+    ]);
+  }
+
+  /**
+   * Obtains value for the given name option in the option group.
+   *
+   * @param string $name
+   * @param string $group
+   *
+   * @return array|string
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getOptionValue($name, $group) {
+    return civicrm_api3('OptionValue', 'getvalue', [
+      'return' => 'value',
+      'option_group_id' => $group,
+      'name' => $name,
+    ]);
+  }
+
+  /**
+   * Obtains ID for the given financial type name.
+   *
+   * @param $financialType
+   *
+   * @return int|array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getFinancialTypeID($financialType) {
+    return civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => $financialType,
     ]);
   }
 

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
@@ -3,14 +3,14 @@ use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
 use Civi\Test\HookInterface;
 use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
 use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
-use CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor as MembershipPaymentPlanProcessor;
+use CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution as MembershipPaymentPlanProcessor;
 
 /**
- * Class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest
+ * Class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionTest
  *
  * @group headless
  */
-class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends BaseHeadlessTest implements HookInterface {
+class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionTest extends BaseHeadlessTest implements HookInterface {
 
   use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
 
@@ -37,7 +37,7 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends Ba
       'campaign_id' => NULL,
       'membership_id' => $membership['id'],
     ];
-    $paymentPlanCreator = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
+    $paymentPlanCreator = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution($params);
     $paymentPlanCreator->createPaymentPlan();
     $recurringContribution = $paymentPlanCreator->getRecurringContribution();
     $recurringContribution = civicrm_api3('ContributionRecur', 'get', [
@@ -73,7 +73,7 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends Ba
       'campaign_id' => NULL,
       'membership_id' => $membership['id'],
     ];
-    $paymentPlanCreator = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
+    $paymentPlanCreator = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution($params);
     $paymentPlanCreator->createPaymentPlan();
     $recurringContribution = $paymentPlanCreator->getRecurringContribution();
     $recurringContribution = civicrm_api3('ContributionRecur', 'get', [
@@ -111,7 +111,7 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends Ba
       'test_receive_date_calculation_hook' => $newReceiveDate,
       'membership_id' => $membership['id'],
     ];
-    $paymentPlanCreator = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor($params);
+    $paymentPlanCreator = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution($params);
     $paymentPlanCreator->createPaymentPlan();
     $recurringContribution = $paymentPlanCreator->getRecurringContribution();
     $recurringContribution = civicrm_api3('ContributionRecur', 'get', [
@@ -256,7 +256,7 @@ class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessorTest extends Ba
   /**
    * Get payment plan from reflection object
    *
-   * @param CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor $processor
+   * @param CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution $processor
    * @return mixed
    */
   private function getCreatedPaymentPlan(MembershipPaymentPlanProcessor $processor) {

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
@@ -1,0 +1,339 @@
+<?php
+
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Membership as MembershipFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_Contribution as ContributionFabricator;
+use CRM_MembershipExtras_Test_Fabricator_PriceSet as PriceSetFabricator;
+use CRM_MembershipExtras_Test_Fabricator_PriceField as PriceFieldFabricator;
+use CRM_MembershipExtras_Test_Fabricator_PriceFieldValue as PriceFieldValueFabricator;
+use CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem as MembershipPaymentPlanProcessor;
+use CRM_MembershipExtras_Service_MembershipTypeDurationCalculator as MembershipTypeDurationCalculator;
+use CRM_MembershipExtras_Service_MembershipTypeDatesCalculator as MembershipTypeDatesCalculator;
+use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeAnnualCalculator as FixedPeriodCalculator;
+use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
+
+/**
+ * Class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest
+ *
+ * @group headless
+ */
+class CRM_MembershpExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest extends BaseHeadlessTest {
+
+  use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
+  use CRM_MembershipExtras_Test_Helper_FixedPeriodMembershipTypeSettingsTrait;
+
+  private $membrship;
+  private $priceSet;
+
+  /**
+   * Tests pro rated price set contribution line item on calucation by month for fixed period membership type.
+   *
+   * @throws Exception
+   */
+  public function testProRatedPriceSetContributionLineItemOnCalculationByMonthFixedMembershipType() {
+    $params = $this->mockParams('fixed', 'year', FixedPeriodCalculator::BY_MONTHS);
+    $memTypeObj = CRM_Member_BAO_MembershipType::findById($params['membership_type_id']);
+    $membershipTypeDurationCalculator = new MembershipTypeDurationCalculator($memTypeObj, new MembershipTypeDatesCalculator());
+    $diffInMonths = $membershipTypeDurationCalculator->calculateMonthsBasedOnDates(new DateTime($this->membership['start_date']));
+    $expectedLineToTal = MoneyUtilities::roundToPrecision($params['line_total'] / 12 * $diffInMonths, 2);
+    $expectedTaxAmount = MoneyUtilities::roundToPrecision(($params['tax_rate'] / 100) * $expectedLineToTal, 2);
+
+    $_REQUEST['price_set_id'] = $this->priceSet['id'];
+    $_REQUEST['payment_plan_schedule'] = 'annual';
+    $processor = new MembershipPaymentPlanProcessor($params);
+    $processor->alterLineItemParameters();
+
+    $this->assertEquals($expectedLineToTal, $params['line_total']);
+    $this->assertEquals($expectedTaxAmount, $params['tax_amount']);
+  }
+
+  /**
+   * Tests pro rated price set contribuiton line item on calucation by days for fixed period membership type.
+   *
+   * @throws Exception
+   */
+  public function testProRatedPriceSetContributionLineItemOnCalculationByDaysFixedMembershipType() {
+    $params = $this->mockParams('fixed', 'year', FixedPeriodCalculator::BY_DAYS);
+    $memTypeObj = CRM_Member_BAO_MembershipType::findById($params['membership_type_id']);
+    $membershipTypeDurationCalculator = new MembershipTypeDurationCalculator($memTypeObj, new MembershipTypeDatesCalculator());
+    $membershipTypeDurationInDays = $membershipTypeDurationCalculator->calculateOriginalInDays();
+    $diffInDays = $membershipTypeDurationCalculator->calculateDaysBasedOnDates(new DateTime($this->membership['start_date']));
+    $expectedLineToTal = MoneyUtilities::roundToPrecision(($params['line_total'] / $membershipTypeDurationInDays) * $diffInDays, 2);
+    $expectedTaxAmount = MoneyUtilities::roundToPrecision(($params['tax_rate'] / 100) * $expectedLineToTal, 2);
+
+    $_REQUEST['price_set_id'] = $this->priceSet['id'];
+    $_REQUEST['payment_plan_schedule'] = 'annual';
+    $processor = new MembershipPaymentPlanProcessor($params);
+    $processor->alterLineItemParameters();
+
+    $this->assertEquals($expectedLineToTal, $params['line_total']);
+    $this->assertEquals($expectedTaxAmount, $params['tax_amount']);
+  }
+
+  /**
+   * Tests alter non price set line item for fixed period membership type.
+   *
+   * @throws Exception
+   */
+  public function testAlterNonPriceSetLineItemForFixedMembershipType() {
+    $defaultPriceSet = $this->getDefaultMembershipTypeAmountPriceSet();
+    $params = $this->mockParams('fixed', 'year', FixedPeriodCalculator::BY_DAYS, $defaultPriceSet);
+
+    $memTypeObj = CRM_Member_BAO_MembershipType::findById($params['membership_type_id']);
+    $membershipTypeDurationCalculator = new MembershipTypeDurationCalculator($memTypeObj, new MembershipTypeDatesCalculator());
+    $membershipTypeDurationInDays = $membershipTypeDurationCalculator->calculateOriginalInDays();
+    $diffInDays = $membershipTypeDurationCalculator->calculateDaysBasedOnDates(new DateTime($this->membership['start_date']));
+
+    //Make sure we pro rated the line item amounts before calling processor for default membership type price set
+    //as when we select non price set price on the membership sign up form, the default line item will be used
+    //and the price will already be pro prorated as per total amount thus we need to do there to make sure that
+    //the processor will calculate line item amounts correcly.
+    $amount = $params['line_total'];
+    $params['line_total'] = MoneyUtilities::roundToPrecision(($amount / $membershipTypeDurationInDays) * $diffInDays, 2);
+    $params['unit_price'] = MoneyUtilities::roundToPrecision(($amount / $membershipTypeDurationInDays) * $diffInDays, 2);
+    $params['tax_amount'] = MoneyUtilities::roundToPrecision(($params['tax_rate'] / 100) * $params['tax_amount'], 2);
+
+    //12 = number of instalment as we are paying montthly
+    $expectedLineToTal = MoneyUtilities::roundToPrecision($params['line_total'] / 12, 2);
+    $expectedTaxAmount = MoneyUtilities::roundToPrecision($params['tax_amount'] / 12, 2);
+
+    //Make sure we unset $_REQUEST array before calling processor
+    unset($_REQUEST);
+    $_REQUEST['payment_plan_schedule'] = 'monthly';
+    $processor = new MembershipPaymentPlanProcessor($params);
+    $processor->alterLineItemParameters();
+
+    $this->assertEquals($expectedLineToTal, $params['line_total']);
+    $this->assertEquals($expectedTaxAmount, $params['tax_amount']);
+  }
+
+  /**
+   * Tests alter line itiem for rolling period membership type.
+   */
+  public function testAlterLineItemForRollingMembershipType() {
+    $defaultPriceSet = $this->getDefaultMembershipTypeAmountPriceSet();
+    $params = $this->mockParams('rolling', 'year', NULL, $defaultPriceSet);
+
+    //12 = number of instalment as we are paying montthly
+    $expectedLineToTal = MoneyUtilities::roundToPrecision($params['line_total'] / 12, 2);
+    $expectedTaxAmount = MoneyUtilities::roundToPrecision($params['tax_amount'] / 12, 2);
+
+    $_REQUEST['payment_plan_schedule'] = 'monthly';
+    $processor = new MembershipPaymentPlanProcessor($params);
+    $processor->alterLineItemParameters();
+
+    $this->assertEquals($expectedLineToTal, $params['line_total']);
+    $this->assertEquals($expectedTaxAmount, $params['tax_amount']);
+  }
+
+  /**
+   * @param $membershipPeriodType
+   * @param $membershipTypeDuration
+   * @param null $membershipTypeSetting
+   * @param null $priceSet
+   * @return array
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockParams($membershipPeriodType, $membershipTypeDuration, $membershipTypeSetting = NULL, $priceSet = NULL) {
+    $this->mockSalesTaxFinancialAccount();
+    $contact = ContactFabricator::fabricate();
+    $membershipType = $this->mockMembershipType($membershipPeriodType, $membershipTypeDuration, $membershipTypeSetting);
+    $this->membership = $this->mockMembership($contact['id'], $membershipType['id'], date('Y-m-d'));
+    $contribution = $this->mockContribution($this->membership, $membershipType);
+    if (is_null($priceSet)) {
+      $this->priceSet = $this->mockPriceSet();
+      $priceField = $this->mockPriceField($this->priceSet['id'], 'price field for price set ' . $priceSet['id']);
+    }
+    else {
+      $priceField = $this->mockPriceField($priceSet['id']);
+    }
+    $priceFieldValue = $this->mockPriceFieldValue($priceField['id'], $membershipType['id']);
+    $rate = $this->getMemberDuesTaxRate();
+    return [
+      'price_field_id' => $priceField['id'],
+      'price_field_value_id' => $priceFieldValue['id'],
+      'label' => $priceFieldValue['label'],
+      'field_title' => $priceFieldValue['label'],
+      'qty' => 1,
+      'unit_price' => $priceFieldValue['amount'],
+      'line_total' => $priceFieldValue['amount'],
+      'membership_type_id' => $membershipType['id'],
+      'membership_num_terms' => 1,
+      'auto_renew' => 1,
+      'html_type' => $priceField['html_type'],
+      'financial_type_id' => 2,
+      'tax_amount' => ($priceFieldValue['amount'] * $rate) / 100,
+      'non_deductible_amount' => 0.00,
+      'tax_rate' => $rate,
+      'contribution_id' => $contribution['id'],
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $this->membership['id'],
+    ];
+  }
+
+  /**
+   * @param $membershipPeriodType
+   * @param $durationUnit
+   * @param $setting
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockMembershipType($membershipPeriodType, $durationUnit, $setting) {
+    $memType = MembershipTypeFabricator::fabricate([
+      'name' => 'Mock Membership type',
+      'period_type' => $membershipPeriodType,
+      'minimum_fee' => 120,
+      'duration_interval' => 1,
+      'duration_unit' => $durationUnit,
+      //01 Oct
+      'fixed_period_start_day' => 1001,
+      // 30 Sep
+      'fixed_period_rollover_day' => 930,
+    ]);
+    if (isset($setting)) {
+      $this->mockSettings($memType['id'], $setting);
+    }
+
+    return $memType;
+  }
+
+  /**
+   * @param $contactID
+   * @param $membershipTypeID
+   * @param $startDate
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockMembership($contactID, $membershipTypeID, $startDate) {
+    return MembershipFabricator::fabricate([
+      'contact_id' => $contactID,
+      'membership_type_id' => $membershipTypeID,
+      'join_date' => $startDate,
+      'start_date' => $startDate,
+    ]);
+  }
+
+  /**
+   * @param $membership
+   * @param $membershipType
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockContribution($membership, $membershipType) {
+    $rate = $this->getMemberDuesTaxRate();
+    $taxAmount  = ($membershipType['minimum_fee'] * $rate) / 100;
+    $totalAmount = $membershipType['minimum_fee'] + $taxAmount;
+    $params = [
+      'currency' => 'GBP',
+      'receipt_date' => NULL,
+      'source' => NULL,
+      'non_deductible_amount' => 0,
+      'skipCleanMoney' => 1,
+      'payment_processor' => NULL,
+      'contact_id' => $membership['contact_id'],
+      'fee_amount' => 0,
+      'total_amount' => $totalAmount,
+      'receive_date' => $membership['start_date'],
+      'financial_type_id' => $this->getFinancialTypeId('Member Dues'),
+      'payment_instrument_id' => 4,
+      'trxn_id' => NULL,
+      'invoice_id' => NULL,
+      'is_test' => NULL,
+      'contribution_status_id]' => 2,
+      'check_number' => NULL,
+      'campaign_id' => NULL,
+      'is_pay_later' => 1,
+      'membership_id' => $membership['id'],
+      'tax_amount' => $taxAmount,
+      'skipLineItem' => 0,
+      'contribution_recur_id' => NULL,
+      'pan_truncation' => NULL,
+      'card_type_id' => NULL,
+    ];
+
+    return ContributionFabricator::fabricate($params);
+  }
+
+  /**
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockPriceSet() {
+    $priceSetParams = [
+      'name' => "test_price_set",
+      'extends' => "CiviMember",
+      'financial_type_id' => "Member Dues",
+      'is_active' => 1,
+    ];
+
+    return PriceSetFabricator::fabricate($priceSetParams);
+  }
+
+  /**
+   * @param $priceSetId
+   * @param string $priceFieldLabel
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockPriceField($priceSetId, $priceFieldLabel = 'Membership Amount') {
+    return PriceFieldFabricator::fabricate([
+      'price_set_id' => $priceSetId,
+      'label' => "$priceFieldLabel",
+      'name' => "price_field_1",
+      'html_type' => "Radio",
+    ]);
+  }
+
+  /**
+   *
+   * @return array
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockPriceFieldValue($priceFieldId, $membershipTypeId) {
+    return PriceFieldValueFabricator::fabricate([
+      'price_field_id' => $priceFieldId,
+      'label' => "Price Field Value with Membership Type " . (string) $membershipTypeId,
+      'amount' => 240,
+      'membership_type_id' => $membershipTypeId,
+      'financial_type_id' => "Member Dues",
+    ]);
+  }
+
+  /**
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function getMemberDuesTaxRate() {
+    $financialTypeId = $this->getFinancialTypeID('Member Dues');
+    $taxRates = CRM_Core_PseudoConstant::getTaxRates();
+    return CRM_Utils_Array::value($financialTypeId, $taxRates, 0);
+  }
+
+  /**
+   * Obtains ID for the given financial type name.
+   *
+   * @param $financialType
+   *
+   * @return int|array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getFinancialTypeID($financialType) {
+    return civicrm_api3('FinancialType', 'getvalue', [
+      'return' => 'id',
+      'name' => $financialType,
+    ]);
+  }
+
+  /**
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function getDefaultMembershipTypeAmountPriceSet() {
+    return civicrm_api3('PriceSet', 'get', [
+      'sequential' => 1,
+      'name' => "default_membership_type_amount",
+    ])['values'][0];
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR fixes the issue when we set up a membership with price set and the membership is pro rated, the contribution's line item will still hold the original full amount while the total amount of the contribution is the correct pro rated amount. 

This PR also fixes another issue where tax amount is not pro rated when price set is used with fixed period membership type. 

Below before and after screenshots were created with the same membership types and price sets where

- Membership types are fixed period type. 
- Period start day is 01 Jan and Period roll over day is 31 Dec.
- Duration is 1 year.
- Annual Pro-rata calculation is by months.
- Membership start date is today (10-Feb-2021)

## Before

Pro rated amounts show on membership sign up page

![screenshot-compuclient local-2021 02 10-14_26_15](https://user-images.githubusercontent.com/208713/107522996-2f79f200-6bac-11eb-8aa8-841f2f97a249.png)

View contribution shows original  line item and  tax amount and after membership is created

![screenshot-compuclient local-2021 02 10-14_27_12](https://user-images.githubusercontent.com/208713/107522983-2be66b00-6bac-11eb-861d-b17f09d04e9e.png)

## After

Pro rated amounts show on membership sign up page

![screenshot-compuclient local-2021 02 10-14_12_53](https://user-images.githubusercontent.com/208713/107521715-cc3b9000-6baa-11eb-9c01-e5d7e21c58ba.png)

Pro rated  line item and tax amount show on view contribution after membership is created

![screenshot-compuclient local-2021 02 10-17_38_33](https://user-images.githubusercontent.com/208713/107548694-e08d8600-6bc6-11eb-9bc9-68c55b42b820.png)

## Technical Details

There are few technical points that worth mention are: 

1. Line item amounts will only be pro rated if price set is used and membership type is fixed period membership type.
2. The Logic of altering the line item remains are it was except for the above criteria. 
2. This PR also refactors the Membership payment plan pre hook code to separate classes for contribution and line item object, so each hook class has a single responsibility.   
3.  Uni tests were added to test new implementation of altering line item as well as existing altering line item logic.

