### PR TITLE
IO-120: Set default annual calculation setting value

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipType/Setting.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipType/Setting.php
@@ -28,8 +28,21 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipType_Setting extends Base {
     if (is_null($settings)) {
       return;
     }
-    $fields = [self::ANNUAL_PRORATA_CALCULATION_ELEMENT];
-    parent::setFieldsDefaultValue($settings, $fields);
+    if (empty($this->form->_id)) {
+      $this->setDefaultValue();
+    }
+    else {
+      $fields = [self::ANNUAL_PRORATA_CALCULATION_ELEMENT];
+      parent::setFieldsDefaultValue($settings, $fields);
+    }
+  }
+
+  /**
+   * Sets defaults settings for a create membership type form
+   */
+  private function setDefaultValue() {
+    $defaults = [self::ANNUAL_PRORATA_CALCULATION_ELEMENT => FixedPeriodCalculator::BY_DAYS];
+    $this->form->setDefaults($defaults);
   }
 
   /**

--- a/templates/CRM/Member/Form/MembershipType/Settings.hlp
+++ b/templates/CRM/Member/Form/MembershipType/Settings.hlp
@@ -4,6 +4,6 @@
 {htxt id="membership_type_annual_pro_rata_calculation"}
 <p>{ts}When a membership is billed annually, you can define how the first years fee is calculated.{/ts}</p>
 <p>{ts}The options are: {/ts}</p>
-<p>{ts}By days: The system will calculate how many days until the next renewal date and then will divide this by number of days in a standard years.{/ts}</p>
+<p>{ts}By days: The system will calculate how many days until the next renewal date and then will divide this by number of days in a standard year.{/ts}</p>
 <p>{ts}By months: The system will calculate how many complete months the membership will be active for before the next renewal date.{/ts}</p>
 {/htxt}


### PR DESCRIPTION
## Overview

This PR adds the default value setting to an Annual Pro-rata Calculation field to a Membership Type Form when creating a new membership type. 

This PR also fixes the typo on the help text of Annual Pro-rata Calculation field.

## Before

![Peek 2021-02-12 14-25](https://user-images.githubusercontent.com/208713/107780126-30db2400-6d3e-11eb-8e02-cb20d82202d0.gif)

## After

![Peek 2021-02-12 14-24](https://user-images.githubusercontent.com/208713/107780100-2587f880-6d3e-11eb-9f90-0243c77c44e2.gif)


