### PR TITLE
MAE-479:  Payment plan start date

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
@@ -40,9 +40,27 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
 
   /**
    * Validates the payment plan form submission
-   * fields when renewing or creating memberships.
+   * fields when creating a membership.
    */
   public function validate() {
+    $this->validateMembershipStartDate();
+    $this->validatePriceSet();
+  }
+
+  /**
+   * Validates that membership start date is entered.
+   */
+  private function validateMembershipStartDate() {
+    if (empty($this->fields['start_date'])) {
+      $this->errors['start_date'] = ts('Start date is required');
+    }
+  }
+
+  /**
+   * Validates selected fixed membermship types when using price set
+   * have that same period type and same period start day.
+   */
+  private function validatePriceSet() {
     $fixedPeriodStartDays = [];
     $periodTypes = [];
     $priceSetID = $this->fields['price_set_id'];
@@ -73,7 +91,6 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
     if (!empty($fixedPeriodStartDays) && count($fixedPeriodStartDays) != 1) {
       $this->errors['price_set_id'] = InvalidMembershipTypeInstalment::SAME_PERIOD_START_DAY;
     }
-
   }
 
   /**

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -369,9 +369,8 @@ function membershipextras_civicrm_pageRun($page) {
 function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
   $formAction = $form->getAction();
   $isNewMembershipForm = ($formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::ADD));
-  $isRenewMembershipForm = ($formName === 'CRM_Member_Form_MembershipRenewal' && ($formAction & CRM_Core_Action::RENEW));
-  $isPaymentPlanPaymentlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanWithSchedule();
-  if (($isNewMembershipForm || $isRenewMembershipForm) && $isPaymentPlanPaymentlanPayment) {
+  $isPaymentPlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanWithSchedule();
+  if ($isNewMembershipForm && $isPaymentPlanPayment) {
     $paymentPlanValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($form, $fields, $errors);
     $paymentPlanValidateHook->validate();
   }

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -91,6 +91,7 @@
             }
           });
         }
+        assignFirstContributionReceiveDate();
       });
 
       $('#payment_plan_schedule, #payment_instrument_id, #start_date, #end_date').change(() => {
@@ -98,7 +99,17 @@
           return;
         }
         generateInstalmentSchedule(isPriceSetSelected());
+        assignFirstContributionReceiveDate();
       });
+    }
+
+    /**
+     * Assigns first contribution received date from either start date or join date
+     */
+    function assignFirstContributionReceiveDate() {
+      let startDate =  $('#start_date').val();
+      recievedDate = !startDate || 0 === startDate.length ? $('#join_date').val() : startDate;
+      $('#receive_date').val(recievedDate);
     }
 
     /**
@@ -269,7 +280,6 @@
     function setupPayPlanTogglingEvents () {
       $('#payment_plan_fields_tabs li').click(function () {
         const tabOptionId = $(this).attr('data-selector');
-
         selectPaymentPlanTab(tabOptionId);
       });
     }
@@ -292,6 +302,7 @@
         $('.crm-membership-form-block-payment_instrument_id')
                 .insertBefore('.crm-membership-form-block-contribution_status_id');
         $('.crm-membership-form-block-billing').insertAfter('.crm-membership-form-block-contribution_status_id');
+        $('#receive_date').val('');
       } else if (tabOptionId === 'payment_plan') {
         $('#payment_plan_schedule_row').show();
         $('#payment_plan_schedule_instalment_row').show();
@@ -306,6 +317,7 @@
         if ($('#membership_type_id_1').val()) {
           $('#membership_type_id_1').change();
         }
+        assignFirstContributionReceiveDate();
       }
     }
 


### PR DESCRIPTION
## Overview

Membership Extras version 5 hides contribution received date field on the user interface by default and the default value also set to sign up date. 

This PR adds logic in the interface to assign membership start date onto payment plan start date (first contribution received date) automatically when the payment plan is selected. 

Since Membership extras version 5 is using membership start date as a first contribution received date when creating a new membership, the validation to check that membership start date is required is added to the form on the existing validation Form hook. 

## Before

- First contribution receive date in the payment plan is always set as sign up date.
- Membership can be created without select membership start date (civicrm will assign start date automatically based on membership type) 

## After

- First contribution receive date in the payment plan will always be set as membership start date.
- Membership will only be created only when membership start date is selected or the form will throw an error if membership start date is not set. 

## Technical Details

The logic to set receive date as membership start date is done on UI because if  we use pre hook to alter contribution receive date param, we could encounter the issue where the first contribution may not always be membership start date when renew the membership 
