### PR TITLE
IO-136: V5 contribution receive date calculation

### DIFF
--- a/CRM/MembershipExtras/API/PaymentSchedule/Base.php
+++ b/CRM/MembershipExtras/API/PaymentSchedule/Base.php
@@ -57,7 +57,10 @@ abstract class CRM_MembershipExtras_API_PaymentSchedule_Base {
       return new DateTime($date);
     }, $membershipTypeDates);
 
+    $paymentMethod = $this->params['payment_method'];
+
     return $membershipInstalmentsSchedule->generate(
+      $paymentMethod,
       $membershipTypeDates['start_date'],
       $membershipTypeDates['end_date'],
       $membershipTypeDates['join_date']
@@ -81,15 +84,15 @@ abstract class CRM_MembershipExtras_API_PaymentSchedule_Base {
       $formattedInstalment['instalment_total_amount'] = $instalment->getInstalmentAmount()->getTotalAmount();
       $formattedInstalment['instalment_status'] = $this->getPendingStatusValue();
       $formattedLineItems = [];
-      foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
-        $formattedLineItems[$key]['item_no'] = $key + 1;
-        $formattedLineItems[$key]['financial_type_id'] = $lineItem->getFinancialTypeId();
-        $formattedLineItems[$key]['quantity'] = $lineItem->getQuantity();
-        $formattedLineItems[$key]['unit_price'] = $lineItem->getUnitPrice();
-        $formattedLineItems[$key]['sub_total'] = $lineItem->getSubTotal();
-        $formattedLineItems[$key]['tax_rate'] = $lineItem->getTaxRate();
-        $formattedLineItems[$key]['tax_amount'] = $lineItem->getTaxAmount();
-        $formattedLineItems[$key]['total_amount'] = $lineItem->getTotalAmount();
+      foreach ($instalment->getInstalmentAmount()->getLineItems() as $lineKey => $lineItem) {
+        $formattedLineItems[$lineKey]['item_no'] = $lineKey + 1;
+        $formattedLineItems[$lineKey]['financial_type_id'] = $lineItem->getFinancialTypeId();
+        $formattedLineItems[$lineKey]['quantity'] = $lineItem->getQuantity();
+        $formattedLineItems[$lineKey]['unit_price'] = $lineItem->getUnitPrice();
+        $formattedLineItems[$lineKey]['sub_total'] = $lineItem->getSubTotal();
+        $formattedLineItems[$lineKey]['tax_rate'] = $lineItem->getTaxRate();
+        $formattedLineItems[$lineKey]['tax_amount'] = $lineItem->getTaxAmount();
+        $formattedLineItems[$lineKey]['total_amount'] = $lineItem->getTotalAmount();
       }
 
       $formattedInstalment['instalment_lineitems'] = $formattedLineItems;

--- a/CRM/MembershipExtras/Page/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Page/InstalmentSchedule.php
@@ -1,5 +1,4 @@
 <?php
-use CRM_MembershipExtras_ExtensionUtil as E;
 
 class CRM_MembershipExtras_Page_InstalmentSchedule extends CRM_Core_Page {
 
@@ -12,9 +11,6 @@ class CRM_MembershipExtras_Page_InstalmentSchedule extends CRM_Core_Page {
   }
 
   private function assignInstalments() {
-    $startDate = CRM_Utils_Request::retrieve('start_date', 'String');
-    $joinDate = CRM_Utils_Request::retrieve('join_date', 'String');
-    $schedule = CRM_Utils_Request::retrieve('schedule', 'String');
     $membershipTypeId = CRM_Utils_Request::retrieve('membership_type_id', 'Int');
     $priceFieldValues = CRM_Utils_Request::retrieve('price_field_values', 'String');
 
@@ -28,9 +24,10 @@ class CRM_MembershipExtras_Page_InstalmentSchedule extends CRM_Core_Page {
       $action = 'getbypricefieldvalues';
     }
 
-    $params['schedule'] = $schedule;
-    $params['start_date'] = $startDate;
-    $params['join_date'] = $joinDate;
+    $params['schedule'] = CRM_Utils_Request::retrieve('schedule', 'String');
+    $params['payment_method'] = CRM_Utils_Request::retrieve('payment_method', 'Int');
+    $params['start_date'] = CRM_Utils_Request::retrieve('start_date', 'String');
+    $params['join_date'] = CRM_Utils_Request::retrieve('join_date', 'String');
 
     try {
       $result = civicrm_api3('PaymentSchedule', $action, $params);

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
@@ -39,6 +39,11 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
   private $receiveDateCalculator;
 
   /**
+   * @var DateTime
+   */
+  private $previousInstalmentDate;
+
+  /**
    * @var int
    */
   private $instalmentsCount = 0;
@@ -46,10 +51,12 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
   public function __construct($currentRecurContributionId) {
     $this->setCurrentRecurContribution($currentRecurContributionId);
     $this->setLastContribution();
+    $this->setPreviousInstalmentDate($this->lastContribution['receive_date']);
 
     $this->receiveDateCalculator = new InstalmentReceiveDateCalculator($this->currentRecurContribution);
 
     $this->setContributionPendingStatusValue();
+
   }
 
   /**
@@ -73,7 +80,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
       'return' => [
         'currency', 'contribution_source', 'net_amount', 'contact_id',
         'fee_amount', 'total_amount', 'payment_instrument_id', 'is_test',
-        'tax_amount', 'contribution_recur_id', 'financial_type_id',
+        'tax_amount', 'contribution_recur_id', 'financial_type_id', 'receive_date',
       ],
       'contribution_recur_id' => $this->currentRecurContribution['id'],
       'options' => ['limit' => 1, 'sort' => 'id DESC'],
@@ -130,8 +137,17 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
    */
   private function createContribution($contributionNumber = 1) {
     $contribution = $this->recordMembershipContribution($contributionNumber);
-
+    $this->setPreviousInstalmentDate($contribution->receive_date);
     $this->createLineItems($contribution);
+  }
+
+  /**
+   * Sets Previous Instalment Date.
+   *
+   * @throws Exception
+   */
+  private function setPreviousInstalmentDate(string $dateString) {
+    $this->previousInstalmentDate = new DateTime($dateString);
   }
 
   /**
@@ -228,10 +244,33 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
   private function dispatchReceiveDateCalculationHook($contributionNumber, &$params) {
     $receiveDate = $params['receive_date'];
 
-    $dispatcher = new CalculateContributionReceiveDateDispatcher($contributionNumber, $receiveDate, $params);
+    $contributionReceiveDateParams = [
+      'membership_id' => $this->getMembership()['membership_id.id'],
+      'contribution_recur_id' => $this->currentRecurContribution['id'],
+      'previous_instalment_date' => $this->previousInstalmentDate->format('Y-m-d'),
+      'payment_schedule' => CRM_MembershipExtras_Utils_InstalmentSchedule::getPaymentPlanSchedule(),
+      'payment_instrument_id' => $params['payment_instrument_id'],
+      'membership_start_date' => $this->getMembership()['membership_id.start_date'],
+      'frequency_interval' => $this->currentRecurContribution['frequency_interval'],
+      'frequency_unit' => $this->currentRecurContribution['frequency_unit'],
+    ];
+
+    $dispatcher = new CalculateContributionReceiveDateDispatcher($contributionNumber, $receiveDate, $contributionReceiveDateParams);
     $dispatcher->dispatch();
 
     $params['receive_date'] = $receiveDate;
+
+  }
+
+  private function getMembership() {
+    return civicrm_api3('MembershipPayment', 'get', [
+      'sequential' => 1,
+      'return' => [
+        'membership_id.start_date',
+        'membership_id.id',
+      ],
+      'contribution_id' => $this->lastContribution['id'],
+    ])['values'][0];
   }
 
   /**

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
@@ -274,29 +274,6 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
   }
 
   /**
-   * Copies the contribution custom field values from
-   * the first contribution to the specified upfront contribution
-   *
-   * @param $contributionId
-   *   The upfront contribution Id
-   */
-  private function copyContributionCustomFields($contributionId) {
-    $customValues = CRM_Core_BAO_CustomValueTable::getEntityValues($this->lastContribution['id'], 'Contribution');
-    if (empty($customValues)) {
-      return;
-    }
-
-    foreach ($customValues as $key => $value) {
-      if (!empty($value)) {
-        $customParams["custom_{$key}"] = $value;
-      }
-    }
-    $customParams['id'] = $contributionId;
-
-    civicrm_api3('Contribution', 'create', $customParams);
-  }
-
-  /**
    * Creates the contribution line items.
    *
    * @param CRM_Contribute_BAO_Contribution $contribution

--- a/CRM/MembershipExtras/Test/Helper/PaymentMethodTrait.php
+++ b/CRM/MembershipExtras/Test/Helper/PaymentMethodTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+
+trait CRM_MembershipExtras_Test_Helper_PaymentMethodTrait {
+
+  private function getPaymentMethodValue($name = 'EFT') {
+    return civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => "payment_instrument",
+      'name' => $name,
+    ])['values'][0]['value'];
+  }
+
+}

--- a/CRM/MembershipExtras/Utils/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Utils/InstalmentSchedule.php
@@ -44,7 +44,7 @@ class CRM_MembershipExtras_Utils_InstalmentSchedule {
    * @param $schedule
    * @return int
    */
-  private static function getFrequencyInterval($schedule) {
+  public static function getFrequencyInterval($schedule) {
     return $schedule == InstalmentsSchedule::QUARTERLY ? 3 : 1;
   }
 
@@ -60,7 +60,7 @@ class CRM_MembershipExtras_Utils_InstalmentSchedule {
    * @param $interval
    * @return string
    */
-  private static function getFrequencyUnit($schedule, $interval) {
+  public static function getFrequencyUnit($schedule, $interval) {
     return $interval == 1 && $schedule == InstalmentsSchedule::ANNUAL ? 'year' : 'month';
   }
 
@@ -94,7 +94,7 @@ class CRM_MembershipExtras_Utils_InstalmentSchedule {
    * @return bool
    */
   public static function isPaymentPlanWithSchedule() {
-    $paymentPlanSchedule = CRM_Utils_Request::retrieve('payment_plan_schedule', 'String');
+    $paymentPlanSchedule = self::getPaymentPlanSchedule();
     $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
@@ -103,6 +103,10 @@ class CRM_MembershipExtras_Utils_InstalmentSchedule {
     }
 
     return FALSE;
+  }
+
+  public static function getPaymentPlanSchedule() {
+    return CRM_Utils_Request::retrieve('payment_plan_schedule', 'String');
   }
 
 }

--- a/api/v3/PaymentSchedule/Getbymembershiptype.php
+++ b/api/v3/PaymentSchedule/Getbymembershiptype.php
@@ -1,7 +1,5 @@
 <?php
 
-use CRM_MembershipExtras_ExtensionUtil as E;
-
 function _civicrm_api3_payment_schedule_getbymembershiptype_spec(&$spec) {
   $spec['membership_type_id'] = [
     'name' => 'membership_type_id',
@@ -17,6 +15,13 @@ function _civicrm_api3_payment_schedule_getbymembershiptype_spec(&$spec) {
     'name' => 'schedule',
     'title' => 'Schedule (monthly, quarterly, annual)',
     'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $spec['payment_method'] = [
+    'name' => 'payment_method',
+    'title' => 'Payment method',
+    'type' => CRM_Utils_Type::T_INT,
     'api.required' => 1,
   ];
 

--- a/api/v3/PaymentSchedule/Getbypricefieldvalues.php
+++ b/api/v3/PaymentSchedule/Getbypricefieldvalues.php
@@ -1,8 +1,5 @@
 <?php
 
-
-use CRM_MembershipExtras_ExtensionUtil as E;
-
 function _civicrm_api3_payment_schedule_getbypriceset_spec(&$spec) {
   $spec['price_field_values'] = [
     'name' => 'price_field_value',
@@ -16,6 +13,13 @@ function _civicrm_api3_payment_schedule_getbypriceset_spec(&$spec) {
     'name' => 'schedule',
     'title' => 'Schedule (monthly, quarterly, annual)',
     'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+
+  $spec['payment_method'] = [
+    'name' => 'payment_method',
+    'title' => 'Payment method',
+    'type' => CRM_Utils_Type::T_INT,
     'api.required' => 1,
   ];
 

--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -129,6 +129,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
         schedule: schedule,
         start_date: $('#start_date').val(),
         join_date: $('#join_date').val(),
+        payment_method: $('#payment_instrument_id').val(),
       };
       if (isPriceSet) {
         let selectedPriceFieldValues = getSelectedPriceFieldValues();

--- a/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/MembershipTypeTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/MembershipTypeTest.php
@@ -12,6 +12,7 @@ use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator 
 class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHeadlessTest {
 
   use CRM_MembershipExtras_Test_Helper_FixedPeriodMembershipTypeSettingsTrait;
+  use CRM_MembershipExtras_Test_Helper_PaymentMethodTrait;
 
   /**
    * Tests exception is thrown if invalid schedule is passed
@@ -30,6 +31,7 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
     $this->expectException(API_Exception::class);
     $params['schedule'] = 'xyz';
     $params['membership_type_id'] = $membershipType['id'];
+    $params['payment_method'] = $this->getPaymentMethodValue();
     $schedule = new CRM_MembershipExtras_API_PaymentSchedule_MembershipType($params);
     $schedule->getPaymentSchedule();
   }
@@ -129,6 +131,7 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
     $params = [
       'schedule' => $schedule,
       'membership_type_id' => $membershipType['id'],
+      'payment_method' => $this->getPaymentMethodValue(),
     ];
 
     return new CRM_MembershipExtras_API_PaymentSchedule_MembershipType($params);
@@ -152,6 +155,7 @@ class CRM_MembershipExtras_API_PaymentSchedule_MembershipTypeTest extends BaseHe
     $params = [
       'schedule' => $schedule,
       'membership_type_id' => $membershipType['id'],
+      'payment_method' => $this->getPaymentMethodValue(),
       //make sure we pass start date in params,
       //so the calculators can calculate correct dates and amounts for
       // fixed period membership type.

--- a/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/PriceValuesTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/API/PaymentSchedule/PriceValuesTest.php
@@ -12,6 +12,8 @@ use CRM_MembershipExtras_Test_Fabricator_PriceFieldValue as PriceFieldValueFabri
  */
 class CRM_MembershipExtras_API_PaymentSchedule_PriceValuesTest extends BaseHeadlessTest {
 
+  use CRM_MembershipExtras_Test_Helper_PaymentMethodTrait;
+
   /**
    * @throws CiviCRM_API3_Exception
    * @throws API_Exception
@@ -37,6 +39,7 @@ class CRM_MembershipExtras_API_PaymentSchedule_PriceValuesTest extends BaseHeadl
     $params = [
       'schedule' => CRM_MembershipExtras_Service_MembershipInstalmentsSchedule::MONTHLY,
       'price_field_values' => ['IN' => $selectedPriceFieldValues],
+      'payment_method' => $this->getPaymentMethodValue(),
     ];
 
     $paymentSchedule = new CRM_MembershipExtras_API_PaymentSchedule_PriceValues($params);
@@ -57,6 +60,7 @@ class CRM_MembershipExtras_API_PaymentSchedule_PriceValuesTest extends BaseHeadl
     $params = [
       'sequential' => 1,
       'schedule' => 'monthly',
+      'payment_method' => $this->getPaymentMethodValue(),
     ];
     $selectedPriceFieldValues = [];
     foreach ($priceFieldValues as $priceFieldValue) {

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
@@ -16,6 +16,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionT
   use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
   use CRM_MembershipExtras_Test_Helper_FixedPeriodMembershipTypeSettingsTrait;
 
+  private $mockCalculatedReceiveDate;
+
   /**
    * Implements calculateContributionReceiveDate hook for testing.
    *
@@ -24,8 +26,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionT
    * @param $contributionCreationParams
    */
   public function hook_membershipextras_calculateContributionReceiveDate($instalment, &$receiveDate, &$contributionCreationParams) {
-    if (isset($contributionCreationParams['test_receive_date_calculation_hook'])) {
-      $receiveDate = $contributionCreationParams['test_receive_date_calculation_hook'];
+    if (isset($this->mockCalculatedReceiveDate)) {
+      $receiveDate = $this->mockCalculatedReceiveDate;
     }
   }
 
@@ -126,6 +128,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionT
     $membershipType = $this->mockMembershipType('rolling', 'month');
     $membership = $this->mockMembership($contact['id'], $membershipType['id'], $startDate);
     $newReceiveDate = date('Y-m-27');
+    $this->mockCalculatedReceiveDate = $newReceiveDate;
     $params = [
       'is_pay_later' => TRUE,
       'skipLineItem' => 1,
@@ -141,7 +144,6 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionT
       'currency' => NULL,
       'is_test' => FALSE,
       'campaign_id' => NULL,
-      'test_receive_date_calculation_hook' => $newReceiveDate,
       'line_item' => [
         0 => [
           1 => [

--- a/tests/phpunit/CRM/MembershipExtras/Page/InstalmentScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Page/InstalmentScheduleTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
-use CRM_MembershipExtras_Test_Fabricator_PriceSet as PriceSetFabricator;
-use CRM_MembershipExtras_Test_Fabricator_PriceField as PriceFieldFabricator;
-use CRM_MembershipExtras_Test_Fabricator_PriceFieldValue as PriceFieldValueFabricator;
 
 /**
  * Class CRM_MembershipExtras_Page_InstalmentScheduleTest
@@ -14,6 +11,7 @@ class CRM_MembershipExtras_Page_InstalmentScheduleTest extends BaseHeadlessTest 
 
   use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
   use CRM_MembershipExtras_Test_Helper_FixedPeriodMembershipTypeSettingsTrait;
+  use CRM_MembershipExtras_Test_Helper_PaymentMethodTrait;
 
   public function testRunRollingMembershipType() {
     $memType = $this->mockFixedMembershipType('rolling');
@@ -22,6 +20,7 @@ class CRM_MembershipExtras_Page_InstalmentScheduleTest extends BaseHeadlessTest 
     $_REQUEST['start_date'] = $today->format('Y-m-d');
     $_REQUEST['join_date'] = $today->format('Y-m-d');
     $_REQUEST['membership_type_id'] = $memType['id'];
+    $_REQUEST['payment_method'] = $this->getPaymentMethodValue();
     $_REQUEST['snippet']  = 'json';
     $page = new CRM_MembershipExtras_Page_InstalmentSchedule();
     $this->disableReturnResult($page);
@@ -88,41 +87,6 @@ class CRM_MembershipExtras_Page_InstalmentScheduleTest extends BaseHeadlessTest 
     $this->mockSettings($memType['id'], CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator::BY_MONTHS);
 
     return $memType;
-  }
-
-  /**
-   * @return array
-   * @throws CiviCRM_API3_Exception
-   */
-  private function mockPriceFieldValues() {
-    $priceFieldValues = [];
-    $membershipType = MembershipTypeFabricator::fabricate(array_merge(
-      ['name' => 'Rolling Membership Type 1', 'minimum_fee' => 120]));
-
-    $priceSetParams = [
-      'name' => "test_price_set",
-      'extends' => "CiviMember",
-      'financial_type_id' => "Member Dues",
-      'is_active' => 1,
-    ];
-    $priceSet = PriceSetFabricator::fabricate($priceSetParams);
-
-    $priceField1 = PriceFieldFabricator::fabricate([
-      'price_set_id' => $priceSet['id'],
-      'label' => "Price Field 1",
-      'name' => "price_field_1",
-      'html_type' => "Radio",
-    ]);
-
-    $priceFieldValues[] = PriceFieldValueFabricator::fabricate([
-      'price_field_id' => $priceField1['id'],
-      'label' => "Price Field Value with Membership Type 1",
-      'amount' => 240,
-      'membership_type_id' => $membershipType['id'],
-      'financial_type_id' => "Member Dues",
-    ]);
-
-    return $priceFieldValues;
   }
 
 }

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
@@ -18,6 +18,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
 
   use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
   use CRM_MembershipExtras_Test_Helper_FixedPeriodMembershipTypeSettingsTrait;
+  use CRM_MembershipExtras_Test_Helper_PaymentMethodTrait;
 
   /**
    * Defatuls tax rate
@@ -222,7 +223,6 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $divisor = 12;
     $expectedAmount = $this->calculateExpectedAmount($membershipTypes, $divisor);
     $expectedTaxAmount = $this->calculateExpectedTaxAmount($expectedAmount);
-    $expectedTotalAmount = $expectedAmount + $expectedTaxAmount;
     foreach ($schedule['instalments'] as $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
@@ -385,7 +385,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
       MembershipInstalmentsSchedule::MONTHLY
     );
     $expectedAmount = $totalAmount / 12;
-    foreach ($schedule['instalments'] as $index => $instalment) {
+    foreach ($schedule['instalments'] as $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals(0, $instalment->getInstalmentAmount()->getTaxAmount());
       $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
@@ -421,7 +421,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
       MembershipInstalmentsSchedule::MONTHLY
     );
     $expectedTaxAmount = ($totalAmount * self::TAX_RATE / 100) / 12;
-    foreach ($schedule['instalments'] as $index => $instalment) {
+    foreach ($schedule['instalments'] as $instalment) {
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
       $this->assertCount(count($membershipTypes), $instalment->getInstalmentAmount()->getLineItems());
       foreach ($instalment->getInstalmentAmount()->getLineItems() as $key => $lineItem) {
@@ -482,13 +482,12 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $totalNonMembershipPriceFieldValueTaxAmount = $totalUnitPrice * self::TAX_RATE / 100;
     $totalNonMembershipPriceFieldValueTaxAmount *= $mockedQuantity;
     $totalNonMembershipPriceFieldValueAmount  = $totalUnitPrice * $mockedQuantity;
-    $totalNonMembershipPriceFieldValueTotal = $totalNonMembershipPriceFieldValueTaxAmount + $totalNonMembershipPriceFieldValueAmount;
 
     $mockInstalmentNumber = 12;
     $expectedAmount = ($totalAmount + $totalNonMembershipPriceFieldValueAmount) / $mockInstalmentNumber;
     $expectedTaxAmount = ($taxAmount + $totalNonMembershipPriceFieldValueTaxAmount) / $mockInstalmentNumber;
 
-    foreach ($schedule['instalments'] as $index => $instalment) {
+    foreach ($schedule['instalments'] as $instalment) {
       $this->assertEquals($expectedAmount, $instalment->getInstalmentAmount()->getAmount());
       $this->assertEquals($expectedTaxAmount, $instalment->getInstalmentAmount()->getTaxAmount());
       //Membership type array size = 1 and none membership price field size = 1
@@ -661,6 +660,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $membershipTypeDates = $this->getMembershipDates($membershipTypes[0]->id, $startDate);
 
     return $membershipInstalmentsSchedule->generate(
+      $this->getPaymentMethodValue(),
       new DateTime($membershipTypeDates['start_date']),
       new DateTime($membershipTypeDates['end_date']),
       new DateTime($membershipTypeDates['join_date'])

--- a/tests/phpunit/api/v3/PaymentSchedule/GetPaymentScheduleTest.php
+++ b/tests/phpunit/api/v3/PaymentSchedule/GetPaymentScheduleTest.php
@@ -13,6 +13,7 @@ use CRM_MembershipExtras_Test_Fabricator_PriceFieldValue as PriceFieldValueFabri
 class api_v3_PaymentSchedule_GetPaymentScheduleTest extends BaseHeadlessTest {
 
   use CRM_MembershipExtras_Test_Helper_FixedPeriodMembershipTypeSettingsTrait;
+  use CRM_MembershipExtras_Test_Helper_PaymentMethodTrait;
 
   /**
    * Test ExceptionIsThrownIfScheduleIsNotValid
@@ -24,6 +25,7 @@ class api_v3_PaymentSchedule_GetPaymentScheduleTest extends BaseHeadlessTest {
     civicrm_api3('PaymentSchedule', 'getByMembershipType', [
       'membership_type_id' => 1,
       'schedule' => 'xyz',
+      'payment_method' => $this->getPaymentMethodValue(),
     ])['values'];
   }
 
@@ -87,7 +89,6 @@ class api_v3_PaymentSchedule_GetPaymentScheduleTest extends BaseHeadlessTest {
 
     //Mock end date as per membership type rollover day
     $endDate = new DateTime(date('2021-09-30'));
-    $interval = $endDate->diff($startDate);
     $interval = $endDate->diff($startDate);
     $durationInDays = (int) $interval->format("%a") + 1;
     //Calculate expected amount by days.
@@ -171,6 +172,7 @@ class api_v3_PaymentSchedule_GetPaymentScheduleTest extends BaseHeadlessTest {
     $priceFieldValues = $this->mockPriceFieldValues();
     $params = [
       'schedule' => 'monthly',
+      'payment_method' => $this->getPaymentMethodValue(),
     ];
     $selectedPriceFieldValues = [];
     foreach ($priceFieldValues as $priceFieldValue) {
@@ -247,6 +249,7 @@ class api_v3_PaymentSchedule_GetPaymentScheduleTest extends BaseHeadlessTest {
     $params = [
       'membership_type_id' => $membershipID,
       'schedule' => $schedule,
+      'payment_method' => $this->getPaymentMethodValue(),
     ];
     if (!is_null($startDate)) {
       $params['start_date'] = $startDate;


### PR DESCRIPTION
## Overview

This PR modifies the custom CalculateContribuitonRecieveDate hook dispatches with an abstract params instead of dispatching contribution object. 

Membership Extras version 5 provides a new payment schedule UI that virtualise the details of instalments that would be created as follow

![screenshot-compuclient local-2021 04 14-15_17_57](https://user-images.githubusercontent.com/208713/114725838-c0985100-9d34-11eb-898f-31e20e0016df.png)

The existing CalculateContribuitonRecieveDate hook did not support when the payment plan has not been created it yet therefore, the instalment date could not be modified to virtualise on the instalment schedule table. 

This PR fixed that. 

## Before

Hook can only be dispatched after the membership form is submitted.

## After

Hook can be dispatched either before and after the payment plan is created. 

## Technical Details

The parameter that was passed to the hook was the contribution object and the hook implementer  that modify the instalment date (e.g. Manual Direct bit Extension)  does not need all the information. 

The new parameters that provide to hook are below, which would work when generating instalment schedule before and after submit the membership form. 

```
    $params = [
      'membership_id' => NULL,
      'contribution_recur_id' => NULL,
      'previous_instalment_date' => NULL,
      'payment_schedule' => $this->schedule,
      'payment_instrument_id' => $paymentMethod,
      'membership_start_date' => $firstInstalmentDate,
      'frequency_interval' => $instalmentFrequencyInterval,
      'frequency_unit' => $instalmentFrequencyUnit,
    ];
```