### PR TITLE
IO-121: Validate membership type screen

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipType.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipType.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_ValidateForm_MembershipType
+ *
+ * Validates Membership Type Form
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_MembershipType {
+
+  /**
+   * @var array
+   *   List of the submitted fields and their values passed from the hook.
+   */
+  private $fields;
+
+  /**
+   * @var array
+   *   List of form validation errors passed from the hook.
+   */
+  private $errors;
+
+  /**
+   * CRM_MembershipExtras_Hook_ValidateForm_MembershipType constructor.
+   *
+   * @param $fields
+   * @param $errors
+   */
+  public function __construct(&$fields, &$errors) {
+    $this->fields = &$fields;
+    $this->errors = &$errors;
+  }
+
+  /**
+   * Validates the membership form submission
+   */
+  public function validate() {
+    $membershipPeriodType = $this->fields['period_type'];
+    if ($membershipPeriodType != 'fixed') {
+      return;
+    }
+
+    $this->validateDuration();
+    $this->validateAnnualProRataCalculation();
+  }
+
+  /**
+   * Validates if the annual pro rata calculation is required.
+   */
+  private function validateAnnualProRataCalculation() {
+    if (empty($this->fields['membership_type_annual_pro_rata_calculation'])) {
+      $this->errors['membership_type_annual_pro_rata_calculation'] = ts('This field is required.');
+    }
+  }
+
+  /**
+   * Validates that only yearly membership is supported.
+   */
+  private function validateDuration() {
+    $durationInterval = $this->fields['duration_interval'];
+    $durationUnit = $this->fields['duration_unit'];
+    if ($durationInterval != 1 || $durationUnit != 'year') {
+      $this->errors['duration_unit'] = ts('Fixed period membership type only supports 1 year duration.');
+    }
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -367,6 +367,11 @@ function membershipextras_civicrm_pageRun($page) {
  * Implements hook_civicrm_validateForm().
  */
 function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
+  if ($formName === 'CRM_Member_Form_MembershipType') {
+    $membershipType = new CRM_MembershipExtras_Hook_ValidateForm_MembershipType($fields, $errors);
+    $membershipType->validate();
+  }
+
   $formAction = $form->getAction();
   $isNewMembershipForm = ($formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::ADD));
   $isRenewMembershipForm = ($formName === 'CRM_Member_Form_MembershipRenewal' && ($formAction & CRM_Core_Action::RENEW));

--- a/templates/CRM/Member/Form/MembershipType/Settings.tpl
+++ b/templates/CRM/Member/Form/MembershipType/Settings.tpl
@@ -53,10 +53,11 @@
       let durationInterval = $('#duration_interval');
       durationInterval.val(1);
       durationInterval.prop( 'readonly', true );
-      $('#duration_unit option').val('year');
-      $('#duration_unit').prop( 'readonly', true );
+      $('#duration_unit option[value="year"]').prop('selected', true);
       $('#fixed_period_start_day_d').val(1);
       $('#fixed_period_start_day_d option:not(:selected)').prop('disabled', true);
+      $('#fixed_start_day_row').show();
+      $('#fixed_rollover_day_row').show();
     }
 
     /**
@@ -65,7 +66,7 @@
     function handleRollingPeriod() {
       $('#membership_type_annual_pro_rata_calculation').hide();
       $('#duration_interval').prop( 'readonly', false );
-      $(`#duration_unit`).prop( 'readonly', false );
+      $(`#duration_interval`).val('');
     }
 
     /**

--- a/templates/CRM/Member/Form/MembershipType/Settings.tpl
+++ b/templates/CRM/Member/Form/MembershipType/Settings.tpl
@@ -13,6 +13,7 @@
      */
     function moveFields() {
       $('#membership_type_annual_pro_rata_calculation').insertAfter($('#month_fixed_rollover_day_row'));
+      $('.crm-membership-type-form-block-period_type').insertBefore($('.crm-membership-type-form-block-duration_unit_interval'));
     }
 
     /**

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembershipTypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_ValidateForm_MembershipTypeTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_MembershipTypeTest extends BaseHeadlessTest {
+
+  public function testValidateFixedPeriodWithInValidDuration() {
+    $fields = [
+      'period_type' => 'fixed',
+      'duration_interval' => '1',
+      'duration_unit' => 'month',
+      'membership_type_annual_pro_rata_calculation' => '1',
+    ];
+    $errors = [];
+    $membeshipType = new CRM_MembershipExtras_Hook_ValidateForm_MembershipType($fields, $errors);
+    $membeshipType->validate();
+    $this->assertArrayHasKey('duration_unit', $errors);
+  }
+
+  public function testValidateFixedPeriodWithInValidInterval() {
+    $fields = [
+      'period_type' => 'fixed',
+      'duration_interval' => '2',
+      'duration_unit' => 'year',
+      'membership_type_annual_pro_rata_calculation' => '1',
+    ];
+    $errors = [];
+    $membeshipType = new CRM_MembershipExtras_Hook_ValidateForm_MembershipType($fields, $errors);
+    $membeshipType->validate();
+    $this->assertArrayHasKey('duration_unit', $errors);
+  }
+
+  public function testValidateFixedPeriodWithInValidIntervalAndDuration() {
+    $fields = [
+      'period_type' => 'fixed',
+      'duration_interval' => '12',
+      'duration_unit' => 'month',
+      'membership_type_annual_pro_rata_calculation' => '1',
+    ];
+    $errors = [];
+    $membeshipType = new CRM_MembershipExtras_Hook_ValidateForm_MembershipType($fields, $errors);
+    $membeshipType->validate();
+    $this->assertArrayHasKey('duration_unit', $errors);
+  }
+
+  public function testValidateFixedPeriodWithValidIntervalAndDuration() {
+    $fields = [
+      'period_type' => 'fixed',
+      'duration_interval' => '1',
+      'duration_unit' => 'year',
+      'membership_type_annual_pro_rata_calculation' => '1',
+    ];
+    $errors = [];
+    $membeshipType = new CRM_MembershipExtras_Hook_ValidateForm_MembershipType($fields, $errors);
+    $membeshipType->validate();
+    $this->assertEmpty($errors);
+  }
+
+  public function testNotToValidateRolling() {
+    $fields = [
+      'period_type' => 'rolling',
+    ];
+    $errors = [];
+    $membeshipType = new CRM_MembershipExtras_Hook_ValidateForm_MembershipType($fields, $errors);
+    $membeshipType->validate();
+    $this->assertEmpty($errors);
+  }
+
+  public function testValidateAnnualProrataCalculationIsRequired() {
+    $fields = [
+      'period_type' => 'fixed',
+      'duration_interval' => '1',
+      'duration_unit' => 'year',
+    ];
+    $errors = [];
+    $membeshipType = new CRM_MembershipExtras_Hook_ValidateForm_MembershipType($fields, $errors);
+    $membeshipType->validate();
+    $this->assertArrayHasKey('membership_type_annual_pro_rata_calculation', $errors);
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR: 

- Adds validate for fixed period membership type when submitting the form and unit tests.
- Moves Membership Type Plan field before Membership Type Duration Unit field.

Validations added are

1. Validate if membership type annual pro rata calculation field is selected when fixed period membership type is selected.
2. Validate if membership type duration is 1 year if fixed period membership type is selected

## Before

![Peek 2021-02-18 11-20](https://user-images.githubusercontent.com/208713/108349851-65862a00-71db-11eb-9f2e-437afeb39ce7.gif)

## After

![Peek 2021-02-18 11-13](https://user-images.githubusercontent.com/208713/108349011-636f9b80-71da-11eb-95eb-d616d808cf78.gif)

![Screenshot from 2021-02-18 11-29-44](https://user-images.githubusercontent.com/208713/108352501-d844d480-71de-11eb-99ef-3cc3d98e4ba9.png)
