### PR TITLE
MAE-581: Prevent updating 'Next contribution date' from outside Membershipextras for offline payment processors

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/UpdateSubscription.php
@@ -76,11 +76,6 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
       'auto_renew' => $autoRenew,
     ];
 
-    $nextScheduledDate = CRM_Utils_Array::value('next_sched_contribution_date', $this->formValues);
-    if (!empty($nextScheduledDate)) {
-      $params['next_sched_contribution_date'] = $this->formValues['next_sched_contribution_date'];
-    }
-
     if ($this->isUpdatedCycleDay()) {
       $firstInstallment = $this->getFirstInstallment();
       if ($firstInstallment['contribution_status'] == 'Pending') {
@@ -89,6 +84,15 @@ class CRM_MembershipExtras_Hook_PostProcess_UpdateSubscription {
     }
 
     civicrm_api3('ContributionRecur', 'create', $params);
+
+    $nextScheduledDate = CRM_Utils_Array::value('next_sched_contribution_date', $this->formValues);
+    if (!empty($nextScheduledDate)) {
+      $query = 'UPDATE civicrm_contribution_recur SET next_sched_contribution_date = %1 WHERE id = %2';
+      CRM_Core_DAO::executeQuery($query, [
+        1 => [$nextScheduledDate, 'String'],
+        2 => [$params['id'], 'Integer'],
+      ]);
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/ContributionRecurTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_Pre_ContributionRecurTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_Pre_ContributionRecurTest extends BaseHeadlessTest {
+
+  public function testPreventUpdatingNextScheduledContributionDateForManualRecurContribution() {
+    $offlinePaymentProcessorId = civicrm_api3('PaymentProcessor', 'getvalue', [
+      'return' => 'id',
+      'name' => 'Offline Recurring Contribution',
+      'is_test' => 0,
+    ]);
+
+    $recurringContributionID = civicrm_api3('ContributionRecur', 'create', [
+      'contact_id' => 1,
+      'amount' => 10,
+      'frequency_interval' => 1,
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'next_sched_contribution_date' => date('Y-m-d', strtotime('+1 month')),
+    ])['id'];
+
+    $paymentPlanParams = [
+      'next_sched_contribution_date' => date('Y-m-d', strtotime('+1 month')),
+      'payment_processor_id' => $offlinePaymentProcessorId,
+    ];
+
+    $hook = new CRM_MembershipExtras_Hook_Pre_ContributionRecur('edit', $recurringContributionID, $paymentPlanParams);
+    $hook->preProcess();
+
+    $this->assertFalse(array_key_exists('next_sched_contribution_date', $paymentPlanParams));
+  }
+
+  public function testKeepingNextScheduledContributionDateForNonManualRecurContribution() {
+    $dummyPaymentProcessorId = civicrm_api3('PaymentProcessor', 'create', [
+      'payment_processor_type_id' => 'Dummy',
+      'financial_account_id' => 'Payment Processor Account',
+      'name' => 'dummy_processor',
+    ])['id'];
+
+    $recurringContributionID = civicrm_api3('ContributionRecur', 'create', [
+      'contact_id' => 1,
+      'amount' => 10,
+      'frequency_interval' => 1,
+      'payment_processor_id' => 'dummy_processor',
+      'next_sched_contribution_date' => date('Y-m-d', strtotime('+1 month')),
+    ])['id'];
+
+    $paymentPlanParams = [
+      'next_sched_contribution_date' => date('Y-m-d', strtotime('+1 month')),
+      'payment_processor_id' => $dummyPaymentProcessorId,
+    ];
+
+    $hook = new CRM_MembershipExtras_Hook_Pre_ContributionRecur('edit', $recurringContributionID, $paymentPlanParams);
+    $hook->preProcess();
+
+    $this->assertTrue(array_key_exists('next_sched_contribution_date', $paymentPlanParams));
+  }
+
+}


### PR DESCRIPTION
## Overview

I here prevent any update to the recurring contribution 'next_sched_contribution_date' field from outside
Membershipextras (Basically preventing CiviCRM core and the webform_civicrm module from altering its value) since it will be used for autorenewal, and thus we need to be able to control its value with external interference. Hence that this only affect offline payment processors (any payment processor that extends the Payment_Manual class).

## Before

Creating payment plan from the admin form or from a webform will set the `next_sched_contribution_date` value 

![bee](https://user-images.githubusercontent.com/6275540/130268629-2019d572-8820-4a55-866d-0e441baac6c0.gif)



## After

Creating payment plan from admin form or from webform will set the `next_sched_contribution_date` to blank

![affff](https://user-images.githubusercontent.com/6275540/130268706-75e73e8e-b4fe-4423-bc21-1e681892f4c9.gif)

Hence that this is temporary, and I will later implement new code to set its value but form within Membershipextras, since the value that we see in the "Before" section gif is coming from CiviCRM core which we don't control. 


## Technical details

I unset the value by removing the value of this field inside the Recurring Contribution Pre hook, this means that
any API or DAO that try to change the value of this field will not work (which is how CiviCRM core and webform_civicrm module alter its value), Which allow us to control its value within Membershipextras using Direct SQL queries.

