### PR TITLE
MAE-551: Make membership manual renewal screen work with version 5 UI

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -262,7 +262,7 @@ function membershipextras_civicrm_postProcess($formName, &$form) {
       return;
     }
 
-    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor($form);
+    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor($formName, $form);
     $paymentPlanProcessor->postProcess();
 
     if ($formName == 'CRM_Member_Form_Membership') {

--- a/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessorTest.php
@@ -34,6 +34,8 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
    */
   private $paymentPlanMembershipOrder;
 
+  private static $NEW_MEMBERSHIP_FORM_NAME = 'CRM_Member_Form_Membership';
+
   public function setUp() {
     $this->setUpMembershipForm();
   }
@@ -41,7 +43,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
   public function testProcessFormWithRollingMembershipTypeAndMonthlySchedule() {
     $this->createPaymentPlanMembershipOrder('rolling');
     $this->simulateMembershipSignupForm('monthly', date('Y-m-d'));
-    $processor = new MembershipPaymentPlanProcessor($this->form);
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form);
     $processor->postProcess();
 
     $membershipPayments = $this->getMembershipPayment($this->form->_id);
@@ -52,7 +54,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
   public function testProcessFormWithRollingMembershipTypeAndQuarterlySchedule() {
     $this->createPaymentPlanMembershipOrder('rolling');
     $this->simulateMembershipSignupForm('quarterly', date('Y-m-d'));
-    $processor = new MembershipPaymentPlanProcessor($this->form);
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form);
     $processor->postProcess();
 
     $membershipPayments = $this->getMembershipPayment($this->form->_id);
@@ -63,7 +65,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
   public function testProcessFormWithFixedPeriodTypeWithMonthlySchedule() {
     $this->createPaymentPlanMembershipOrder('fixed');
     $this->simulateMembershipSignupForm('monthly', date('Y-01-15'));
-    $processor = new MembershipPaymentPlanProcessor($this->form);
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form);
     $processor->postProcess();
 
     $membershipPayments = $this->getMembershipPayment($this->form->_id);
@@ -80,7 +82,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
   public function testPostProcessFormForOneInstalment() {
     $this->createPaymentPlanMembershipOrder('rolling');
     $this->simulateMembershipSignupForm('annual', date('Y-m-d'));
-    $processor = new MembershipPaymentPlanProcessor($this->form);
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form);
     $processor->postProcess();
 
     $membershipPayments = $this->getMembershipPayment($this->form->_id);
@@ -183,7 +185,6 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
       'sequential' => 1,
       'membership_id' => $membershipId,
     ]);
-
   }
 
 }


### PR DESCRIPTION
## Overview

This PR fixes the issue when using renewal membership manually.  

## Before

When clicking Renew from the form, the indicator kept spinning due to the error happens in the backend. 

![MAE-551](https://user-images.githubusercontent.com/208713/128183949-70528c52-0ac1-4053-bd08-1f640b1456a5.gif)

## After

![Peek 2021-08-04 13-50](https://user-images.githubusercontent.com/208713/128183635-d8fa3455-5243-4228-bb27-11be88616448.gif)

## Technical Details

The MembershipPaymentPlanProcessor  and paymentPlanToggler.js designed to use `start_date` field to pass to the API to generate instalments as well as using as the first contribution received date.  The start_date`  field only exists in the new membership form and does not exist in the renewal membership form. 

This PR updates MembershipPaymentPlanProcessor and paymentPlanToggler.js to use  `renewal_date` as contribution received date when using renewal membership form. 
