### PR TITLE
MAE-454: Add validations when creating membership payment plan

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
@@ -1,0 +1,119 @@
+<?php
+
+use CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment as InvalidMembershipTypeInstalment;
+
+/**
+ * Form Validation on payment plan submission.
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
+
+  /**
+   * @var \CRM_Member_Form_Membership
+   *   Form object that is being validated.
+   */
+  private $form;
+
+  /**
+   * @var array
+   *   List of the submitted fields and their values passed from the hook.
+   */
+  private $fields;
+
+  /**
+   * @var array
+   *   List of form validation errors passed from the hook.
+   */
+  private $errors;
+
+  /**
+   * CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan constructor.
+   *
+   * @param CRM_Member_Form $form
+   * @param $fields
+   * @param $errors
+   */
+  public function __construct(CRM_Member_Form &$form, &$fields, &$errors) {
+    $this->form = $form;
+    $this->fields = &$fields;
+    $this->errors = &$errors;
+  }
+
+  /**
+   * Validates the payment plan form submission
+   * fields when renewing or creating memberships.
+   */
+  public function validate() {
+    $fixedPeriodStartDays = [];
+    $periodTypes = [];
+    $priceSetID = $this->fields['price_set_id'];
+    if (empty($priceSetID)) {
+      return;
+    }
+
+    $membershipTypes = $this->getMembershipTypesFromPriceFieldValueFields();
+
+    $fixedPeriodStartDays = [];
+    $periodTypes = [];
+    foreach ($membershipTypes as $membershipType) {
+      $periodTypes[] = $membershipType['period_type'];
+      if ($membershipType['period_type'] == 'fixed') {
+        $fixedPeriodStartDays[] = $membershipType['fixed_period_start_day'];
+      }
+    }
+
+    $periodTypes = array_unique($periodTypes);
+
+    if (!empty($periodTypes)) {
+      if (!empty($periodTypes) && count($periodTypes) != 1) {
+        $this->errors['price_set_id'] = InvalidMembershipTypeInstalment::PERIOD_TYPE;
+      }
+    }
+
+    $fixedPeriodStartDays = array_unique($fixedPeriodStartDays);
+    if (!empty($fixedPeriodStartDays) && count($fixedPeriodStartDays) != 1) {
+      $this->errors['price_set_id'] = InvalidMembershipTypeInstalment::SAME_PERIOD_START_DAY;
+    }
+
+  }
+
+  /**
+   * Gets price field values and membership types from the submitted form fields.
+   */
+  private function getMembershipTypesFromPriceFieldValueFields() {
+    $indexes = array_keys($this->fields);
+    //Search for field starting with price_ follwoing by arbitrary numbers
+    $matchedPriceFieldFields = preg_grep('/^price_(\d+)/', $indexes);
+    $selectedPriceFieldIdValues = [];
+    foreach ($matchedPriceFieldFields as $matchedField) {
+      if ((is_array($this->fields[$matchedField]))) {
+        foreach ($this->fields[$matchedField] as $priceFieldValueId => $value) {
+          $selectedPriceFieldIdValues[] = $priceFieldValueId;
+        }
+      }
+      else {
+        $selectedPriceFieldIdValues[] = $this->fields[$matchedField];
+      }
+    }
+
+    if (empty($selectedPriceFieldIdValues)) {
+      return;
+    }
+
+    $priceFieldValues = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'id' => ['IN' => $selectedPriceFieldIdValues],
+      'api.MembershipType.get' => [],
+    ])['values'];
+
+    $membershipTypes = [];
+    foreach ($priceFieldValues as $priceFieldValue) {
+      $membershipType = $priceFieldValue['api.MembershipType.get']['values'][0];
+      if (!empty($membershipType)) {
+        $membershipTypes[] = $membershipType;
+      }
+    }
+
+    return $membershipTypes;
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -368,6 +368,14 @@ function membershipextras_civicrm_pageRun($page) {
  */
 function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   $formAction = $form->getAction();
+  $isNewMembershipForm = ($formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::ADD));
+  $isRenewMembershipForm = ($formName === 'CRM_Member_Form_MembershipRenewal' && ($formAction & CRM_Core_Action::RENEW));
+  $isPaymentPlanPaymentlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanWithSchedule();
+  if (($isNewMembershipForm || $isRenewMembershipForm) && $isPaymentPlanPaymentlanPayment) {
+    $paymentPlanValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($form, $fields, $errors);
+    $paymentPlanValidateHook->validate();
+  }
+
   $isMembershipUpdateForm = $formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::UPDATE);
   if ($isMembershipUpdateForm) {
     $membershipUpdateValidationHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate($form, $fields, $errors);

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembesPaymentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembesPaymentPlanTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_PriceSet as PriceSetFabricator;
+use CRM_MembershipExtras_Test_Fabricator_PriceField as PriceFieldFabricator;
+use CRM_MembershipExtras_Test_Fabricator_PriceFieldValue as PriceFieldValueFabricator;
+use CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment as InvalidMembershipTypeInstalment;
+
+/**
+ * Class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlanTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlanTest extends BaseHeadlessTest {
+
+  private $form;
+  private $errors;
+
+  public function setUp() {
+    $this->form = new CRM_Member_Form();
+    $this->errors = ['price_set_id' => NULL];
+  }
+
+  /**
+   * Tests error when mixed period membership type price field values are submitted.
+   */
+  public function testErrorWhenMixedPeriodMembershipTypePriceFieldValuesAreSubmitted() {
+    $priceSet = $this->mockPriceSet();
+    $priceField = $this->mockPriceField($priceSet['id'], 'Test Field Set 1');
+    $memType1 = $this->mockMembershipType('rolling', 'year');
+    $memType2 = $this->mockMembershipType('fixed', 'year');
+    $priceFieldValue1 = $this->mockPriceFieldValue($priceField['id'], $memType1['id']);
+    $priceFieldValue2 = $this->mockPriceFieldValue($priceField['id'], $memType2['id']);
+
+    $fields = [];
+    $fields['price_set_id'] = $priceSet['id'];
+    $mockedPriceFieldKey = 'price_' . (string) $priceField['id'];
+    //Simulate check boxes with different period membership period type attach to price field values
+    $fields[$mockedPriceFieldKey] = [
+      $priceFieldValue1['id'] => 1,
+      $priceFieldValue2['id'] => 1,
+    ];
+    $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
+    $paymentPlanValidation->validate();
+    $this->assertEquals(InvalidMembershipTypeInstalment::PERIOD_TYPE, $this->errors['price_set_id']);
+  }
+
+  /**
+   * Tests error when mixed period start days membership type for price field values are submitted.
+   */
+  public function testErrorWhenMixedFixedPeriodStartDaysMembershipTypePriceFieldValuesAreSubmitted() {
+    $priceSet = $this->mockPriceSet();
+    $priceField1 = $this->mockPriceField($priceSet['id'], 'Test Price Field 1');
+    $priceField2 = $this->mockPriceField($priceSet['id'], 'Test Price Field 1');
+
+    $memType1 = $this->mockMembershipType('fixed', 'year', 101);
+    $memType2 = $this->mockMembershipType('fixed', 'year', 1001);
+
+    $priceFieldValue2 = $this->mockPriceFieldValue($priceField2['id'], $memType2['id']);
+    $priceFieldValue1 = $this->mockPriceFieldValue($priceField1['id'], $memType1['id']);
+
+    $fields = [];
+    $fields['price_set_id'] = $priceSet['id'];
+    $mockedPriceFieldKey1 = 'price_' . (string) $priceField1['id'];
+    //Simulate field when price field is check box
+    $fields[$mockedPriceFieldKey1] = [
+      $priceFieldValue1['id'] => 1,
+    ];
+    //Simulate field when price field is radio button
+    $mockedPriceFieldKey2 = 'price_' . (string) $priceField2['id'];
+    $fields[$mockedPriceFieldKey2] = $priceFieldValue2['id'];
+
+    $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
+    $paymentPlanValidation->validate();
+    $this->assertEquals(InvalidMembershipTypeInstalment::SAME_PERIOD_START_DAY, $this->errors['price_set_id']);
+  }
+
+  /**
+   * Tests no error when price set
+   */
+  public function testNoErrorWhenPriceSetRollingMembershipTypeIsSubmitted() {
+    $priceSet = $this->mockPriceSet();
+    $priceField = $this->mockPriceField($priceSet['id'], 'Test Field Set 1');
+    $memType1 = $this->mockMembershipType('rolling', 'year');
+    $memType2 = $this->mockMembershipType('rolling', 'year');
+    $priceFieldValue1 = $this->mockPriceFieldValue($priceField['id'], $memType1['id']);
+    $priceFieldValue2 = $this->mockPriceFieldValue($priceField['id'], $memType2['id']);
+
+    $fields = [];
+    $fields['price_set_id'] = $priceSet['id'];
+    $mockedPriceFieldKey = 'price_' . (string) $priceField['id'];
+    //Simulate check boxes with different period membership period type attach to price field values
+    $fields[$mockedPriceFieldKey] = [
+      $priceFieldValue1['id'] => 1,
+      $priceFieldValue2['id'] => 1,
+    ];
+
+    $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
+    $paymentPlanValidation->validate();
+    $this->assertNull($this->errors['price_set_id']);
+  }
+
+  /**
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockPriceSet() {
+    $priceSetParams = [
+      'name' => "test_price_set",
+      'extends' => "CiviMember",
+      'financial_type_id' => "Member Dues",
+      'is_active' => 1,
+    ];
+
+    return PriceSetFabricator::fabricate($priceSetParams);
+  }
+
+  /**
+   * @param $priceSetId
+   * @param string $priceFieldLabel
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockPriceField($priceSetId, $priceFieldLabel = 'Membership Amount') {
+    return PriceFieldFabricator::fabricate([
+      'price_set_id' => $priceSetId,
+      'label' => "$priceFieldLabel",
+      'name' => "price_field_1",
+      'html_type' => "Radio",
+    ]);
+  }
+
+  /**
+   *
+   * @return array
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockPriceFieldValue($priceFieldId, $membershipTypeId) {
+    return PriceFieldValueFabricator::fabricate([
+      'price_field_id' => $priceFieldId,
+      'label' => "Price Field Value with Membership Type " . (string) $membershipTypeId,
+      'amount' => 240,
+      'membership_type_id' => $membershipTypeId,
+      'financial_type_id' => "Member Dues",
+    ]);
+  }
+
+  /**
+   * @param $membershipPeriodType
+   * @param $durationUnit
+   * @param $setting
+   * @param $fixedPeriodStartDate
+   * @return mixed
+   * @throws CiviCRM_API3_Exception
+   */
+  private function mockMembershipType($membershipPeriodType, $durationUnit, $fixedPeriodStartDate = 101) {
+    $memType = MembershipTypeFabricator::fabricate([
+      'name' => 'Mock Membership type',
+      'period_type' => $membershipPeriodType,
+      'minimum_fee' => 120,
+      'duration_interval' => 1,
+      'duration_unit' => $durationUnit,
+      //01 Oct
+      'fixed_period_start_day' => $fixedPeriodStartDate,
+      // 30 Sep
+      'fixed_period_rollover_day' => 930,
+    ]);
+
+    return $memType;
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR adds two custom validations when creating a payment plan when using a price set. 

Unit tests are also added to test validations. 

## Before

No custom validations implemented on version 5

## After

Custom validations added to prevent user submit the form that will generate incorrect data. 

The validations are: 

- Validate if the membership period types are mixed of price field values. (rolling or fixed) 
- Validate if fixed period membership type are selected with different period start days
