### PR TITLE
MAE-492: Fix membership end date after CiviCRM 5.35 update

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -30,6 +30,15 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
   private $paymentContributionID;
 
   /**
+   * The payment type e.g. refund or owed
+   *
+   * see CRM_Contribute_Form_AdditionalPayment::getPaymentType
+   *
+   * @var string
+   */
+  private $paymentType;
+
+  /**
    * We don't want to extend the same membership
    * more than one time if for whatever reason
    * this hook get called more than one time
@@ -41,10 +50,11 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    */
   private static $extendedMemberships = [];
 
-  public function __construct($id, &$params, $contributionID) {
+  public function __construct($id, &$params, $contributionID, $paymentType) {
     $this->id = $id;
     $this->params = &$params;
     $this->paymentContributionID = $contributionID;
+    $this->paymentType = $paymentType;
   }
 
   /**
@@ -86,7 +96,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
       $contributionId = $paymentRecordingDetails['id'];
     }
 
-    $isRecordPayment = CRM_Utils_Request::retrieve('_qf_AdditionalPayment_upload', 'String') === 'Record Payment';
+    $isRecordPayment = $this->paymentType === 'owed';
 
     if ($isAddAction && $contributionId && $isRecordPayment) {
       $this->paymentContributionID = $contributionId;

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -177,7 +177,8 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   }
 
   if ($objectName === 'Membership' && $op == 'edit') {
-    $membershipPreHook = new CRM_MembershipExtras_Hook_Pre_MembershipEdit($id, $params, $contributionID);
+    $paymentType = Civi::$statics[E::LONG_NAME]['paymentType'] ?? '';
+    $membershipPreHook = new CRM_MembershipExtras_Hook_Pre_MembershipEdit($id, $params, $contributionID, $paymentType);
     $membershipPreHook->preProcess();
   }
 
@@ -333,6 +334,10 @@ function membershipextras_civicrm_buildForm($formName, &$form) {
   if ($formName === 'CRM_Contribute_Form_Contribution') {
     $membershipTypeHook = new CRM_MembershipExtras_Hook_BuildForm_ContributionEdit();
     $membershipTypeHook->buildForm();
+  }
+
+  if ($formName == 'CRM_Contribute_Form_AdditionalPayment') {
+    Civi::$statics[E::LONG_NAME]['paymentType'] = $form->getVar('_paymentType');
   }
 }
 

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
@@ -113,8 +113,9 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
     $membershipParams = array_shift($memberships);
     $membershipParams['end_date'] = date('Y-m-d');
+    $paymentType = 'owed';
 
-    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id']);
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id'], $paymentType);
     $hook->preProcess();
 
     $this->assertTrue(!isset($membership['end_date']));
@@ -134,13 +135,13 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
     $membershipParams = array_shift($memberships);
     $membershipParams['end_date'] = date('Y-m-d');
+    $paymentType = 'owed';
 
     $tmpGlobals = [];
     $tmpGlobals['_REQUEST']['entryURL'] = 'action=add&id=' . $contributions[0]['id'];
-    $tmpGlobals['_REQUEST']['_qf_AdditionalPayment_upload'] = 'Record Payment';
     CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
 
-    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL);
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL, $paymentType);
     $hook->preProcess();
 
     $this->assertTrue(!isset($membership['end_date']));
@@ -160,6 +161,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
     $membershipParams = array_shift($memberships);
     $membershipParams['end_date'] = date('Y-m-d');
+    $paymentType = 'owed';
 
     $tmpGlobals = [];
     $tmpGlobals['_REQUEST']['q'] = 'civicrm/contribute/search';
@@ -167,7 +169,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $tmpGlobals['_REQUEST']['contribution_status_id'] = '1';
     CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
 
-    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL);
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL, $paymentType);
     $hook->preProcess();
 
     $this->assertTrue(!isset($membership['end_date']));
@@ -220,7 +222,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
 
     $newEndDate = date('Y-m-d', strtotime($membership['end_date'] . '+2 years'));
     $membership['end_date'] = $newEndDate;
-    $hook = new MembershipEditHook($membership['id'], $membership, $payment['id']);
+    $paymentType = 'owed';
+    $hook = new MembershipEditHook($membership['id'], $membership, $payment['id'], $paymentType);
     $hook->preProcess();
 
     $this->assertEquals($newEndDate, $membership['end_date']);
@@ -240,6 +243,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
     $membershipParams = array_shift($memberships);
     $membershipEndDate = $membershipParams['end_date'];
+    $paymentType = 'owed';
 
     $tmpGlobals = [];
     $tmpGlobals['_REQUEST']['action'] = CRM_Core_Action::RENEW;
@@ -253,7 +257,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $tmpGlobals['_REQUEST']['contribution_type_toggle'] = 'payment_plan';
     CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
 
-    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id']);
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id'], $paymentType);
     $hook->preProcess();
 
     $this->assertEquals(
@@ -279,6 +283,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
     $membershipParams = array_shift($memberships);
     $membershipEndDate = $membershipParams['end_date'];
+    $paymentType = 'owed';
 
     $tmpGlobals['_REQUEST']['action'] = CRM_Core_Action::RENEW;
     $tmpGlobals['_REQUEST']['contribution_status_id'] = civicrm_api3('OptionValue', 'getvalue', [
@@ -291,7 +296,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $tmpGlobals['_REQUEST']['contribution_type_toggle'] = 'payment_plan';
     CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
 
-    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id']);
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id'], $paymentType);
     $hook->preProcess();
 
     $this->assertEquals(
@@ -316,8 +321,9 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $membershipParams = array_shift($memberships);
     $originalStartDate = $membershipParams['start_date'];
     $membershipParams['start_date'] = date('Y-m-d', strtotime('+1000 years'));
+    $paymentType = 'owed';
 
-    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id']);
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id'], $paymentType);
     $hook->preProcess();
 
     $this->assertEquals($originalStartDate, $membershipParams['start_date']);


### PR DESCRIPTION
## Overview
After updating to CiviCRM 5.35, If we created a payment plan membership with pending status, we found out that the end date will increase each time we recorded a new payment.

## Before
Recording a new payment **will increase** the membership end date.
![Peek 2021-03-12 21-12](https://user-images.githubusercontent.com/74309109/110987424-bbcc3000-8377-11eb-8119-39b79b862ae5.gif)

## After
Recording a new payment **will not increase** the membership end date.
![Peek 2021-03-12 20-47](https://user-images.githubusercontent.com/74309109/110987588-f930bd80-8377-11eb-97f5-7c8a61532a23.gif)

## Technical Details
This PR https://github.com/civicrm/civicrm-core/pull/18410  to CiviCRM core has the [following change](https://github.com/civicrm/civicrm-core/pull/18410/commits/cbd83ddebb3c7e88157f90905c4ac63bf5214c44) : 

```diff
- $prevnext[] = $this->createElement('submit', $buttonName, $button['name'], $attrs);
+ $attrs['type'] = 'submit';
+ $prevnext[] = $this->createElement('xbutton', $buttonName, $button['name'], $attrs);
```

Instead of creating a button with the value "Record Payment" like this
```html
<input class="crm-form-submit default validate" onclick="return verify( );" crm-icon="fa-check" name="_qf_AdditionalPayment_upload" value="Record Payment" type="submit" id="_qf_AdditionalPayment_upload">
```

It will create a button with the value "1" like this
```html
<button class="crm-form-submit default validate crm-button crm-button-type-upload crm-button_qf_AdditionalPayment_upload" onclick="return verify( );" value="1" type="submit" name="_qf_AdditionalPayment_upload" id="_qf_AdditionalPayment_upload"><i aria-hidden="true" class="crm-i fa-check"></i> Record Payment</button>
```

And the condition [here](https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/7acc3dadd384d03e1d7c4d32313a0715db64b776/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php#L89) will be false
```php
$isRecordPayment = CRM_Utils_Request::retrieve('_qf_AdditionalPayment_upload', 'String') === 'Record Payment';
```

The main point is to figure out if the submitted form is a record payment submission or refund submission and we can do that by checking the the variable `_paymentType` in the `AdditionalPayment` Form class and prepare it for `MembershipEdit` class.


## Comments
Another potential solution is to alter the button attributes and inject the value "Record Payment" again like this

```php
/**
 * Implements hook_civicrm_buildForm().
 */
function membershipextras_civicrm_buildForm($formName, &$form) {
  if ($formName == 'CRM_Contribute_Form_AdditionalPayment') {
    $buttons = $form->getElement('buttons');
    $elements = $buttons->getElements();
    $elements[0]->setValue("Record Payment");
  }
}
```