### PR TITLE
CIVIPLUS-176: Add administer Membership Extras permission

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -134,8 +134,8 @@ function membershipextras_civicrm_navigationMenu(&$menu) {
     'name' => 'payment_plan_settings',
     'label' => ts('Payment Plan Settings'),
     'url' => 'civicrm/admin/payment_plan_settings',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
+    'permission' => 'administer CiviCRM,administer MembershipExtras',
+    'operator' => 'OR',
     'separator' => NULL,
   ];
 
@@ -145,8 +145,8 @@ function membershipextras_civicrm_navigationMenu(&$menu) {
     'name' => 'automated_membership_upgrade_rules',
     'label' => ts('Membership Automated Upgrade Rules'),
     'url' => 'civicrm/admin/member/automated-upgrade-rules?reset=1',
-    'permission' => 'administer CiviCRM',
-    'operator' => NULL,
+    'permission' => 'administer CiviCRM,administer MembershipExtras',
+    'operator' => 'OR',
     'separator' => 2,
   ];
   _membershipextras_civix_insert_navigation_menu($menu, 'Administer/CiviMember', $automatedMembershipUpgradeRulesMenuItem);
@@ -466,4 +466,17 @@ function membershipextras_civicrm_preProcess($formName, $form) {
 function membershipextras_civicrm_alterMailParams(&$params, $context) {
   $alterMailParamsHook = new CRM_MembershipExtras_Hook_Alter_MailParamsHandler($params);
   $alterMailParamsHook->handle();
+}
+
+/**
+ * Implements hook_civicrm_permission().
+ *
+ */
+function membershipextras_civicrm_permission(&$permissions) {
+  $permissions += [
+    'administer MembershipExtras' => [
+      E::ts('MembershipExtras: administer Membership Extras'),
+      E::ts('Perform all Membership Extras administration tasks in CiviCRM'),
+    ],
+  ];
 }

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -4,25 +4,25 @@
     <path>civicrm/admin/payment_plan_settings</path>
     <page_callback>CRM_MembershipExtras_Form_PaymentPlanSettings</page_callback>
     <title>Payment Plan Settings</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;administer MembershipExtras</access_arguments>
   </item>
   <item>
     <path>civicrm/admin/member/automated-upgrade-rules</path>
     <page_callback>CRM_MembershipExtras_Page_AutomatedMembershipUpgradeRule</page_callback>
     <title>Membership Automated Upgrade Rules</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;administer MembershipExtras</access_arguments>
   </item>
   <item>
     <path>civicrm/admin/member/automated-upgrade-rules/add</path>
     <page_callback>CRM_MembershipExtras_Form_AutomatedUpgradeRule</page_callback>
     <title>New Automated Membership Upgrade Rule</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;administer MembershipExtras</access_arguments>
   </item>
   <item>
     <path>civicrm/admin/member/automated-upgrade-rules/delete</path>
     <page_callback>CRM_MembershipExtras_Form_AutomatedUpgradeRuleDelete</page_callback>
     <title>Delete Automated Membership Upgrade Rule</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM;administer MembershipExtras</access_arguments>
   </item>
   <item>
     <path>civicrm/recurring-contribution/cancel</path>


### PR DESCRIPTION
## Overview

Currently, the direct debit configuration can only be accessed with a user that has permission `administer CiviCRM`. In some systems like SaaS platform or even in some organisations, that may not want to give  `administer CiviCRM` to the site administer  but allows access to the certain admin pages and forms.   

This PR adds new `administer MembershipExtras` permission and assign this permission to existing configuration pages that  allows a system admin to assign a new permission to other roles, so the user with the role can access the setting pages without having a global `administer CiviCRM` permission.

## Before

Only user that has `administer CiviCRM` permission can access Membership Extras configuration pages.

## After

Either user that has `administer CiviCRM`  or  `administer MembershipExtras` permission can access Membership Extras configuration pages.
