### PR TITLE
MAE-479: Alter contribution receive date

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/Contribution.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/Contribution.php
@@ -35,8 +35,20 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution 
    * depending on the instalments count.
    */
   public function createPaymentPlan() {
+    $this->alterRecievedDate();
     $this->createRecurringContribution();
     $this->alterFirstContributionParameters();
+  }
+
+  /**
+   * Set Contribution receive date as Membership start date.
+   */
+  private function alterRecievedDate() {
+    $membership = civicrm_api3('Membership', 'getSingle', [
+      'sequential' => 1,
+      'id' => $this->membershipId,
+    ]);
+    $this->params['receive_date'] = $membership['start_date'];
   }
 
   /**


### PR DESCRIPTION
## Overview

Membership Extras version 5 hides contribution received date field on the user interface by default and the default value also set to sign up date. 

This PR adds logic to alter contribution receive date param to always use membership start date when creating payment plan on civicrm pre hook with contribution object

The contribution receive date param is used as

- A received date for first contribution in a payment plan
- Payment plan start date 

## Before

- First contribution receive date in the payment plan is always set as sign up date

## After

- First contribution receive date in the payment plan will always be set as membership start date 

## Technical Details

Alter receive date param in the pre hook is preferred to create a logic in the UI set receive date as membership start date or membership join date as we can ensure that the first contribution receive date will always set as membership start date as well as the test can be done via unit test. 
