### PR TITLE
MAE-539: Fix new membership screen on memberships tab 

### DIFF
--- a/CRM/MembershipExtras/Helper/PaymentPlanTogglerTrait.php
+++ b/CRM/MembershipExtras/Helper/PaymentPlanTogglerTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Trait CRM_MembershipExtras_Helper_PaymentPlanTogglerTrait
+ */
+trait CRM_MembershipExtras_Helper_PaymentPlanTogglerTrait {
+
+  /**
+   * @param $region
+   */
+  private function addResources($region) {
+    Civi::resources()->add([
+      'scriptFile' => ['uk.co.compucorp.membershipextras', 'js/paymentPlanToggler.js'],
+      'region' => $region,
+    ]);
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/MembershipPaymentPlan.php
@@ -8,6 +8,8 @@ use CRM_MembershipExtras_ExtensionUtil as E;
  */
 class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan {
 
+  use CRM_MembershipExtras_Helper_PaymentPlanTogglerTrait;
+
   /**
    * @var string
    *   Path where template with new fields is stored.
@@ -53,6 +55,8 @@ class CRM_MembershipExtras_Hook_BuildForm_MembershipPaymentPlan {
     CRM_Core_Region::instance('page-body')->add([
       'template' => "{$this->templatePath}/CRM/Member/Form/PaymentPlanToggler.tpl",
     ]);
+
+    $this->addResources('html-header');
   }
 
 }

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageDashboardColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageDashboardColourUpdate.php
@@ -2,7 +2,7 @@
 
 use CRM_MembershipExtras_SettingsManager as MembershipTypeSettings;
 
-class CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate {
+class CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate implements CRM_MembershipExtras_Hook_PageRun_PageRunInterface {
 
   /**
    * Modifies the membership type background colour on the member dashboard page

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageDashboardColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageDashboardColourUpdate.php
@@ -31,7 +31,7 @@ class CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate implemen
   /**
    * Sets membership typ colour styles on member dashboard page.
    *
-   * @param CRM_Core_Page$page
+   * @param CRM_Core_Page $page
    */
   private function setMembershipTypeColourStyle($page) {
     $rows = $page->get_template_vars('rows');
@@ -63,4 +63,5 @@ class CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate implemen
     }
     CRM_Core_Resources::singleton()->addStyle($css);
   }
+
 }

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageTab.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageTab.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_PageRun_MemberPageTab
+ */
+class CRM_MembershipExtras_Hook_PageRun_MemberPageTab implements CRM_MembershipExtras_Hook_PageRun_PageRunInterface {
+
+  use CRM_MembershipExtras_Helper_PaymentPlanTogglerTrait;
+
+  /**
+   * @param CRM_Core_Page $page
+   */
+  public function handle($page) {
+    if (!$this->shouldHandle($page)) {
+      return;
+    }
+
+    $this->addResources('page-header');
+  }
+
+  /**
+   * Checks if this is the right page
+   *
+   * @param CRM_Core_Page $page
+   *
+   * @return bool
+   */
+  private function shouldHandle($page) {
+    return $page instanceof CRM_Member_Page_Tab;
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
@@ -2,7 +2,7 @@
 
 use CRM_MembershipExtras_SettingsManager as MembershipTypeSettings;
 
-class CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate {
+class CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate implements CRM_MembershipExtras_Hook_PageRun_PageRunInterface {
 
   /**
    * Modifies the membership type background colour on the member page tab

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
@@ -56,4 +56,5 @@ class CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate implements CRM
     }
     CRM_Core_Resources::singleton()->addStyle($css, 10);
   }
+
 }

--- a/CRM/MembershipExtras/Hook/PageRun/MembershipTypePageColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MembershipTypePageColourUpdate.php
@@ -26,7 +26,7 @@ class CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate implement
     $membershipTypeColourSettings = Civi::settings()->get(MembershipTypeSettings::COLOUR_SETTINGS_KEY);
     $css = '';
 
-    foreach ($membershipTypeColourSettings  as $membershipTypeId => $settings) {
+    foreach ($membershipTypeColourSettings as $membershipTypeId => $settings) {
       $backgroundColour = $settings['membership_colour'];
       if (empty($settings['set_membership_colour'])) {
         $backgroundColour = 'inherit';
@@ -59,4 +59,5 @@ class CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate implement
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.membershipextras', 'js/vendor/spectrum/spectrum.min.js');
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.membershipextras', 'js/vendor/spectrum/spectrum.css');
   }
+
 }

--- a/CRM/MembershipExtras/Hook/PageRun/MembershipTypePageColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MembershipTypePageColourUpdate.php
@@ -2,7 +2,7 @@
 
 use CRM_MembershipExtras_SettingsManager as MembershipTypeSettings;
 
-class CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate {
+class CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate implements CRM_MembershipExtras_Hook_PageRun_PageRunInterface {
 
   /**
    * Modifies the membership type background colour.

--- a/CRM/MembershipExtras/Hook/PageRun/PageRunInterface.php
+++ b/CRM/MembershipExtras/Hook/PageRun/PageRunInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+interface CRM_MembershipExtras_Hook_PageRun_PageRunInterface {
+
+  /**
+   * @param CRM_Core_Page $page
+   */
+  public function handle($page);
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -342,7 +342,9 @@ function membershipextras_civicrm_pageRun($page) {
     new CRM_MembershipExtras_Hook_PageRun_MembershipTypePageColourUpdate(),
     new CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate(),
     new CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate(),
+    new CRM_MembershipExtras_Hook_PageRun_MemberPageTab(),
   ];
+
   foreach ($hooks as $hook) {
     $hook->handle($page);
   }

--- a/templates/CRM/Member/Form/PaymentPlanToggler.tpl
+++ b/templates/CRM/Member/Form/PaymentPlanToggler.tpl
@@ -1,4 +1,3 @@
-{crmScript ext=uk.co.compucorp.membershipextras file=js/paymentPlanToggler.js region=html-header}
 <script type="text/javascript">
   {literal}
   CRM.$(function ($) {

--- a/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
+++ b/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
@@ -1,9 +1,4 @@
 {crmStyle ext=uk.co.compucorp.membershipextras file=css/instalmentSchedule.css}
-<script type="text/javascript">
-  {literal}
-
-  {/literal}
-</script>
 {crmScript ext=uk.co.compucorp.membershipextras file=js/instalmentSchedule.js}
 <table id="instalment_row_table" class="selector row-highlight" style="position: relative;">
   <thead class="sticky">


### PR DESCRIPTION
## Overview

This PR fixes the new membership form does not load properly when accessing from Membership Tab in Contact summary page.

## Before

![Peek 2021-05-10 15-06](https://user-images.githubusercontent.com/208713/117672039-59d64e00-b1a1-11eb-9163-80243c71b99d.gif)

## After

![Peek 2021-05-10 15-08](https://user-images.githubusercontent.com/208713/117672317-a457ca80-b1a1-11eb-938e-7cf4670789f6.gif)

## Technical Details

In this [PR](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/366), we separated JavaScript functions onto  a JavaScript file, and then we add JavaScript files into the template, so we could separate logics from template. By doing that the JavaScript was loaded property when buildForm hook is called and the JavaScript is loaded into` html-header` region.   

However, when accessing the form as a modal from membership tab on the contact summary page, the html header region has been declared on the main page and therefore CiviCRM ignore this injection.  In order to address this issue, the JavaScript file must be added to `CRM_Member_Page_Tab` in `page-body ` region so the JavaScript exist before the form is loaded. 

A trait was created so the code for injection of the JavaScript can be shared into different hooks. 


```
trait CRM_MembershipExtras_Helper_PaymentPlanTogglerTrait {

  /**
   * @param $region
   */
  private function addResources($region) {
    Civi::resources()->add([
      'scriptFile' => ['uk.co.compucorp.membershipextras', 'js/paymentPlanToggler.js'],
      'region' => $region,
    ]);
  }

}

```
