### PR TITLE
COMCL-101: Use postInstall hook for settings membership extras

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -9,7 +9,7 @@ use CRM_MembershipExtras_PaymentProcessor_OfflineRecurringContribution as Offlin
  */
 class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
-  public function Install() {
+  public function postInstall() {
     $this->createOfflineAutoRenewalScheduledJob();
     $this->createPaymentProcessorType();
     $this->createPaymentProcessor();


### PR DESCRIPTION
## Overview

This PR is to change the hook on installation from install hook to post install hook.

The reason for changing is that the tasks for creating default values that created during installation for example membership extras settings and other values may not be available yet for subsequence steps like set default value into the one of the settings. Therefore, the subsequences steps that require settings should be done in the post install hook which is immediately called after installed is done. 

## Before

- Install hook was used
- Below error threw when installing the extension with Drush. 
```
User deprecated function: Deprecated Path: There is a setting (membershipextras_paymentplan_default_processor) not correctly defined. You may see unpredictability due to this. CRM_Core_Setting::setItems in                [error]
CRM_Core_Error::deprecatedWarning() (line 1053 of /vagrant/test11/profiles/compuclient/modules/contrib/civicrm/CRM/Core/Error.php).

```

## After

- postInstall hook is used. 
- No error threw during is installation. 