### PR TITLE
MAE-523: Improve/fix instalment amount calculations.

### DIFF
--- a/CRM/MembershipExtras/Helper/InstalmentCalculatorTrait.php
+++ b/CRM/MembershipExtras/Helper/InstalmentCalculatorTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtils;
+
+trait CRM_MembershipExtras_Helper_InstalmentCalculatorTrait {
+
+  /**
+   * Calculates Single Instalment Amount
+   *
+   * @param $amount
+   * @param $divisor
+   * @return float|int
+   */
+  public function calculateSingleInstalmentAmount(float $amount, float $divisor) {
+    return MoneyUtils::roundToPrecision($amount / $divisor, 2);
+  }
+
+}

--- a/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
+++ b/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
@@ -9,17 +9,17 @@ trait CRM_MembershipExtras_Helper_InstalmentHelperTrait {
   /**
    * Gets Membership start date
    *
-   * @param int $membershipId
+   * @param int $membershipTypeId
    * @param DateTime|NULL $startDate
    * @param DateTime|NULL $endDate
    * @param DateTime|NULL $joinDate
    *
    * @return mixed
    */
-  private function getMembershipStartDate(int $membershipId, DateTime $startDate = NULL, DateTime $endDate = NULL, DateTime $joinDate = NULL) {
+  private function getMembershipStartDate(int $membershipTypeId, DateTime $startDate = NULL, DateTime $endDate = NULL, DateTime $joinDate = NULL) {
     $membershipTypeDatesCalculator = new CRM_MembershipExtras_Service_MembershipTypeDatesCalculator();
     $membershipDates = $membershipTypeDatesCalculator->getDatesForMembershipType(
-      $membershipId,
+      $membershipTypeId,
       $startDate,
       $endDate,
       $joinDate

--- a/CRM/MembershipExtras/Service/MembershipInstalmentAmountCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentAmountCalculator.php
@@ -180,7 +180,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator {
   }
 
   /**
-   * Calculates instalment total amount.
+   * Calculates instalments total amount.
    *
    * @param array $instalments
    * @return float

--- a/CRM/MembershipExtras/Service/MembershipInstalmentAmountCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentAmountCalculator.php
@@ -1,8 +1,11 @@
 <?php
 
 use CRM_MembershipExtras_Service_MembershipPeriodType_PeriodTypeCalculatorInterface as Calculator;
+use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtils;
 
 class CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator {
+
+  use CRM_MembershipExtras_Helper_InstalmentCalculatorTrait;
 
   /**
    * @var \CRM_MembershipExtras_Service_MembershipPeriodType_PeriodTypeCalculatorInterface
@@ -22,6 +25,172 @@ class CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator {
    */
   public function getCalculator() {
     return $this->calculator;
+  }
+
+  /**
+   * Calculates instalment amount from line items.
+   *
+   * We need to ensure that sub total, tax and total amounts
+   * are calculate from line items to avoid precision issue
+   * when amount is divided by instalment amount.
+   *
+   * @param int $instalmentCount
+   * @return CRM_MembershipExtras_DTO_ScheduleInstalmentAmount
+   */
+  public function calculateInstalmentAmount(int $instalmentCount) {
+    $instalment = new CRM_MembershipExtras_DTO_ScheduleInstalmentAmount();
+
+    $lineItems = $this->calculator->getLineItems();
+    if ($instalmentCount != 1) {
+      $lineItems = $this->setLineItemsAmountPerInstalment($lineItems, $instalmentCount);
+    }
+    $instalment->setLineItems($lineItems);
+
+    $amount = 0.0;
+    $taxAmount = 0.0;
+    $totalAmount = 0.0;
+    foreach ($lineItems as $lineItem) {
+      $amount += $lineItem->getSubTotal();
+      $taxAmount += $lineItem->getTaxAmount();
+      $totalAmount += $lineItem->getTotalAmount();
+    }
+    $instalment->setAmount($amount);
+    $instalment->setTaxAmount($taxAmount);
+    $instalment->setTotalAmount($totalAmount);
+
+    return $instalment;
+
+  }
+
+  /**
+   * Calculates Line item amount per instalment
+   *
+   * @param array $lineItems
+   * @param int $instalmentCount
+   * @return array
+   */
+  private function setLineItemsAmountPerInstalment(array $lineItems, int $instalmentCount) {
+    $newInstalmentLineItems = [];
+    foreach ($lineItems as $lineItem) {
+      $instalmentUnitPrice = $this->calculateSingleInstalmentAmount($lineItem->getUnitPrice(), $instalmentCount);
+      $instalmentSubTotal = $this->calculateSingleInstalmentAmount($lineItem->getSubTotal(), $instalmentCount);
+      $instalmentTaxAmount = $this->calculateSingleInstalmentAmount($lineItem->getTaxAmount(), $instalmentCount);
+      $instalmentTotal = MoneyUtils::roundToPrecision($instalmentSubTotal + $instalmentTaxAmount, 2);
+
+      $lineItem->setUnitPrice($instalmentUnitPrice);
+      $lineItem->setSubTotal($instalmentSubTotal);
+      $lineItem->setTaxAmount($instalmentTaxAmount);
+      $lineItem->setTotalAmount($instalmentTotal);
+
+      array_push($newInstalmentLineItems, $lineItem);
+    }
+
+    return $newInstalmentLineItems;
+  }
+
+  /**
+   * Applies amount, tax amount from Non Membership Price Field Value.
+   * to instalment amount
+   *
+   * @param CRM_MembershipExtras_DTO_ScheduleInstalmentAmount $instalmentAmount
+   * @param array $nonMembershipPriceFieldValues
+   * @param CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator $instalmentTaxAmountCalculator
+   * @param int $instalmentCount
+   */
+  public function setNonMembershipPriceFieldValueAmount(
+    CRM_MembershipExtras_DTO_ScheduleInstalmentAmount $instalmentAmount,
+    array $nonMembershipPriceFieldValues,
+    CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator $instalmentTaxAmountCalculator,
+    int $instalmentCount
+  ) {
+    $totalNonMembershipPriceFieldValueAmount = 0;
+    $totalNonMembershipPriceFieldValueTaxAmount = 0;
+    $nonMembershipPriceFieldValueLineItems = [];
+    foreach ($nonMembershipPriceFieldValues as $priceFieldValue) {
+      $quantity = $priceFieldValue['quantity'];
+      $amount = $priceFieldValue['values']['amount'];
+      $subTotal = (float) $amount * (float) $quantity;
+      $totalNonMembershipPriceFieldValueAmount += $subTotal;
+      $salesTax = $instalmentTaxAmountCalculator->calculateByPriceFieldValue($priceFieldValue['values']) * (float) $quantity;
+      $totalNonMembershipPriceFieldValueTaxAmount += $salesTax;
+
+      $scheduleInstalmentLineItem = new CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem();
+      $financialTypeId = $priceFieldValue['values']['financial_type_id'];
+      $scheduleInstalmentLineItem->setFinancialTypeId($financialTypeId);
+      $scheduleInstalmentLineItem->setQuantity($quantity);
+      $scheduleInstalmentLineItem->setUnitPrice($this->calculateSingleInstalmentAmount($amount, $instalmentCount));
+      $scheduleInstalmentLineItem->setSubTotal($this->calculateSingleInstalmentAmount($subTotal, $instalmentCount));
+      $scheduleInstalmentLineItem->setTaxRate($instalmentTaxAmountCalculator->getTaxRateByFinancialTypeId($financialTypeId));
+      $scheduleInstalmentLineItem->setTaxAmount($this->calculateSingleInstalmentAmount($salesTax, $instalmentCount));
+      $lineItemTotalAmount = $scheduleInstalmentLineItem->getSubTotal() + $scheduleInstalmentLineItem->getTaxAmount();
+      $scheduleInstalmentLineItem->setTotalAmount($lineItemTotalAmount);
+      $nonMembershipPriceFieldValueLineItems[] = $scheduleInstalmentLineItem;
+    }
+
+    $totalNonMembershipPriceFieldValueAmountPerInstalment = $this->calculateSingleInstalmentAmount($totalNonMembershipPriceFieldValueAmount, $instalmentCount);
+    $newInstalmentAmount = $totalNonMembershipPriceFieldValueAmountPerInstalment + $instalmentAmount->getAmount();
+    $totalNonMembershipPriceFieldValueTaxAmountPerInstalment = $this->calculateSingleInstalmentAmount($totalNonMembershipPriceFieldValueTaxAmount, $instalmentCount);
+    $newInstalmentTaxAmount = $totalNonMembershipPriceFieldValueTaxAmountPerInstalment + $instalmentAmount->getTaxAmount();
+
+    $instalmentAmount->setAmount($newInstalmentAmount);
+    $instalmentAmount->setTaxAmount($newInstalmentTaxAmount);
+
+    $nonMembershipPriceFieldValueTotalAmount = $totalNonMembershipPriceFieldValueAmountPerInstalment + $totalNonMembershipPriceFieldValueTaxAmountPerInstalment;
+    $currentTotalAmount = $instalmentAmount->getTotalAmount();
+    $totalAmount = $nonMembershipPriceFieldValueTotalAmount + $currentTotalAmount;
+    $instalmentAmount->setTotalAmount($totalAmount);
+
+    if (empty($nonMembershipPriceFieldValueLineItems)) {
+      return;
+    }
+
+    $currentLineItems = $instalmentAmount->getLineItems();
+    foreach ($nonMembershipPriceFieldValueLineItems as $priceFieldLineItem) {
+      array_push($currentLineItems, $priceFieldLineItem);
+    }
+    $instalmentAmount->setLineItems($currentLineItems);
+  }
+
+  /**
+   * Calculates Instalments Sub Total Amount.
+   *
+   * @param array $instalments
+   * @return float
+   */
+  public function getInstalmentsSubTotalAmount(array $instalments) {
+    $subTotalAmount = 0.0;
+    foreach ($instalments as $instalment) {
+      $subTotalAmount += $instalment->getInstalmentAmount()->getAmount();
+    }
+    return $subTotalAmount;
+  }
+
+  /**
+   * Calculates Instalments Tax Amount.
+   *
+   * @param array $instalments
+   * @return float
+   */
+  public function getInstalmentsTaxAmount(array $instalments) {
+    $taxAmount = 0.0;
+    foreach ($instalments as $instalment) {
+      $taxAmount += $instalment->getInstalmentAmount()->getTaxAmount();
+    }
+    return $taxAmount;
+  }
+
+  /**
+   * Calculates instalment total amount.
+   *
+   * @param array $instalments
+   * @return float
+   */
+  public function getInstalmentsTotalAmount(array $instalments) {
+    $totalAmount = 0.0;
+    foreach ($instalments as $instalment) {
+      $totalAmount += $instalment->getInstalmentAmount()->getTotalAmount();
+    }
+    return $totalAmount;
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -1,7 +1,6 @@
 <?php
 
 use CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment as InvalidMembershipTypeInstalment;
-use CRM_MembershipExtras_DTO_ScheduleInstalmentAmount as ScheduleInstalmentAmount;
 use CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator as InstalmentAmountCalculator;
 use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator as FixedPeriodTypeCalculator;
 use CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalculator as RollingPeriodCalculator;
@@ -60,6 +59,10 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
    * @var \CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator
    */
   private $instalmentCalculator;
+  /**
+   * @var int
+   */
+  private $instalmentCount;
 
   /**
    * CRM_MembershipExtras_Service_MembershipTypeInstalment constructor.
@@ -89,16 +92,24 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
    */
   public function generate(DateTime $startDate = NULL, DateTime $endDate = NULL, DateTime $joinDate = NULL) {
     if (empty($startDate)) {
-      $startDate = new DateTime($this->getMembershipStartDate($startDate, $endDate, $joinDate));
+      $startDate = new DateTime($this->getMembershipStartDate($this->membershipTypes[0]->id, $startDate, $endDate, $joinDate));
     }
     $this->startDate = $startDate;
     $this->endDate = $endDate;
     $this->joinDate = $joinDate;
+    $this->instalmentCount = $this->getInstalmentsNumber(
+      $this->membershipTypes[0], $this->schedule, $this->startDate, $this->endDate, $this->joinDate
+    );
 
     $instalmentAmount = $this->calculateInstalmentAmount();
 
     if (!empty($this->nonMembershipPriceFieldValues)) {
-      $this->applyNonMembershipPriceFieldValueAmount($instalmentAmount);
+      $this->instalmentCalculator->setNonMembershipPriceFieldValueAmount(
+        $instalmentAmount,
+        $this->nonMembershipPriceFieldValues,
+        $this->membershipInstalmentTaxAmountCalculator,
+        $this->instalmentCount
+      );
     }
 
     $instalment = new CRM_MembershipExtras_DTO_ScheduleInstalment();
@@ -107,10 +118,9 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
 
     $instalments['instalments'][] = $instalment;
 
-    $noOfInstalment = $this->getInstalmentsNumber($this->membershipTypes[0], $this->schedule, $this->startDate, $this->endDate, $this->joinDate);
-    if ($noOfInstalment > 1) {
+    if ($this->instalmentCount > 1) {
       $nextInstalmentDate = $startDate->format('Y-m-d');
-      for ($i = 1; $i < $noOfInstalment; $i++) {
+      for ($i = 1; $i < $this->instalmentCount; $i++) {
         $intervalSpec = 'P1M';
         if ($this->schedule == self::QUARTERLY) {
           $intervalSpec = 'P3M';
@@ -125,39 +135,19 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
       }
     }
 
-    $instalments['sub_total'] = $this->getInstalmentsSubTotalAmount($instalments['instalments']);
-    $instalments['tax_amount'] = $this->getInstalmentsTaxAmount($instalments['instalments']);
-    $instalments['total_amount'] = $this->getInstalmentsTotalAmount($instalments['instalments']);
+    $instalments['sub_total'] = $this->instalmentCalculator->getInstalmentsSubTotalAmount($instalments['instalments']);
+    $instalments['tax_amount'] = $this->instalmentCalculator->getInstalmentsTaxAmount($instalments['instalments']);
+    $instalments['total_amount'] = $this->instalmentCalculator->getInstalmentsTotalAmount($instalments['instalments']);
 
     $instalments['membership_start_date'] = $this->startDate->format('Y-m-d');
     $instalments['membership_end_date'] = $this->endDate->format('Y-m-d');
 
-    if ($this->membershipTypes[0]->period_type == 'fixed') {
+    if ($this->instalmentCalculator->getCalculator() instanceof FixedPeriodTypeCalculator) {
       $instalments['prorated_number'] = $this->instalmentCalculator->getCalculator()->getProRatedNumber();
       $instalments['prorated_unit'] = $this->instalmentCalculator->getCalculator()->getProRatedUnit();
     }
 
     return $instalments;
-  }
-
-  /**
-   * Gets Membership start date
-   *
-   * @param DateTime|NULL $startDate
-   * @param DateTime|NULL $endDate
-   * @param DateTime|NULL $joinDate
-   *
-   * @return mixed
-   */
-  private function getMembershipStartDate(DateTime $startDate = NULL, DateTime $endDate = NULL, DateTime $joinDate = NULL) {
-    $membershipDates = $this->membershipTypeDatesCalculator->getDatesForMembershipType(
-      $this->membershipTypes[0]->id,
-      $startDate,
-      $endDate,
-      $joinDate
-    );
-
-    return $membershipDates['start_date'];
   }
 
   /**
@@ -171,45 +161,8 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
   private function calculateInstalmentAmount() {
     $this->getInstalmentAmountCalculator();
     $this->instalmentCalculator->getCalculator()->calculate();
-    $divisor = $this->getInstalmentsNumber($this->membershipTypes[0], $this->schedule, $this->startDate, $this->endDate, $this->joinDate);
-    $amount = $this->calculateSingleInstalmentAmount($this->instalmentCalculator->getCalculator()->getAmount(), $divisor);
-    $taxAmount = $this->calculateSingleInstalmentAmount($this->instalmentCalculator->getCalculator()->getTaxAmount(), $divisor);
-    $totalAmount = $this->calculateSingleInstalmentAmount($this->instalmentCalculator->getCalculator()->getTotalAmount(), $divisor);
 
-    $instalment = new CRM_MembershipExtras_DTO_ScheduleInstalmentAmount();
-    $instalment->setAmount($amount);
-    $instalment->setTaxAmount($taxAmount);
-    $instalment->setTotalAmount($totalAmount);
-    $lineItems = $this->instalmentCalculator->getCalculator()->getLineItems();
-    if ($divisor != 1) {
-      $lineItems = $this->setLineItemsAmountPerInstalment($lineItems, $divisor);
-    }
-    $instalment->setLineItems($lineItems);
-    return $instalment;
-  }
-
-  /**
-   * @param array $lineItems
-   * @param $instalmentCount
-   * @return array
-   */
-  private function setLineItemsAmountPerInstalment(array $lineItems, $instalmentCount) {
-    $newInstalmentLineItems = [];
-    foreach ($lineItems as $lineItem) {
-      $instalmentUnitPrice = $this->calculateSingleInstalmentAmount($lineItem->getUnitPrice(), $instalmentCount);
-      $instalmentSubTotal = $this->calculateSingleInstalmentAmount($lineItem->getSubTotal(), $instalmentCount);
-      $instalmentTaxAmount = $this->calculateSingleInstalmentAmount($lineItem->getTaxAmount(), $instalmentCount);
-      $instalmentTotal = $this->calculateSingleInstalmentAmount($lineItem->getTotalAmount(), $instalmentCount);
-
-      $lineItem->setUnitPrice($instalmentUnitPrice);
-      $lineItem->setSubTotal($instalmentSubTotal);
-      $lineItem->setTaxAmount($instalmentTaxAmount);
-      $lineItem->setTotalAmount($instalmentTotal);
-
-      array_push($newInstalmentLineItems, $lineItem);
-    }
-
-    return $newInstalmentLineItems;
+    return $this->instalmentCalculator->calculateInstalmentAmount($this->instalmentCount);
   }
 
   /**
@@ -227,64 +180,6 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
     else {
       $this->instalmentCalculator = new InstalmentAmountCalculator(new RollingPeriodCalculator($this->membershipTypes));
     }
-  }
-
-  /**
-   * Applies amount, tax amount from Non Membership Price Field Value
-   * to instalment amount
-   *
-   * @param CRM_MembershipExtras_DTO_ScheduleInstalmentAmount $instalmentAmount
-   * @throws Exception
-   */
-  private function applyNonMembershipPriceFieldValueAmount(ScheduleInstalmentAmount $instalmentAmount) {
-    $totalNonMembershipPriceFieldValueAmount = 0;
-    $totalNonMembershipPriceFieldValueTaxAmount = 0;
-    $lineItemTotalAmount = 0;
-    $nonMembershipPriceFieldValueLineItems = [];
-    $divisor = $this->getInstalmentsNumber($this->membershipTypes[0], $this->schedule, $this->startDate, $this->endDate, $this->joinDate);
-    foreach ($this->nonMembershipPriceFieldValues as $priceFieldValue) {
-      $quantity = $priceFieldValue['quantity'];
-      $amount = $priceFieldValue['values']['amount'];
-      $subTotal = (float) $amount * (float) $quantity;
-      $totalNonMembershipPriceFieldValueAmount += $subTotal;
-      $salesTax = $this->membershipInstalmentTaxAmountCalculator->calculateByPriceFieldValue($priceFieldValue['values']) * (float) $quantity;
-      $totalNonMembershipPriceFieldValueTaxAmount += $salesTax;
-
-      $scheduleInstalmentLineItem = new CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem();
-      $financialTypeId = $priceFieldValue['values']['financial_type_id'];
-      $scheduleInstalmentLineItem->setFinancialTypeId($financialTypeId);
-      $scheduleInstalmentLineItem->setQuantity($quantity);
-      $scheduleInstalmentLineItem->setUnitPrice($this->calculateSingleInstalmentAmount($amount, $divisor));
-      $scheduleInstalmentLineItem->setSubTotal($this->calculateSingleInstalmentAmount($subTotal, $divisor));
-      $scheduleInstalmentLineItem->setTaxRate($this->membershipInstalmentTaxAmountCalculator->getTaxRateByFinancialTypeId($financialTypeId));
-      $scheduleInstalmentLineItem->setTaxAmount($this->calculateSingleInstalmentAmount($salesTax, $divisor));
-      $lineItemTotalAmount = $this->calculateSingleInstalmentAmount($subTotal + $salesTax, $divisor);
-      $scheduleInstalmentLineItem->setTotalAmount($lineItemTotalAmount);
-      $nonMembershipPriceFieldValueLineItems[] = $scheduleInstalmentLineItem;
-    }
-
-    $totalNonMembershipPriceFieldValueAmountPerInstalment = $this->calculateSingleInstalmentAmount($totalNonMembershipPriceFieldValueAmount, $divisor);
-    $newInstalmentAmount = $totalNonMembershipPriceFieldValueAmountPerInstalment + $instalmentAmount->getAmount();
-    $totalNonMembershipPriceFieldValueTaxAmountPerInstalment = $this->calculateSingleInstalmentAmount($totalNonMembershipPriceFieldValueTaxAmount, $divisor);
-    $newInstalmentTaxAmount = $totalNonMembershipPriceFieldValueTaxAmountPerInstalment + $instalmentAmount->getTaxAmount();
-
-    $instalmentAmount->setAmount($newInstalmentAmount);
-    $instalmentAmount->setTaxAmount($newInstalmentTaxAmount);
-
-    $nonMembershipPriceFieldValueTotalAmount = $totalNonMembershipPriceFieldValueAmountPerInstalment + $totalNonMembershipPriceFieldValueTaxAmountPerInstalment;
-    $currentTotalAmount = $instalmentAmount->getTotalAmount();
-    $totalAmount = $nonMembershipPriceFieldValueTotalAmount + $currentTotalAmount;
-    $instalmentAmount->setTotalAmount($totalAmount);
-
-    if (empty($nonMembershipPriceFieldValueLineItems)) {
-      return;
-    }
-
-    $currentLineItems = $instalmentAmount->getLineItems();
-    foreach ($nonMembershipPriceFieldValueLineItems as $priceFieldLineItem) {
-      array_push($currentLineItems, $priceFieldLineItem);
-    }
-    $instalmentAmount->setLineItems($currentLineItems);
   }
 
   /**
@@ -332,65 +227,12 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
   }
 
   /**
-   * Calculates Instalments Sub Total Amount
-   *
-   * @param array $instalments
-   * @return float
-   */
-  private function getInstalmentsSubTotalAmount(array $instalments) {
-    $subTotalAmount = 0.0;
-    foreach ($instalments as $instalment) {
-      $subTotalAmount += $instalment->getInstalmentAmount()->getAmount();
-    }
-    return $subTotalAmount;
-  }
-
-  /**
-   * Calculates Instalments Tax Amount
-   *
-   * @param array $instalments
-   * @return float
-   */
-  private function getInstalmentsTaxAmount(array $instalments) {
-    $taxAmount = 0.0;
-    foreach ($instalments as $instalment) {
-      $taxAmount += $instalment->getInstalmentAmount()->getTaxAmount();
-    }
-    return $taxAmount;
-  }
-
-  /**
-   * Calculates instalment total amount.
-   *
-   * @param array $instalments
-   * @return float
-   */
-  private function getInstalmentsTotalAmount(array $instalments) {
-    $totalAmount = 0.0;
-    foreach ($instalments as $instalment) {
-      $totalAmount += $instalment->getInstalmentAmount()->getTotalAmount();
-    }
-    return $totalAmount;
-  }
-
-  /**
    * Sets Non Membership Price Field values to the class property.
    *
    * @param array $nonMembershipPriceFieldValues
    */
   public function setNonMembershipPriceFieldValues(array $nonMembershipPriceFieldValues) {
     $this->nonMembershipPriceFieldValues = $nonMembershipPriceFieldValues;
-  }
-
-  /**
-   * Calculates Single Instalment Amount
-   *
-   * @param $amount
-   * @param $divisor
-   * @return float|int
-   */
-  private function calculateSingleInstalmentAmount($amount, $divisor) {
-    return $amount / $divisor;
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtils;
+
 /**
  * Class CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodTypeCalculator
  */
@@ -45,7 +47,7 @@ abstract class CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodT
   }
 
   /**
-   * @return flaot
+   * @return float
    */
   public function getTotalAmount() {
     return $this->amount + $this->taxAmount;
@@ -61,16 +63,16 @@ abstract class CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodT
   /**
    * Generates line item for each instalment
    *
-   * @param int $fiancialTypeId
+   * @param int $financialTypeId
    * @param float $amount
    * @param float $taxAmount
    */
-  protected function generateLineItem(int $fiancialTypeId, float $amount, float $taxAmount) {
-    $subTotal = $amount * $this->quantity;
-    $totalAmount = $subTotal + $taxAmount;
-    $taxRate = $this->instalmentTaxAmountCalculator->getTaxRateByFinancialTypeId($fiancialTypeId);
+  protected function generateLineItem(int $financialTypeId, float $amount, float $taxAmount) {
+    $subTotal = MoneyUtils::roundToPrecision($amount, 2) * MoneyUtils::roundToPrecision($this->quantity, 2);
+    $totalAmount = $subTotal + MoneyUtils::roundToPrecision($taxAmount, 2);
+    $taxRate = $this->instalmentTaxAmountCalculator->getTaxRateByFinancialTypeId($financialTypeId);
     $scheduleInstalmentLineItem = new CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem();
-    $scheduleInstalmentLineItem->setFinancialTypeId($fiancialTypeId);
+    $scheduleInstalmentLineItem->setFinancialTypeId($financialTypeId);
     $scheduleInstalmentLineItem->setQuantity($this->quantity);
     $scheduleInstalmentLineItem->setUnitPrice($amount);
     $scheduleInstalmentLineItem->setSubTotal($subTotal);

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
@@ -78,7 +78,7 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
         $duration = self::TWELVE_MONTHS;
         $this->proRatedNumber = $membershipTypeDurationCalculator->calculateMonthsBasedOnDates($this->startDate, $this->endDate, $this->joinDate);
         if ($this->isDurationWithInOneYearPeriod($duration, $this->proRatedNumber)) {
-          $this->recalCalcuateEndDate();
+          $this->reCalculateEndDate();
           $this->proRatedNumber = $membershipTypeDurationCalculator->calculateMonthsBasedOnDates($this->startDate, $this->endDate, $this->joinDate);
         }
       }
@@ -87,7 +87,7 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
         $duration  = $membershipTypeDurationCalculator->calculateOriginalInDays();
         $this->proRatedNumber = $membershipTypeDurationCalculator->calculateDaysBasedOnDates($this->startDate, $this->endDate, $this->joinDate);
         if ($this->isDurationWithInOneYearPeriod($duration, $this->proRatedNumber)) {
-          $this->recalCalcuateEndDate();
+          $this->reCalculateEndDate();
           $this->proRatedNumber = $membershipTypeDurationCalculator->calculateDaysBasedOnDates($this->startDate, $this->endDate, $this->joinDate);
         }
       }
@@ -183,7 +183,7 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
    * Subtracts end date by 1 year as
    * Membership extras default fixed membership to 1 year duration.
    */
-  private function recalCalcuateEndDate() {
+  private function reCalculateEndDate() {
     $this->endDate->sub(new DateInterval('P1Y'));
   }
 

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/PeriodTypeCalculatorInterface.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/PeriodTypeCalculatorInterface.php
@@ -11,4 +11,6 @@ interface CRM_MembershipExtras_Service_MembershipPeriodType_PeriodTypeCalculator
 
   public function getTotalAmount();
 
+  public function getLineItems();
+
 }


### PR DESCRIPTION
## Overview

This PR does the followings: 

- Fixed CiviCRM 5.35.1 compatibility. 
- Fixed precision issue on the calculation. 

Issue 1: CiviCRM 5.35.1 

In CiviCRM 5.35,  `membership_id` will not add to parameter when creating contribution / line item objects [Membership.php#L1451)](https://github.com/civicrm/civicrm-core/blob/5.35.0/CRM/Member/Form/Membership.php#L1451), and `membership_payment` record will only be created once the contribution is saved.  However, Membership extras require membership_id to calculate instalment amount and frequency.   

Issue 2: Precision

Membership extras version 5, provides a new UI to visualise the instalment details before the membership is created.  

![screenshot-compuclient local-2021 04 14-15_17_57](https://user-images.githubusercontent.com/208713/114725838-c0985100-9d34-11eb-898f-31e20e0016df.png)

The instalment details are included instalment amount, tax, total amount as well as sub line item that show the line item(s) of the instalment.

Since the precision error can happen easily when we pro-rated amount by months or by days, see  one of the error that could happen as  example below when membership is created with a price set. 

```
Price set 1
Membership 1 fee  = £10.55 / annual
Membership 2 fee  = £10 / annual
Membership fee total = £22.55 / annual

if we prorated for 269 days and pay 9 instalments the membership fee would be  £18.18 / annual
Sub total amount = 15.15
Tax amount = 3.03
Total Amount = 18.18

Instalment amount is 18.18 / 9 = 2.02

Line items would look like this 
Line Item 1 amount = 7.78
Line Item 1 tax = 1.56
Line Item 1 amount + tax = 9.34

Line Item 2 amount = 7.37
Line Item 2 tax = 1.47
Line Item 2 amount + tax = 8.84

Line1 + Line 2 = 18.18
Line item total amount  is 18.18 / 9 = 2.02

However if we calculate by divide line item (or instalment amount) by number of instalment, we would have different result as below. 

Line Item 1 per instalment  would be 9.34 / 9 = 1.03
Line Item 1 per instalment would be  8.84 / 9 = 0.98

Instalment amount would be  1.03 + 0.98 = 2.01
```

The different would be £0.01 when we created an instalment because CiviCRM records amounts in different places for instance, contribution, contribution line item, membership line item, financial line item, recurring contribution. 

The calculation that is currently being  implemented in the PR is that total amount is calculated from line item, we do it this way because CiviCRM records financial line item this way, and then we would need to ensure that the calculation will be done the same when we virtualise the schedule and when contribution and line items are created, so this PR does that. 

## Before

- Calculation was incorrectly because `membership_id` did not exist in the contribution / line item object since we upgrade to CiviCRM 5.35.1
- The calculation was done separately between when we virtualise the schedule and when we create a contribution / line item. 

## After

## Technical Details

There are a couple of things that worth mention in this section. 

- In this PR, I refactored the code that used to calculate the instalment amount to MembershipInstalmentAmountCalculator class, so we can reuse the calculation methods in the hook and the instalment calculation. 
- Since Membership Payment record does not exist (yet) and membership ID did not pass in the contribution and line item object, we would need to obtain the `membership_id` from the membership line item that attached to the contribution parameter which is done [here ](https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/25c378af028dcc6a42796f34610b6b74ece46e48/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/Contribution.php#L59)
- When creating a line item, we also need to obtain the `membership_id` in order to calculate the right amount for each instalment however, the `membership_id` will not always be available because the line item could be a contribution line item which does not a have `membership_id` attached to it, the solution to address this is to use static class available that it was set when contribution object was being created. 


