### PR TITLE
MAE-499: Fix Update Recurring Contribution's confirm dialogue button

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -54,12 +54,16 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
     if (!$isManualPaymentPlan) {
       return;
     }
+    $this->addElements();
+    $this->addTemplates();
+  }
 
+  private function addElements() {
     $amount = $this->form->getElement('amount');
-    $amount->setAttribute('readonly', true);
+    $amount->setAttribute('readonly', TRUE);
 
     $installments = $this->form->getElement('installments');
-    $installments->setAttribute('readonly', true);
+    $installments->setAttribute('readonly', TRUE);
 
     $this->form->add('checkbox', 'auto_renew', ts('Auto-renew?'));
     $this->form->setDefaults(['auto_renew' => $this->recurringContribution['auto_renew']]);
@@ -75,22 +79,24 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
     $this->form->add('text', 'cycle_day', ts('Cycle Day'), TRUE);
     $this->form->setDefaults(['cycle_day' => $this->recurringContribution['cycle_day']]);
 
-    CRM_Core_Region::instance('page-body')->add([
-      'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl"
-    ]);
-
     $this->form->addButtons([
       [
         'type' => 'upload',
         'name' => ts('Confirm'),
         'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
         'isDefault' => TRUE,
-        'js' => ['onclick' => "return processUpdate(this,'" . $this->form->getName() . "','" . ts('Processing') . "');"],
+        'js' => ['onclick' => "return processUpdate(event);"],
       ],
       [
         'type' => 'cancel',
         'name' => ts('Cancel'),
       ],
+    ]);
+  }
+
+  private function addTemplates() {
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$this->templatePath}/CRM/Member/Form/UpdateSubscriptionModifications.tpl",
     ]);
   }
 

--- a/js/UpdateSubscriptionModifications.js
+++ b/js/UpdateSubscriptionModifications.js
@@ -1,0 +1,51 @@
+CRM.$(function ($) {
+  var formLayoutTable = $('#UpdateSubscription table.form-layout');
+
+  $('#additional_fields tr').each(function () {
+    formLayoutTable.append($(this));
+  });
+
+  $('#payment_instrument_id').trigger('change');
+});
+
+function isPaymentMethodChanged() {
+  return CRM.$('#old_payment_instrument_id').val() != CRM.$('#payment_instrument_id').val();
+}
+
+function isCycleDayChanged() {
+  return CRM.$('#old_cycle_day').val() != CRM.$('#cycle_day').val();
+}
+
+function processUpdate(event) {
+  if (!isPaymentMethodChanged() && !isCycleDayChanged()) {
+    return true;
+  }
+  event.preventDefault();
+  CRM.$('#confirmInstallmentsUpdate').dialog({
+    modal: true, title: ts('Update Recurring Contribution'), zIndex: 10000, autoOpen: true,
+    width: 'auto', resizable: false,
+    buttons: [{
+      text: ts('Yes'),
+      click: function () {
+        disableConfirmButton();
+        CRM.$('#update_installments').val(1);
+        CRM.$('#UpdateSubscription').unbind();
+        CRM.$('#UpdateSubscription').submit();
+        CRM.$(this).dialog("close");
+      },
+    }, {
+      text: ts('No'),
+      click: function () {
+        CRM.$(this).dialog("close");
+      }
+    }],
+    close: function (event, ui) {
+      CRM.$(this).dialog("close");
+    }
+  });
+}
+
+function disableConfirmButton() {
+  CRM.$('button[data-identifier="_qf_UpdateSubscription_upload"]').attr("disabled", true);
+  CRM.$('button[data-identifier="_qf_UpdateSubscription_upload"]').html(ts('Processing') + '...');
+}

--- a/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
+++ b/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
@@ -1,55 +1,5 @@
 {include file="CRM/common/paymentBlock.tpl"}
-<script type="text/javascript">
-  {literal}
-  CRM.$(function($) {
-    var formLayoutTable = $('#UpdateSubscription table.form-layout');
-
-    $('#additional_fields tr').each(function () {
-      formLayoutTable.append($(this));
-    });
-
-    $('#payment_instrument_id').trigger('change');
-  });
-
-  function processUpdate(buttonObj, formName, onClickLabel) {
-    var showConfirmationDialog = false;
-
-    if (CRM.$('#old_payment_instrument_id').val() != CRM.$('#payment_instrument_id').val()) {
-      showConfirmationDialog = true;
-    }
-
-    if (CRM.$('#old_cycle_day').val() != CRM.$('#cycle_day').val()) {
-      showConfirmationDialog = true;
-    }
-
-    if (showConfirmationDialog) {
-      CRM.$('#confirmInstallmentsUpdate').dialog({
-        modal: true, title: 'Update Recurring Contribution', zIndex: 10000, autoOpen: true,
-        width: 'auto', resizable: false,
-        buttons: {
-          Yes: function () {
-            CRM.$('#update_installments').val(1);
-            submitOnce(buttonObj, formName, onClickLabel);
-            CRM.$(this).dialog("close");
-          },
-          No: function () {
-            submitOnce(buttonObj, formName, onClickLabel);
-            CRM.$(this).dialog("close");
-          }
-        },
-        close: function (event, ui) {
-          CRM.$(this).dialog("close");
-        }
-      });
-    } else {
-      return submitOnce(buttonObj, formName, onClickLabel);
-    }
-
-    return false;
-  }
-  {/literal}
-</script>
-
+{crmScript ext=uk.co.compucorp.membershipextras file=js/UpdateSubscriptionModifications.js}
 <table id="additional_fields">
   <tr id="payment_instrument_id_field">
     <td class="label">
@@ -57,8 +7,9 @@
     </td>
     <td>
       {$form.payment_instrument_id.html}
-      <input type="hidden" name="old_payment_instrument_id" id="old_payment_instrument_id" value="{$form.payment_instrument_id.value.0}" />
-      <input type="hidden" name="update_installments" id="update_installments" value="0" />
+      <input type="hidden" name="old_payment_instrument_id" id="old_payment_instrument_id"
+             value="{$form.payment_instrument_id.value.0}"/>
+      <input type="hidden" name="update_installments" id="update_installments" value="0"/>
     </td>
   </tr>
   <tr id="cycle_day_field">
@@ -67,7 +18,7 @@
     </td>
     <td>
       {$form.cycle_day.html}
-      <input type="hidden" name="old_cycle_day" id="old_cycle_day" value="{$form.cycle_day.value}" />
+      <input type="hidden" name="old_cycle_day" id="old_cycle_day" value="{$form.cycle_day.value}"/>
     </td>
   </tr>
   <tr id="autorenew_field">
@@ -85,9 +36,8 @@
   </tr>
 </table>
 <div id="confirmInstallmentsUpdate" style="display: none;">
-  <table>
-    <tr>
-      <td>{ts}Do you want to update any outstanding instalment contribution with the new Payment Method/ Cycle Day?{/ts}</td>
-    </tr>
-  </table>
+  <div class="messages status no-popup">
+    <i aria-hidden="true" class="crm-i fa-info-circle"></i>{ts}Do you want to update any outstanding instalment
+      contribution with the new Payment Method or Cycle Day?{/ts}
+  </div>
 </div>


### PR DESCRIPTION
## Overview

On Update Recurring Contribution confirmation dialogue, the button relies on submotOnce function provided by CiviCRM and the function has been removed from CiviCRM Core since version 5.31.0. The PR that updated in the CiviCRM core can be found [here](https://github.com/civicrm/civicrm-core/pull/18410)  and the actual commit [here](https://github.com/civicrm/civicrm-core/pull/18410/commits/f3ec70ebde50948d984632cc83c3425f833f48ca
)  

Since the submotOnce() function was removed, the error is presented when clicked we clicked Yes on the confirmation dialogue.  

This PR fixes that.

This PR also improves the display box to include a warning colour similar to what CiviCRM core does for consistency as well as refactors the code to improve readability of the code and separate js file from the template.

## Before

![Screenshot from 2021-03-15 14-17-57](https://user-images.githubusercontent.com/208713/111301987-beb27380-864a-11eb-9792-9999789153a5.png)

## After

![Peek 2021-03-16 10-26](https://user-images.githubusercontent.com/208713/111302241-0d600d80-864b-11eb-8520-da64f3c67106.gif)

## Technical Details

CiviCRM removes submitOnce function from the core and the confirmation dialogue relies on the function. 

Since CiviCRM does not provide JS function (as submitOnce is now binding to the form)  as well as provide the API or function to add a  confirmation dialogue when submitting the form. 

We need an alternative options to overcome this issue as we want to maintain the confirmation dialogue for Update Recurring Contribution and to ensure that the form is only submitted once when user clicks 'Yes'

So what changed? 

On addButtons() we updated the return javascript function on the onclick event and pass the event to the function to display a dialogue 

`        'js' => ['onclick' => "return processUpdate(event);"],
`

On JS 

We only want to show the confirmation only then user changed payment method and cycle day then prevent the form to submitted and only summit the form and apply existing functionality to when user clicked yes. 

I have also updated the jQuery to dialogue to include civicrm ts() tag for translation the text.  

```
function processUpdate(event) {
  if (!isPaymentMethodChanged() && !isCycleDayChanged()) {
    return true;
  }
  event.preventDefault();
  CRM.$('#confirmInstallmentsUpdate').dialog({
    modal: true, title: ts('Update Recurring Contribution'), zIndex: 10000, autoOpen: true,
    width: 'auto', resizable: false,
    buttons: [{
      text: ts('Yes'),
      click: function () {
        disableConfirmButton();
        CRM.$('#update_installments').val(1);
        CRM.$('#UpdateSubscription').unbind();
        CRM.$('#UpdateSubscription').submit();
        CRM.$(this).dialog("close");
      },
    }, {
      text: ts('No'),
      click: function () {
        CRM.$(this).dialog("close");
      }
    }],
    close: function (event, ui) {
      CRM.$(this).dialog("close");
    }
  });
}
```

When clicked yes, we also disable the button and change the button text to processing as per CiviCRM fashion. 
```
CRM.$('button[data-identifier="_qf_UpdateSubscription_upload"]').attr("disabled", true);
CRM.$('button[data-identifier="_qf_UpdateSubscription_upload"]').html(ts('Processing') + '...');
```