### PR TITLE
IO-122: Display instalment total amount

### DIFF
--- a/CRM/MembershipExtras/API/PaymentSchedule/Base.php
+++ b/CRM/MembershipExtras/API/PaymentSchedule/Base.php
@@ -82,13 +82,15 @@ abstract class CRM_MembershipExtras_API_PaymentSchedule_Base {
 
     $formattedInstalments = [];
     foreach ($instalments as $key => $instalment) {
-      $instalmentAmount = $currencySymbol . $instalment->getInstalmentAmount()->getTaxAmount();;
-      $instalmentTaxAmount = $currencySymbol . $instalment->getInstalmentAmount()->getAmount();;
+      $instalmentAmount = $currencySymbol . $instalment->getInstalmentAmount()->getTaxAmount();
+      $instalmentTaxAmount = $currencySymbol . $instalment->getInstalmentAmount()->getAmount();
+      $instalmentTotalAmount = $currencySymbol . $instalment->getInstalmentAmount()->getTotalAmount();
       $instalmentDate = CRM_Utils_Date::customFormat($instalment->getInstalmentDate()->format('Y-m-d'), $this->getDateformatFull());
       $formattedInstalment['instalment_no'] = $key + 1;
       $formattedInstalment['instalment_date'] = $instalmentDate;
       $formattedInstalment['instalment_tax_amount'] = $instalmentAmount;
       $formattedInstalment['instalment_amount'] = $instalmentTaxAmount;
+      $formattedInstalment['instalment_total_amount'] = $instalmentTotalAmount;
       $formattedInstalment['instalment_status'] = $pendingStatusLabel;
       array_push($formattedInstalments, $formattedInstalment);
     }

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -242,7 +242,7 @@
       tbody.append('<td>' + rowData.instalment_no + ' </td>');
       tbody.append('<td>' + rowData.instalment_date + '</td>');
       tbody.append('<td>' + rowData.instalment_tax_amount + '</td>');
-      tbody.append('<td>' + rowData.instalment_amount + '</td>');
+      tbody.append('<td>' + rowData.instalment_total_amount + '</td>');
       tbody.append('<td>' + rowData.instalment_status + '</td>');
       tbody.append('</tr>');
     }


### PR DESCRIPTION

## Overview

This PR updates the instalment column instalment schedule table to display the correct total amount. 

## Before

Total column was display value from instalment_amount which did not include any taxes.

![Screenshot from 2021-03-01 08-40-29](https://user-images.githubusercontent.com/208713/109472270-d219e800-7a69-11eb-9c1d-0f114ee362ba.png)
_When instalment amount is £10 and VAT is £2_


## After

Total column displays value from instalment_total_amount that includes any taxes for contribution. 

![Screenshot from 2021-03-01 08-39-08](https://user-images.githubusercontent.com/208713/109472194-bc0c2780-7a69-11eb-9d1c-b3df8fb78855.png)
_When instalment amount is £10 and VAT is £2_
