### PR TITLE
IO-121: Save settings when creating new membership type

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipTypeSetting.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipTypeSetting.php
@@ -48,13 +48,12 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipTypeSetting {
       $this->settings = [];
     }
 
-    if (!empty($this->form->_id)) {
-      $annualProRataCalculationValue = $this->form->_submitValues['membership_type_annual_pro_rata_calculation'];
-      $this->settings[$this->form->_id]  = [
-        'membership_type_annual_pro_rata_calculation' => $annualProRataCalculationValue,
-      ];
-      Civi::settings()->set(SettingsManager::MEMBERSHIP_TYPE_SETTINGS_KEY, $this->settings);
-    }
+    $membershipTypeId = $this->getMembershipTypeId();
+    $annualProRataCalculationValue = $this->form->_submitValues['membership_type_annual_pro_rata_calculation'];
+    $this->settings[$membershipTypeId]  = [
+      'membership_type_annual_pro_rata_calculation' => $annualProRataCalculationValue,
+    ];
+    Civi::settings()->set(SettingsManager::MEMBERSHIP_TYPE_SETTINGS_KEY, $this->settings);
   }
 
   /**
@@ -67,6 +66,17 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipTypeSetting {
       unset($this->settings[$membershipTypeId]);
       Civi::settings()->set(SettingsManager::MEMBERSHIP_TYPE_SETTINGS_KEY, $this->settings);
     }
+  }
+
+  private function getMembershipTypeId() {
+    if (!empty($this->form->_id)) {
+      return $this->form->_id;
+    }
+
+    return civicrm_api3('MembershipType', 'getsingle', [
+      'return' => ['id'],
+      'name' => $this->form->exportValues()['name'],
+    ])['id'];
   }
 
 }

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateMembershipTypeColour.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateMembershipTypeColour.php
@@ -12,7 +12,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateMembershipTypeColour {
   private $form;
 
   /**
-   * @var array.
+   * @var array
    */
   private $membershipTypeColourSettings;
 
@@ -53,7 +53,7 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateMembershipTypeColour {
     $membershipColour = $this->form->_submitValues['membership_colour'];
     $membershipTypeColourSettings[$membershipTypeId] = [
       'set_membership_colour' => $setMembershipColour,
-      'membership_colour' => $setMembershipColour ? $membershipColour : ''
+      'membership_colour' => $setMembershipColour ? $membershipColour : '',
     ];
 
     Civi::settings()->set(MembershipTypeSettings::COLOUR_SETTINGS_KEY, $membershipTypeColourSettings);

--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateMembershipTypeColour.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateMembershipTypeColour.php
@@ -48,16 +48,15 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateMembershipTypeColour {
       $membershipTypeColourSettings = [];
     }
 
-    if (!empty($this->form->_id)) {
-      $setMembershipColour = $this->form->_submitValues['set_membership_colour'];
-      $membershipColour = $this->form->_submitValues['membership_colour'];
-      $membershipTypeColourSettings[$this->form->_id] = [
-        'set_membership_colour' => $setMembershipColour,
-        'membership_colour' => $setMembershipColour ? $membershipColour : ''
-      ];
+    $membershipTypeId = $this->getMembershipTypeId();
+    $setMembershipColour = $this->form->_submitValues['set_membership_colour'];
+    $membershipColour = $this->form->_submitValues['membership_colour'];
+    $membershipTypeColourSettings[$membershipTypeId] = [
+      'set_membership_colour' => $setMembershipColour,
+      'membership_colour' => $setMembershipColour ? $membershipColour : ''
+    ];
 
-      Civi::settings()->set(MembershipTypeSettings::COLOUR_SETTINGS_KEY, $membershipTypeColourSettings);
-    }
+    Civi::settings()->set(MembershipTypeSettings::COLOUR_SETTINGS_KEY, $membershipTypeColourSettings);
   }
 
   /**
@@ -75,4 +74,16 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateMembershipTypeColour {
       Civi::settings()->set(MembershipTypeSettings::COLOUR_SETTINGS_KEY, $membershipTypeColourSettings);
     }
   }
+
+  private function getMembershipTypeId() {
+    if (!empty($this->form->_id)) {
+      return $this->form->_id;
+    }
+
+    return civicrm_api3('MembershipType', 'getsingle', [
+      'return' => ['id'],
+      'name' => $this->form->exportValues()['name'],
+    ])['id'];
+  }
+
 }

--- a/templates/CRM/Member/Form/MembershipType/Settings.tpl
+++ b/templates/CRM/Member/Form/MembershipType/Settings.tpl
@@ -49,6 +49,7 @@
      * Handles fields when Membership Type fixed period is selected
     */
     function handleFixedPeriod() {
+      $('#month_fixed_rollover_day_row').hide();
       $('#membership_type_annual_pro_rata_calculation').show();
       let durationInterval = $('#duration_interval');
       durationInterval.val(1);


### PR DESCRIPTION
## Overview

This PR fixes the issue when extended membership type settings have not been saved when creating a new membership type. 

The PR also adds script to the template to hide fixed rollover days when selected fixed membership type to ensure that the field will not show when the page returns from validation if the user selects month as a duration interval for fixed period membership type. 

## Before

- Membership type colour and annual pro rata calculation values are only created  into the settings on edit mode. 

## After

- Membership type colour and annual pro rata calculation values are created and updated on when create or update membership type. 

## Technical Details

A form object that passes on  CiviCRM postProcess hook does not contain an ID when creating a new object, so the membership  type settings will never be saved. 

In order to address this issue, we check if the ID does not exist, then we will call Membership Type API to get membership type ID by name as membership type name is unique. By doing this, we can ensure that the settings will be saved when creating new membership type. 