### PR TITLE
MAE-474: Auto filling membership end date

### DIFF
--- a/CRM/MembershipExtras/Page/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Page/InstalmentSchedule.php
@@ -37,6 +37,8 @@ class CRM_MembershipExtras_Page_InstalmentSchedule extends CRM_Core_Page {
       $result = civicrm_api3('PaymentSchedule', $action, $params);
       $this->assign('instalments', $result['values']['instalments']);
       $this->assign('total_amount', $result['values']['total_amount']);
+      $this->assign('membership_start_date', $result['values']['membership_start_date']);
+      $this->assign('membership_end_date', $result['values']['membership_end_date']);
     }
     catch (CiviCRM_API3_Exception $e) {
       $errorResponse = [

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -122,6 +122,8 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
     }
 
     $instalments['total_amount'] = $this->getInstalmentsTotalAmount($instalments['instalments']);
+    $instalments['membership_start_date'] = $this->startDate->format('Y-m-d');
+    $instalments['membership_end_date'] = $this->endDate->format('Y-m-d');
 
     return $instalments;
   }

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -154,6 +154,7 @@
           CRM.alert(data.error_message, 'Error', 'error');
         } else {
           updateTotalAmount($('#instalment-total-amount').html(), isPriceSet);
+          setMembershipEndDate($('#instalment-membership-end-date').html());
         }
       });
     }
@@ -208,6 +209,14 @@
       }else {
         delete selectedPriceFieldValues[priceFieldId];
       }
+    }
+
+    /**
+     * Sets membership end date
+     */
+    function setMembershipEndDate($date) {
+      $('#end_date').val($date);
+      $('#end_date').next('.hasDatepicker').datepicker('setDate', new Date($date));
     }
 
     /**

--- a/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
+++ b/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
@@ -83,3 +83,5 @@
   </tbody>
 </table>
 <div id="instalment-total-amount" style="display: none;">{$total_amount}</div>
+<div id="instalment-membership-start-date" style="display: none;">{$membership_start_date}</div>
+<div id="instalment-membership-end-date" style="display: none;">{$membership_end_date}</div>


### PR DESCRIPTION
## Overview

This PR adds functionality to autofilling membership end date when select start date when using payment plan. 

## Before

Membership end date was set automatically on the user interface but only set when after the form is submitted if the user did not input the end date based on membership type configuration. 

![Peek 2021-03-09 09-26](https://user-images.githubusercontent.com/208713/110448958-99a58a00-80b9-11eb-8c4c-5cdfa864650f.gif)

## After

Membership end date will be filled automatically when enter start date and using payment plan.

![Peek 2021-03-09 09-25](https://user-images.githubusercontent.com/208713/110448948-97dbc680-80b9-11eb-8f12-164af693506b.gif)

