### PR TITLE
MAE-524: Fix contribution amount assigned as NaN

### DIFF
--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -220,7 +220,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
      * Updates total amount based and also updated price value if is price set amount
      */
     function updateTotalAmount(totalAmount, isPriceSet) {
-      $('#total_amount').val(CRM.formatMoney(totalAmount, true));
+      $('#total_amount').val(totalAmount);
       if (isPriceSet) {
         $('#pricevalue').html(currencySymbol + ' ' + CRM.formatMoney(totalAmount, true));
       }


### PR DESCRIPTION
## Overview

 This PR fixes NaN is assigned when setting a formatted amount more than 4 digits.

## Before

When assign formatted amount more than 4 digit, NaN was assigned.

![Peek 2021-04-06 09-48](https://user-images.githubusercontent.com/208713/114742947-1d4f3800-9d44-11eb-929e-4176d532b384.gif)

## After

Correct formatted amount is assigned.

![Peek 2021-04-14 17-10](https://user-images.githubusercontent.com/208713/114743162-512a5d80-9d44-11eb-99b3-434ac80c2f1d.gif)

## Technical Details

Since the totalAmount has already been formatted, calling CRM.formatMoney() to format amount again, it returns NaN when passing the amount that more than 999
