### PR TITLE
MAE-513: Fix warning icons in confirmational popups

### DIFF
--- a/templates/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.tpl
+++ b/templates/CRM/MembershipExtras/Form/AutomatedUpgradeRuleDelete.tpl
@@ -1,7 +1,7 @@
 <div class="crm-block crm-form-block">
   <div class="form-item">
     <div class="messages status no-popup">
-      <div class="icon inform-icon"></div>
+      <div class="crm-i fa-info-circle"></div>
         {ts}Are you sure you would like to delete the automated upgrade rule?{/ts}
     </div>
   </div>

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/Cancel.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/Cancel.tpl
@@ -1,6 +1,6 @@
 <div class="crm-block crm-form-block crm-payment-plan-cancel-form-block">
   <div class="messages status no-popup">
-    <div class="icon inform-icon"></div>
+    <div class="crm-i fa-info-circle"></div>
     WARNING - This action sets the CiviCRM recurring contribution status to cancelled, but does NOT send a cancellation request to the payment processor. You will need to ensure that this recurring payment (subscription) is cancelled by the payment processor.
   </div>
   <p>


### PR DESCRIPTION
## Overview
After civicrm upgrade the icon of a warning message was broken in the following popups:
1. Recurring contribution -> Cancel dialog.
2. Automated upgrade rule -> Delete dialog.

This PR fixes the issue.

## Before
![image](https://user-images.githubusercontent.com/39520000/113870436-82da7c00-97ba-11eb-9c8c-5a0da9d5c9e2.png)

## After
![image](https://user-images.githubusercontent.com/39520000/113870448-87069980-97ba-11eb-9624-8d58acfd2c5a.png)

## Technical Details
The issue is caused by core style changes (see civicrm/css/civicrm.css). So previously it had styles like these:
```
.crm-container .icon {
    background-image: url(../i/icons/jquery-ui-52534D.png);
}

.crm-container .inform-icon {
    background-position: -16px -144px;
    margin-right: 5px;
}
```

Now it has following styles only:
```
.crm-container .icon {
    background-image: url(../i/icons/jquery-ui-52534D.png);
}
```

As background image is a sprite and background position is not set - the first icon becomes visible.

To fix the issue we could add some css, but I've checked warning messages in other parts of civicrm and found out that other classes are used there, so I've replaced `icon inform-icon` icon classes with `crm-i fa-info-circle` in related templates and that fixed the issue.

Comparing to previous version icon missing `margin-right: 5px`, but it seems to be a default behavior through out civicrm now, so  it was decided to keep as is.