### PR TITLE
MAE-580: Make 'next scheduled contribution date' field editable from UI

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -79,6 +79,12 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
     $this->form->add('text', 'cycle_day', ts('Cycle Day'), [], TRUE);
     $this->form->setDefaults(['cycle_day' => $this->recurringContribution['cycle_day']]);
 
+    $this->form->add('datepicker', 'next_sched_contribution_date', ts('Next Scheduled Contribution Date'), [], FALSE, ['time' => FALSE]);
+    $nextScheduledDate = CRM_Utils_Array::value('next_sched_contribution_date', $this->recurringContribution);
+    if (!empty($nextScheduledDate)) {
+      $this->form->setDefaults(['next_sched_contribution_date' => $this->recurringContribution['next_sched_contribution_date']]);
+    }
+
     $this->form->addButtons([
       [
         'type' => 'upload',

--- a/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
+++ b/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
@@ -21,6 +21,14 @@
       <input type="hidden" name="old_cycle_day" id="old_cycle_day" value="{$form.cycle_day.value}"/>
     </td>
   </tr>
+  <tr id="next_sched_contribution_date_field">
+    <td class="label">
+      {$form.next_sched_contribution_date.label}
+    </td>
+    <td>
+      {$form.next_sched_contribution_date.html}
+    </td>
+  </tr>
   <tr id="autorenew_field">
     <td class="label">
       {$form.auto_renew.label}


### PR DESCRIPTION
## Overview

Since we are going to use 'next scheduled contribution date' field to determine if we should renew a payment plan or not, we want to give users the ability to adjust its value if needed. The work here exposes this field in the payment plan edit form.

## Before
The  'next scheduled contribution date'  is not available in the payment plan edit form, and updating the cycle day will affect its value.

![2021-08-19 18_51_21-askdas@ad com askdas@ad com _ civi5352v5](https://user-images.githubusercontent.com/6275540/130100951-b7924f1d-3af3-428e-8f7c-bd71f4e20317.png)


## After



The  'next scheduled contribution date'  is available and editable through the payment plan edit form, and updating the cycle day does not affect its value.

![2021-08-19 18_51_58-askdas@ad com askdas@ad com _ civi5352v5](https://user-images.githubusercontent.com/6275540/130101055-b029cb8f-da9e-4703-8f36-bb9a5805b237.png)

![bef1](https://user-images.githubusercontent.com/6275540/130101969-f49c120f-0764-4f0b-a2b6-c2b1b875cd9d.gif)

