### PR TITLE
WHF-175: Don't copy contribution fees from last term on autorenewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -298,8 +298,8 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   private function setLastContribution() {
     $contribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
-      'return' => ['currency', 'contribution_source', 'net_amount',
-        'contact_id', 'fee_amount', 'total_amount', 'payment_instrument_id',
+      'return' => ['currency', 'contribution_source',
+        'contact_id', 'total_amount', 'payment_instrument_id',
         'is_test', 'tax_amount', 'contribution_recur_id', 'financial_type_id',
       ],
       'contribution_recur_id' => $this->currentRecurContributionID,
@@ -758,8 +758,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       'currency' => $this->lastContribution['currency'],
       'source' => $this->lastContribution['contribution_source'],
       'contact_id' => $this->lastContribution['contact_id'],
-      'fee_amount' => $this->lastContribution['fee_amount'],
-      'net_amount' => $this->totalAmount - $this->lastContribution['fee_amount'],
+      'net_amount' => $this->totalAmount,
       'total_amount' => $this->totalAmount,
       'receive_date' => $this->paymentPlanStartDate,
       'payment_instrument_id' => $this->lastContribution['payment_instrument_id'],

--- a/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php
@@ -1017,6 +1017,58 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     ]);
   }
 
+  public function testRenewalWillNotCopyContributionFeeAmountFromPreviousTerm() {
+    $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year +1 day'));
+    $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
+    $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
+    $paymentPlanMembershipOrder->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $this->testRollingMembershipTypePriceFieldValue['price_field_id'],
+      'price_field_value_id' => $this->testRollingMembershipTypePriceFieldValue['id'],
+      'label' => $this->testRollingMembershipType['name'],
+      'qty' => 1,
+      'unit_price' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'line_total' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+    ];
+    $paymentPlan = PaymentPlanOrderFabricator::fabricate($paymentPlanMembershipOrder);
+
+    // updating the fees for the previous term last contribution
+    $previousTermLastContributionId = $this->getPaymentPlanContributions($paymentPlan['id'])[11]['id'];
+    civicrm_api3('Contribution', 'create', [
+      'id' => $previousTermLastContributionId,
+      'fee_amount' => 10,
+    ]);
+
+    $multipleInstalmentRenewal = new MultipleInstalmentRenewalJob();
+    $multipleInstalmentRenewal->run();
+
+    $nextPeriodId = $this->getTheNewRecurContributionIdFromCurrentOne($paymentPlan['id']);
+
+    $newTermContributionFees = $this->getPaymentPlanContributions($nextPeriodId)[0]['fee_amount'];
+    $this->assertEquals('0.00', $newTermContributionFees);
+  }
+
+  /**
+   * Returns list of contributions associated to the given payment plan ID.
+   * @param int $paymentPlanID
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function getPaymentPlanContributions($paymentPlanID) {
+    return civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $paymentPlanID,
+      'options' => [
+        'limit' => 0,
+        'sort' => 'id',
+      ],
+    ])['values'];
+  }
+
   /**
    * Checks the structure of the payment plan follows the given expected values.
    *


### PR DESCRIPTION
## Before
On autorenewal, contribution fees are getting copied to the new term contributions, which should not be the case given new terms might get paid using different payment processor and/or payment method.

## After
Contribution fees are no longer copied for the new term contributions.
