### PR TITLE
IO-139: Add Instalment line item(s) to schedule 

### DIFF
--- a/CRM/MembershipExtras/DTO/ScheduleInstalmentAmount.php
+++ b/CRM/MembershipExtras/DTO/ScheduleInstalmentAmount.php
@@ -1,11 +1,27 @@
 <?php
 
 
+/**
+ * Class CRM_MembershipExtras_DTO_ScheduleInstalmentAmount
+ */
 class CRM_MembershipExtras_DTO_ScheduleInstalmentAmount {
 
+  /**
+   * @var float
+   */
   private $amount;
+  /**
+   * @var float
+   */
   private $taxAmount;
+  /**
+   * @var float
+   */
   private $totalAmount;
+  /**
+   * @var array
+   */
+  private $lineItems;
 
   /**
    * @return float
@@ -47,6 +63,20 @@ class CRM_MembershipExtras_DTO_ScheduleInstalmentAmount {
    */
   public function setTotalAmount(float $totalAmount) {
     $this->totalAmount = $totalAmount;
+  }
+
+  /**
+   * @param array $lineItems
+   */
+  public function setLineItems(array $lineItems) {
+    $this->lineItems = $lineItems;
+  }
+
+  /**
+   * @return array
+   */
+  public function getLineItems() {
+    return $this->lineItems;
   }
 
 }

--- a/CRM/MembershipExtras/DTO/ScheduleInstalmentLineItem.php
+++ b/CRM/MembershipExtras/DTO/ScheduleInstalmentLineItem.php
@@ -1,0 +1,137 @@
+<?php
+
+
+/**
+ * Class CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem
+ */
+class CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem {
+
+  /**
+   * @var int
+   */
+  private $financialTypeId;
+  /**
+   * @var int
+   */
+  private $quantity;
+  /**
+   * @var float
+   */
+  private $unitPrice;
+  /**
+   * @var float
+   */
+  private $subTotal;
+  /**
+   * @var float
+   */
+  private $taxRate;
+  /**
+   * @var float
+   */
+  private $taxAmount;
+  /**
+   * @var float
+   */
+  private $totalAmount;
+
+  /**
+   * @return int
+   */
+  public function getFinancialTypeId() {
+    return $this->financialTypeId;
+  }
+
+  /**
+   * @param int $financialTypeId
+   */
+  public function setFinancialTypeId($financialTypeId) {
+    $this->financialTypeId = $financialTypeId;
+  }
+
+  /**
+   * @return int
+   */
+  public function getQuantity() {
+    return $this->quantity;
+  }
+
+  /**
+   * @param int $quantity
+   */
+  public function setQuantity($quantity) {
+    $this->quantity = $quantity;
+    return $this;
+  }
+
+  /**
+   * @return float
+   */
+  public function getUnitPrice() {
+    return $this->unitPrice;
+  }
+
+  /**
+   * @param float $unitPrice
+   */
+  public function setUnitPrice($unitPrice) {
+    $this->unitPrice = $unitPrice;
+  }
+
+  /**
+   * @return float
+   */
+  public function getSubTotal() {
+    return $this->subTotal;
+  }
+
+  /**
+   * @param float $subTotal
+   */
+  public function setSubTotal($subTotal) {
+    $this->subTotal = $subTotal;
+  }
+
+  /**
+   * @return float
+   */
+  public function getTaxRate() {
+    return $this->taxRate;
+  }
+
+  /**
+   * @param float $taxRate
+   */
+  public function setTaxRate($taxRate) {
+    $this->taxRate = $taxRate;
+  }
+
+  /**
+   * @return float
+   */
+  public function getTaxAmount() {
+    return $this->taxAmount;
+  }
+
+  /**
+   * @param float $taxAmount
+   */
+  public function setTaxAmount($taxAmount) {
+    $this->taxAmount = $taxAmount;
+  }
+
+  /**
+   * @return float
+   */
+  public function getTotalAmount() {
+    return $this->totalAmount;
+  }
+
+  /**
+   * @param float $totalAmount
+   */
+  public function setTotalAmount($totalAmount) {
+    $this->totalAmount = $totalAmount;
+  }
+
+}

--- a/CRM/MembershipExtras/Page/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Page/InstalmentSchedule.php
@@ -1,0 +1,55 @@
+<?php
+use CRM_MembershipExtras_ExtensionUtil as E;
+
+class CRM_MembershipExtras_Page_InstalmentSchedule extends CRM_Core_Page {
+
+  public function run() {
+    $this->assignInstalments();
+    $this->assignCurrencySymbol();
+
+    parent::run();
+  }
+
+  private function assignInstalments() {
+    $startDate = CRM_Utils_Request::retrieve('start_date', 'String');
+    $joinDate = CRM_Utils_Request::retrieve('join_date', 'String');
+    $endDate = CRM_Utils_Request::retrieve('end_date', 'String');
+    $schedule = CRM_Utils_Request::retrieve('schedule', 'String');
+    $membershipTypeId = CRM_Utils_Request::retrieve('membership_type_id', 'Int');
+    $priceFieldValues = CRM_Utils_Request::retrieve('price_field_values', 'String');
+
+    $params = [];
+    $action = 'getbymembershiptype';
+    if (isset($membershipTypeId)) {
+      $params['membership_type_id'] = $membershipTypeId;
+    }
+    elseif (isset($priceFieldValues)) {
+      $params['price_field_values'] = ['IN' => $priceFieldValues];
+      $action = 'getbypricefieldvalues';
+    }
+
+    $params['schedule'] = $schedule;
+    $params['start_date'] = $startDate;
+    $params['join_date'] = $joinDate;
+    $params['end_date'] = $endDate;
+
+    try {
+      $result = civicrm_api3('PaymentSchedule', $action, $params);
+      $this->assign('instalments', $result['values']['instalments']);
+      $this->assign('total_amount', $result['values']['total_amount']);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      $errorResponse = [
+        'is_error' => TRUE,
+        'error_message' => $e->getMessage(),
+      ];
+      CRM_Core_Page_AJAX::returnJsonResponse($errorResponse);
+    }
+  }
+
+  private function assignCurrencySymbol() {
+    $currencySymbol = CRM_Core_BAO_Country::defaultCurrencySymbol();
+    $this->assign('currency_symbol', $currencySymbol);
+  }
+
+}

--- a/CRM/MembershipExtras/Service/MembershipInstalmentTaxAmountCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentTaxAmountCalculator.php
@@ -29,7 +29,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator {
    */
   public function calculateByMembershipType(MembershipType $membershipType, $membershipTypeAmount = NULL) {
     $membershipTypeAmount = $membershipTypeAmount ? $membershipTypeAmount : $membershipType->minimum_fee;
-    $taxRate = CRM_Utils_Array::value($membershipType->financial_type_id, $this->taxRates, 0);
+    $taxRate = $this->getTaxRateByFinancialTypeId($membershipType->financial_type_id);
 
     return $this->calculateTaxAmount($membershipTypeAmount, $taxRate);
   }
@@ -41,9 +41,19 @@ class CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator {
    * @return float|int
    */
   public function calculateByPriceFieldValue(array $priceFieldValue) {
-    $taxRate = CRM_Utils_Array::value($priceFieldValue['financial_type_id'], $this->taxRates, 0);
+    $taxRate = $this->getTaxRateByFinancialTypeId($priceFieldValue['financial_type_id']);
 
     return $this->calculateTaxAmount($priceFieldValue['amount'], $taxRate);
+  }
+
+  /**
+   * Gets Tax Rate by Financial Type Id
+   *
+   * @params int $id
+   * @return float
+   */
+  public function getTaxRateByFinancialTypeId(int $id) {
+    return CRM_Utils_Array::value($id, $this->taxRates, 0);
   }
 
   /**

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodTypeCalculator
+ */
+abstract class CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodTypeCalculator {
+
+  /**
+   * @var float
+   */
+  protected $taxAmount = 0;
+
+  /**
+   * @var float
+   */
+  protected $amount = 0;
+
+  /**
+   * @var array
+   */
+  protected $lineItems = [];
+
+  /**
+   * @var int
+   */
+  protected $quantity = 1;
+
+  /**
+   * @var \CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator
+   */
+  protected $instalmentTaxAmountCalculator;
+
+  /**
+   * @return float
+   */
+  public function getAmount() {
+    return $this->amount;
+  }
+
+  /**
+   * @return float
+   */
+  public function getTaxAmount() {
+    return $this->taxAmount;
+  }
+
+  /**
+   * @return flaot
+   */
+  public function getTotalAmount() {
+    return $this->amount + $this->taxAmount;
+  }
+
+  /**
+   * @return array
+   */
+  public function getLineItems() {
+    return $this->lineItems;
+  }
+
+  /**
+   * Generates line item for each instalment
+   *
+   * @param int $fiancialTypeId
+   * @param float $amount
+   * @param float $taxAmount
+   */
+  protected function generateLineItem(int $fiancialTypeId, float $amount, float $taxAmount) {
+    $subTotal = $amount * $this->quantity;
+    $totalAmount = $subTotal + $taxAmount;
+    $taxRate = $this->instalmentTaxAmountCalculator->getTaxRateByFinancialTypeId($fiancialTypeId);
+    $scheduleInstalmentLineItem = new CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem();
+    $scheduleInstalmentLineItem->setFinancialTypeId($fiancialTypeId);
+    $scheduleInstalmentLineItem->setQuantity($this->quantity);
+    $scheduleInstalmentLineItem->setUnitPrice($amount);
+    $scheduleInstalmentLineItem->setSubTotal($subTotal);
+    $scheduleInstalmentLineItem->setTaxRate($taxRate);
+    $scheduleInstalmentLineItem->setTaxAmount($taxAmount);
+    $scheduleInstalmentLineItem->setTotalAmount($totalAmount);
+    $this->lineItems[] = $scheduleInstalmentLineItem;
+  }
+
+}

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
@@ -1,12 +1,13 @@
 <?php
 
 use CRM_MembershipExtras_Service_MembershipPeriodType_PeriodTypeCalculatorInterface as Calculator;
+use CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodTypeCalculator as PeriodTypeCalculator;
 use CRM_MembershipExtras_Service_MembershipTypeDurationCalculator as MembershipTypeDurationCalculator;
 use CRM_MembershipExtras_Service_MembershipTypeDatesCalculator as MembershipTypeDatesCalculator;
 use CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator as MembershipInstalmentTaxAmountCalculator;
 use CRM_MembershipExtras_Hook_BuildForm_MembershipType_Setting as SettingField;
 
-class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator implements Calculator {
+class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator extends PeriodTypeCalculator implements Calculator {
 
   /**
    * Constants for Annal ProRata Calculation
@@ -19,24 +20,9 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
   const TWELVE_MONTHS = 12;
 
   /**
-   * @var float
-   */
-  private $taxAmount = 0;
-
-  /**
-   * @var float
-   */
-  private $amount = 0;
-
-  /**
    * @var DateTime|null
    */
   private $startDate = NULL;
-
-  /**
-   * @var \CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator
-   */
-  private $instalmentTaxAmountCalculator;
 
   /**
    * @var array
@@ -79,37 +65,15 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
         $duration  = $membershipTypeDurationCalculator->calculateOriginalInDays();
         $diff = $membershipTypeDurationCalculator->calculateDaysBasedOnDates($this->startDate);
       }
-      $this->amount += $this->calculateProRatedAmount($membershipAmount, $duration, $diff);
-      $this->taxAmount += $this->calculateProRatedAmount($taxAmount, $duration, $diff);
+
+      $amount = $this->calculateProRatedAmount($membershipAmount, $duration, $diff);
+      $taxAmount = $this->calculateProRatedAmount($taxAmount, $duration, $diff);
+
+      $this->amount += $amount;
+      $this->taxAmount += $taxAmount;
+
+      $this->generateLineItem($membershipType->financial_type_id, $amount, $taxAmount);
     }
-  }
-
-  /**
-   * @return float
-   */
-  public function getTaxAmount() {
-    return $this->taxAmount;
-  }
-
-  /**
-   * @param float $taxAmount
-   */
-  public function setTaxAmount(float $taxAmount) {
-    $this->taxAmount = $taxAmount;
-  }
-
-  /**
-   * @return float
-   */
-  public function getAmount() {
-    return $this->amount;
-  }
-
-  /**
-   * @param float $amount
-   */
-  public function setAmount(float $amount) {
-    $this->amount = $amount;
   }
 
   /**
@@ -124,13 +88,6 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
    */
   public function setStartDate(DateTime $startDate) {
     $this->startDate = $startDate;
-  }
-
-  /**
-   * @return float|int
-   */
-  public function getTotalAmount() {
-    return $this->amount + $this->taxAmount;
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/RollingPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/RollingPeriodTypeCalculator.php
@@ -1,24 +1,11 @@
 <?php
 
 use CRM_MembershipExtras_Service_MembershipPeriodType_PeriodTypeCalculatorInterface as Calculator;
+use CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodTypeCalculator as PeriodTypeCalculator;
 use CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator as MembershipInstalmentTaxAmountCalculator;
 
-class CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalculator implements Calculator {
+class CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalculator extends PeriodTypeCalculator implements Calculator {
 
-  /**
-   * @var \CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator
-   */
-  private $instalmentTaxAmountCalculator;
-
-  /**
-   * @var float
-   */
-  private $amount = 0;
-
-  /**
-   * @var float
-   */
-  private $taxAmount = 0;
   /**
    * @var array
    */
@@ -36,27 +23,14 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalcula
    */
   public function calculate() {
     foreach ($this->membershipTypes as $membershipType) {
-      $this->amount += $membershipType->minimum_fee;
-      $this->taxAmount += $this->instalmentTaxAmountCalculator->calculateByMembershipType($membershipType, $membershipType->minimum_fee);
+      $amount = $membershipType->minimum_fee;
+      $taxAmount = $this->instalmentTaxAmountCalculator->calculateByMembershipType($membershipType, $membershipType->minimum_fee);
+
+      $this->amount += $amount;
+      $this->taxAmount += $taxAmount;
+
+      $this->generateLineItem($membershipType->financial_type_id, $amount, $taxAmount);
     }
-  }
-
-  /**
-   * @return float
-   */
-  public function getAmount() {
-    return $this->amount;
-  }
-
-  /**
-   * @return float
-   */
-  public function getTaxAmount() {
-    return $this->taxAmount;
-  }
-
-  public function getTotalAmount() {
-    return $this->amount + $this->taxAmount;
   }
 
 }

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -131,29 +131,29 @@
     function generateInstalmentSchedule(isPriceSet) {
       let schedule = $('#payment_plan_schedule').val();
       let params = {
-        "schedule": schedule,
-        "start_date" : $('#start_date').val(),
-        "end_date" : $('#end_date').val(),
-        "join_date" : $('#join_date').val(),
+        schedule: schedule,
+        start_date : $('#start_date').val(),
+        end_date : $('#end_date').val(),
+        join_date : $('#join_date').val(),
       };
-      let apiAction;
       if (isPriceSet) {
         let selectedPriceFieldValues = getSelectedPriceFieldValues();
         if (jQuery.isEmptyObject(selectedPriceFieldValues)) {
           return;
         }
-        params.price_field_values = {'IN' : selectedPriceFieldValues};
-        apiAction = 'getByPriceFieldValues';
+        params.price_field_values = selectedPriceFieldValues;
       } else {
         params.membership_type_id =  parseInt($('#membership_type_id_1').val());;
-        apiAction = 'getByMembershipType';
       }
-      CRM.api3('PaymentSchedule', apiAction, params).then(function(data) {
-        if (data.is_error === 0) {
-          drawTable(data);
-          updateTotalAmount(data.values.total_amount, isPriceSet);
-        } else {
+      let url = CRM.url('civicrm/member/instalment-schedule', params, 'back');
+      CRM.loadPage(url, {
+        target : '#instalment_schedule_table',
+        dialog : false,
+      }).on('crmLoad', function(event, data) {
+        if (data.hasOwnProperty('is_error') && data.is_error == true) {
           CRM.alert(data.error_message, 'Error', 'error');
+        } else {
+          updateTotalAmount($('#instalment-total-amount').html(), isPriceSet);
         }
       });
     }
@@ -218,33 +218,6 @@
       if (isPriceSet) {
         $('#pricevalue').html(currencySymbol + ' ' + CRM.formatMoney(totalAmount, true));
       }
-    }
-
-    /**
-     * Draws instalment table based on given data return from PaymentSchedule API
-     *
-     * @param data
-     */
-    function drawTable(data) {
-      $('#instalment_row_table tbody td').remove();
-      let rows = data.values.instalments;
-      rows.forEach(drawRow);
-    }
-
-    /**
-     * Draws instalment row based given row data
-     *
-     * @param rowData
-     */
-    function drawRow(rowData) {
-      let tbody = $('#instalment_row_table tbody');
-      tbody.append('<tr>');
-      tbody.append('<td>' + rowData.instalment_no + ' </td>');
-      tbody.append('<td>' + rowData.instalment_date + '</td>');
-      tbody.append('<td>' + rowData.instalment_tax_amount + '</td>');
-      tbody.append('<td>' + rowData.instalment_amount + '</td>');
-      tbody.append('<td>' + rowData.instalment_status + '</td>');
-      tbody.append('</tr>');
     }
 
     /**
@@ -338,7 +311,6 @@
     </ul>
   </div>
 </div>
-
 <table id="payment_plan_fields">
   <tr id="payment_plan_schedule_row">
     <td class="label" nowrap>
@@ -351,18 +323,7 @@
   <tr id="payment_plan_schedule_instalment_row">
     <td class="label" nowrap><label>{ts}Instalment Schedule{/ts}</label></td>
     <td>
-        <table id="instalment_row_table" class="selector row-highlight" style="position: relative;">
-          <thead class="sticky">
-          <tr>
-            <th scope="col">{ts}Instalment no{/ts}</th>
-            <th scope="col">{ts}Date{/ts}</th>
-            <th scope="col">{ts}Tax Amount{/ts}</th>
-            <th scope="col">{ts}Total{/ts}</th>
-            <th scope="col">{ts}Status{/ts}</th>
-          </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
+      <div id="instalment_schedule_table"> </div>
     </td>
   </tr>
 </table>

--- a/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
+++ b/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
@@ -1,0 +1,85 @@
+<script type="text/javascript">
+  {literal}
+  CRM.$(function ($) {
+    $(".schedule-row").on('click', function(e) {
+      e.preventDefault();
+      $className = 'expanded';
+      if ($(this).hasClass($className)) {
+        $(this).removeClass($className);
+        $(this).closest('tr').next('tr').hide();
+      } else {
+        $(this).addClass($className);
+        $(this).closest('tr').next('tr').show();
+      }
+    });
+  });
+  {/literal}
+</script>
+
+<table id="instalment_row_table" class="selector row-highlight" style="position: relative;">
+  <thead class="sticky">
+  <tr>
+    <th scope="col"></th>
+    <th scope="col">{ts}Instalment no{/ts}</th>
+    <th scope="col">{ts}Date{/ts}</th>
+    <th scope="col">{ts}Tax Amount{/ts}</th>
+    <th scope="col">{ts}Total{/ts}</th>
+    <th scope="col">{ts}Status{/ts}</th>
+  </tr>
+  </thead>
+  <tbody class="sticky">
+  {foreach from=$instalments item=instalment}
+    <tr>
+      <td><a class="schedule-row nowrap bold crm-expand-row" title="view subitem" href="#">&nbsp</a></td>
+      <td>{$instalment.instalment_no}</td>
+      <td>{$instalment.instalment_date|crmDate}</td>
+      <td>{$currency_symbol}{$instalment.instalment_tax_amount|crmNumberFormat:2}</td>
+      <td>{$currency_symbol}{$instalment.instalment_total_amount|crmNumberFormat:2}</td>
+      <td>
+        {crmAPI var='contribution_status'
+                entity='OptionValue'
+                action='getsingle'
+                sequential=0
+                option_group_id="contribution_status"
+                value=$instalment.instalment_status
+        }
+        {$contribution_status.label}
+      </td>
+    </tr>
+    <tr style="display: none;">
+    <td colspan="6">
+      <table id="instalment_row_sub_table" style="position: relative;">
+        <thead>
+        <th>{ts}Item{/ts}</th>
+        <th>{ts}Financial type{/ts}</th>
+        <th>{ts}Quantity{/ts}</th>
+        <th>{ts}Unit Price{/ts}</th>
+        <th>{ts}Sub total{/ts}</th>
+        <th>{ts}Tax Rate{/ts}</th>
+        <th>{ts}Tax Amount{/ts}</th>
+        <th>{ts}Total Amount{/ts}</th>
+        </thead>
+        <tbody>
+       {foreach from=$instalment.instalment_lineitems item=lineitem}
+         <tr>
+           <td>{$lineitem.item_no}</td>
+           <td>
+             {crmAPI var='result' entity='FinancialType' action='getsingle' sequential=0 return="name" id=$lineitem.financial_type_id}
+             {$result.name}
+           </td>
+           <td>{$lineitem.quantity}</td>
+           <td>{$currency_symbol}{$lineitem.unit_price|crmNumberFormat:2}</td>
+           <td>{$currency_symbol}{$lineitem.sub_total|crmNumberFormat:2}</td>
+           <td>{$lineitem.tax_rate|crmNumberFormat:2}%</td>
+           <td>{$currency_symbol}{$lineitem.tax_amount|crmNumberFormat:2}</td>
+           <td>{$currency_symbol}{$lineitem.total_amount|crmNumberFormat:2}</td>
+         </tr>
+       {/foreach}
+        </tbody>
+      </table>
+    </td>
+    </tr>
+  {/foreach}
+  </tbody>
+</table>
+<div id="instalment-total-amount" style="display: none;">{$total_amount}</div>

--- a/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/MembershipTypeTest.php
@@ -82,14 +82,25 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
   public function testFormatInstalments() {
     $paymentSchedule = $this->mockRollingMembershipTypeSchedule(Schedule::ANNUAL);
     $schedule = $paymentSchedule->getPaymentSchedule();
-    $pendingStatusLabel = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'option_group_id' => "contribution_status",
-      'name' => "pending",
-    ])['values'][0]['label'];
     $paymentSchedule->formatInstalments($schedule['instalments']);
     foreach ($schedule['instalments'] as $formattedInstalment) {
-      $this->assertEquals($pendingStatusLabel, $formattedInstalment['instalment_status']);
+      $this->assertArrayHasKey('instalment_no', $formattedInstalment);
+      $this->assertArrayHasKey('instalment_date', $formattedInstalment);
+      $this->assertArrayHasKey('instalment_tax_amount', $formattedInstalment);
+      $this->assertArrayHasKey('instalment_amount', $formattedInstalment);
+      $this->assertArrayHasKey('instalment_total_amount', $formattedInstalment);
+      $this->assertArrayHasKey('instalment_status', $formattedInstalment);
+      $this->assertArrayHasKey('instalment_lineitems', $formattedInstalment);
+      foreach ($formattedInstalment['instalment_lineitems'] as $lineitem) {
+        $this->assertArrayHasKey('item_no', $lineitem);
+        $this->assertArrayHasKey('financial_type_id', $lineitem);
+        $this->assertArrayHasKey('quantity', $lineitem);
+        $this->assertArrayHasKey('unit_price', $lineitem);
+        $this->assertArrayHasKey('sub_total', $lineitem);
+        $this->assertArrayHasKey('tax_rate', $lineitem);
+        $this->assertArrayHasKey('tax_amount', $lineitem);
+        $this->assertArrayHasKey('total_amount', $lineitem);
+      }
     }
   }
 

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
@@ -141,6 +141,19 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     foreach ($schedule['instalments'] as $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
+      $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
+      foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
+        $membershipFee = $membershipTypes[$key]->minimum_fee;
+        $expectedLineItemAmount = $this->calculateExpectedLineItemAmount($membershipFee, $monthlyInstalmentCount);
+        $expectedLineItemTaxAmount = $this->calculateExpectedTaxAmount($expectedLineItemAmount);
+        $expectedLineItemTotalAmount = $expectedLineItemAmount + $expectedLineItemTaxAmount;
+        $this->assertEquals(1, $lineItem->getQuantity());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getUnitPrice());
+        $this->assertEquals(self::TAX_RATE, $lineItem->getTaxRate());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getSubTotal());
+        $this->assertEquals($expectedLineItemTaxAmount, $lineItem->getTaxAmount());
+        $this->assertEquals($expectedLineItemTotalAmount, $lineItem->getTotalAmount());
+      }
     }
   }
 
@@ -155,16 +168,29 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $membershipTypes = $this->mockRollingMembershipTypes();
     $schedule = $this->getMembershipSchedule($membershipTypes, MembershipInstalmentsSchedule::QUARTERLY);
 
-    $this->assertCount(4, $schedule['instalments']);
+    $expectedCount = 4;
+    $this->assertCount($expectedCount, $schedule['instalments']);
 
-    $expectedAmount = $this->calculateExpectedAmount($membershipTypes, 4);
+    $expectedAmount = $this->calculateExpectedAmount($membershipTypes, $expectedCount);
     $expectedTaxAmount = $this->calculateExpectedTaxAmount($expectedAmount);
 
     foreach ($schedule['instalments'] as $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
+      $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
+      foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
+        $membershipFee = $membershipTypes[$key]->minimum_fee;
+        $expectedLineItemAmount = $this->calculateExpectedLineItemAmount($membershipFee, $expectedCount);
+        $expectedLineItemTaxAmount = $this->calculateExpectedTaxAmount($expectedLineItemAmount);
+        $expectedLineItemTotalAmount = $expectedLineItemAmount + $expectedLineItemTaxAmount;
+        $this->assertEquals(1, $lineItem->getQuantity());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getUnitPrice());
+        $this->assertEquals(self::TAX_RATE, $lineItem->getTaxRate());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getSubTotal());
+        $this->assertEquals($expectedLineItemTaxAmount, $lineItem->getTaxAmount());
+        $this->assertEquals($expectedLineItemTotalAmount, $lineItem->getTotalAmount());
+      }
     }
-
   }
 
   /**
@@ -185,11 +211,26 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $diffInMonth = $membershipTypeDurationCalculator->calculateMonthsBasedOnDates($startDate);
     $this->assertCount($diffInMonth, $schedule['instalments']);
 
-    $expectedAmount = $this->calculateExpectedAmount($membershipTypes, 12);
+    $divisor = 12;
+    $expectedAmount = $this->calculateExpectedAmount($membershipTypes, $divisor);
     $expectedTaxAmount = $this->calculateExpectedTaxAmount($expectedAmount);
+    $expectedTotalAmount = $expectedAmount + $expectedTaxAmount;
     foreach ($schedule['instalments'] as $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
+      $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
+      foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
+        $membershipFee = $membershipTypes[$key]->minimum_fee;
+        $expectedLineItemAmount = $this->calculateExpectedLineItemAmount($membershipFee, $divisor);
+        $expectedLineItemTaxAmount = $this->calculateExpectedTaxAmount($expectedLineItemAmount);
+        $expectedLineItemTotalAmount = $expectedLineItemAmount + $expectedLineItemTaxAmount;
+        $this->assertEquals(1, $lineItem->getQuantity());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getUnitPrice());
+        $this->assertEquals(self::TAX_RATE, $lineItem->getTaxRate());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getSubTotal());
+        $this->assertEquals($expectedLineItemTaxAmount, $lineItem->getTaxAmount());
+        $this->assertEquals($expectedLineItemTotalAmount, $lineItem->getTotalAmount());
+      }
     }
   }
 
@@ -203,13 +244,28 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $membershipTypes = $this->mockRollingMembershipTypes();
     $schedule = $this->getMembershipSchedule($membershipTypes, MembershipInstalmentsSchedule::ANNUAL);
 
-    $this->assertCount(1, $schedule['instalments']);
+    $expectedCount = 1;
+    $this->assertCount($expectedCount, $schedule['instalments']);
 
-    $expectedAmount = $this->calculateExpectedAmount($membershipTypes, 1);
+    $expectedAmount = $this->calculateExpectedAmount($membershipTypes, $expectedCount);
     $expectedTaxAmount = $this->calculateExpectedTaxAmount($expectedAmount);
 
-    $this->assertEquals($expectedAmount, $schedule['instalments'][0]->getInstalmentAmount()->getAmount());
-    $this->assertEquals($expectedTaxAmount, $schedule['instalments'][0]->getInstalmentAmount()->getTaxAmount());
+    $instalment = $schedule['instalments'][0];
+    $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
+    $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
+    $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
+    foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
+      $membershipFee = $membershipTypes[$key]->minimum_fee;
+      $expectedLineItemAmount = $this->calculateExpectedLineItemAmount($membershipFee, $expectedCount);
+      $expectedLineItemTaxAmount = $this->calculateExpectedTaxAmount($expectedLineItemAmount);
+      $expectedLineItemTotalAmount = $expectedLineItemAmount + $expectedLineItemTaxAmount;
+      $this->assertEquals(1, $lineItem->getQuantity());
+      $this->assertEquals($expectedLineItemAmount, $lineItem->getUnitPrice());
+      $this->assertEquals(self::TAX_RATE, $lineItem->getTaxRate());
+      $this->assertEquals($expectedLineItemAmount, $lineItem->getSubTotal());
+      $this->assertEquals($expectedLineItemTaxAmount, $lineItem->getTaxAmount());
+      $this->assertEquals($expectedLineItemTotalAmount, $lineItem->getTotalAmount());
+    }
   }
 
   /**
@@ -228,9 +284,19 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
 
     $expectedAmount = $this->calculateExpectedAmount($membershipTypes, 12, $diffInMonths);
     $expectedTaxAmount = $this->calculateExpectedTaxAmount($expectedAmount);
+    $expectedTotalAmount = $expectedAmount + $expectedTaxAmount;
+    $instalment = $schedule['instalments'][0];
+    $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
+    $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
+    $this->assertCount(1, $instalment->getInstalmentAmount()->getLineItems());
+    $lineItem = $instalment->getInstalmentAmount()->getLineItems()[0];
+    $this->assertEquals(1, $lineItem->getQuantity());
+    $this->assertEquals($expectedAmount, $lineItem->getUnitPrice());
+    $this->assertEquals(self::TAX_RATE, $lineItem->getTaxRate());
+    $this->assertEquals($expectedAmount, $lineItem->getSubTotal());
+    $this->assertEquals($expectedTaxAmount, $lineItem->getTaxAmount());
+    $this->assertEquals($expectedTotalAmount, $lineItem->getTotalAmount());
 
-    $this->assertEquals($expectedAmount, $schedule['instalments'][0]->getInstalmentAmount()->getAmount());
-    $this->assertEquals($expectedTaxAmount, $schedule['instalments'][0]->getInstalmentAmount()->getTaxAmount());
   }
 
   /**
@@ -313,6 +379,17 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     foreach ($schedule['instalments'] as $index => $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals(0, $instalment->getInstalmentAmount()->getTaxAmount());
+      $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
+      foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
+        $membershipFee = $membershipTypes[$key]->minimum_fee;
+        $expectedLineItemAmount = $this->calculateExpectedLineItemAmount($membershipFee, 12);
+        $this->assertEquals(1, $lineItem->getQuantity());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getUnitPrice());
+        $this->assertEquals(0, $lineItem->getTaxRate());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getSubTotal());
+        $this->assertEquals(0, $lineItem->getTaxAmount());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getTotalAmount());
+      }
     }
   }
 
@@ -337,6 +414,19 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $expectedTaxAmount = ($totalAmount * self::TAX_RATE / 100) / 12;
     foreach ($schedule['instalments'] as $index => $instalment) {
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
+      $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
+      foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
+        $membershipFee = $membershipTypes[$key]->minimum_fee;
+        $expectedLineItemAmount = $this->calculateExpectedLineItemAmount($membershipFee, 12);
+        $expectedLineItemTaxAmount = $this->calculateExpectedTaxAmount($expectedLineItemAmount);
+        $expectedLineItemTotalAmount = $expectedLineItemAmount + $expectedLineItemTaxAmount;
+        $this->assertEquals(1, $lineItem->getQuantity());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getUnitPrice());
+        $this->assertEquals(self::TAX_RATE, $lineItem->getTaxRate());
+        $this->assertEquals($expectedLineItemAmount, $lineItem->getSubTotal());
+        $this->assertEquals($expectedLineItemTaxAmount, $lineItem->getTaxAmount());
+        $this->assertEquals($expectedLineItemTotalAmount, $lineItem->getTotalAmount());
+      }
     }
   }
 
@@ -376,20 +466,53 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
       new DateTime($membershipTypeDates['join_date'])
     );
 
-    $totalNonMembershipPriceFieldValueAmount = 0;
+    $totalUnitPrice = 0;
     foreach ($nonMembershipPriceFieldValues as $priceFieldValue) {
-      $totalNonMembershipPriceFieldValueAmount = +$priceFieldValue['values']['amount'];
+      $totalUnitPrice = +$priceFieldValue['values']['amount'];
     }
-    $totalNonMembershipPriceFieldValueTaxAmount = $totalNonMembershipPriceFieldValueAmount * self::TAX_RATE / 100;
-    $totalNonMembershipPriceFieldValueAmount *= $mockedQuantity;
+    $totalNonMembershipPriceFieldValueTaxAmount = $totalUnitPrice * self::TAX_RATE / 100;
     $totalNonMembershipPriceFieldValueTaxAmount *= $mockedQuantity;
+    $totalNonMembershipPriceFieldValueAmount  = $totalUnitPrice * $mockedQuantity;
+    $totalNonMembershipPriceFieldValueTotal = $totalNonMembershipPriceFieldValueTaxAmount + $totalNonMembershipPriceFieldValueAmount;
 
-    $expectedAmount = ($totalAmount + $totalNonMembershipPriceFieldValueAmount) / 12;
-    $expectedTaxAmount = ($taxAmount + $totalNonMembershipPriceFieldValueTaxAmount) / 12;
+    $mockInstalmentNumber = 12;
+    $expectedAmount = ($totalAmount + $totalNonMembershipPriceFieldValueAmount) / $mockInstalmentNumber;
+    $expectedTaxAmount = ($taxAmount + $totalNonMembershipPriceFieldValueTaxAmount) / $mockInstalmentNumber;
 
     foreach ($schedule['instalments'] as $index => $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
+      //Membership type array size = 1 and none membership price field size = 1
+      $this->assertCount(2, $instalment->getInstalmentAmount()->getLineItems());
+
+      //Asserting membership type line item
+      $membershipFee = $membershipTypes[0]->minimum_fee;
+      $membershipTypeLineItem = $instalment->getInstalmentAmount()->getLineItems()[0];
+      $expectedLineItemAmount = $this->calculateExpectedLineItemAmount($membershipFee, $mockInstalmentNumber);
+      $expectedLineItemTaxAmount = $this->calculateExpectedTaxAmount($expectedLineItemAmount);
+      $expectedLineItemTotalAmount = $expectedLineItemAmount + $expectedLineItemTaxAmount;
+      $this->assertEquals(1, $membershipTypeLineItem->getQuantity());
+      $this->assertEquals($expectedLineItemAmount, $membershipTypeLineItem->getUnitPrice());
+      $this->assertEquals(self::TAX_RATE, $membershipTypeLineItem->getTaxRate());
+      $this->assertEquals($expectedLineItemAmount, $membershipTypeLineItem->getSubTotal());
+      $this->assertEquals($expectedLineItemTaxAmount, $membershipTypeLineItem->getTaxAmount());
+      $this->assertEquals($expectedLineItemTotalAmount, $membershipTypeLineItem->getTotalAmount());
+
+      //Asserting non membership type line item
+      $noneMembershipTypeLineItem = $instalment->getInstalmentAmount()->getLineItems()[1];
+      $this->assertEquals($mockedQuantity, $noneMembershipTypeLineItem->getQuantity());
+
+      $expectedUnitPrice = $totalUnitPrice / $mockInstalmentNumber;
+      $expectedNonMembershipSubTotalLineItem = ($totalUnitPrice * $mockedQuantity) / $mockInstalmentNumber;
+      $expectedNonMembershipTaxAmountLineItem = $this->calculateExpectedTaxAmount($expectedNonMembershipSubTotalLineItem);
+      $expectedNonMembershipTotalAmountLineItem = $expectedNonMembershipSubTotalLineItem + $expectedNonMembershipTaxAmountLineItem;
+
+      $this->assertEquals($expectedUnitPrice, $noneMembershipTypeLineItem->getUnitPrice());
+      $this->assertEquals(self::TAX_RATE, $noneMembershipTypeLineItem->getTaxRate());
+      $this->assertEquals($expectedNonMembershipSubTotalLineItem, $noneMembershipTypeLineItem->getSubTotal());
+      $this->assertEquals($expectedNonMembershipTaxAmountLineItem, $noneMembershipTypeLineItem->getTaxAmount());
+      $this->assertEquals($expectedNonMembershipTotalAmountLineItem, $noneMembershipTypeLineItem->getTotalAmount());
+
     }
   }
 
@@ -683,6 +806,10 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     foreach ($membershipTypes as $membershipType) {
       $amount += $membershipType->minimum_fee;
     }
+    return ($amount / $divisor) * $diff;
+  }
+
+  private function calculateExpectedLineItemAmount($amount, $divisor, $diff = 1) {
     return ($amount / $divisor) * $diff;
   }
 

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -60,4 +60,10 @@
     <title>Cancel Recurring Contribution</title>
     <access_arguments>edit contributions</access_arguments>
   </item>
+  <item>
+    <path>civicrm/member/instalment-schedule</path>
+    <page_callback>CRM_MembershipExtras_Page_InstalmentSchedule</page_callback>
+    <title>InstalmentSchedule</title>
+    <access_arguments>edit memberships</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview

Total amount and tax amount on currently screen is confusing.  This PR adds line item(s) as sub table on each instalment to visualize financial type, quantity, unit price, sub total, tax amount as total amount similar to CiviCRM contribution line item. 

Line items table works with 

- Rolling membership type
- Fixed period membership type
- Price set with membership type
- Price set with none membership type 

## Before

![Peek 2021-03-04 10-27](https://user-images.githubusercontent.com/208713/109950259-3dff8900-7cd4-11eb-8ce6-4bdca458da85.gif)

## After

![Peek 2021-03-04 10-16](https://user-images.githubusercontent.com/208713/109949765-a863f980-7cd3-11eb-96d1-1ae54dfd8032.gif)

## Technical Details

Previously, the instalments display was generated each time by rewriting DOM, this method was expensive especially when we need to rewrite the DOM with nested table each time and the display is not reusable.  

Since, we need a complex table for displaying instalments, the CiviCRM page for displaying the content is created and the membership form is loading the instalments table by using [CRM.loadPage()](https://docs.civicrm.org/dev/en/latest/framework/ajax/#crmloadpageurl-options) function that provided by CiviCRM to inject the page into the membership form. This method is widely used in CiviCRM in many pages.  

Finally, we have also changed the way to display instalments schedule, the API format has also been updated to remove formatting like currency symbol, status label, so the API will return raw data and the page will handle the display format. This way makes the API result more flexible to reuse in other systems or a module like webform.  