### PR TITLE
MAE-582: Set next contribution date when creating payment plan membership

### DIFF
--- a/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
+++ b/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
@@ -17,17 +17,18 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
    * Fabricates payment plan order.
    *
    * @param CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder $paymentPlanMembershipOrder
+   * @param bool $createUpfrontContributions
    *
    * @return array
    */
-  public static function fabricate(PaymentPlanMembershipOrderEntity $paymentPlanMembershipOrder) {
+  public static function fabricate(PaymentPlanMembershipOrderEntity $paymentPlanMembershipOrder, $createUpfrontContributions = TRUE) {
     self::$paymentPlanMembershipOrder = $paymentPlanMembershipOrder;
     self::updatePaymentPlanMissingParams();
 
     $recurringContribution = self::createRecurringContribution();
     $lineItems = self::createRecurringLineItems($recurringContribution);
     self::updateRecurringContributionAmount($recurringContribution);
-    self::createInstalments($recurringContribution, $lineItems);
+    self::createInstalments($recurringContribution, $lineItems, $createUpfrontContributions);
 
     return $recurringContribution;
   }
@@ -238,13 +239,17 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
    *
    * @param array $recurringContribution
    * @param array $lineItems
+   * @param bool $createUpfrontContributions
    *
    * @throws \CRM_Core_Exception
    * @throws \CiviCRM_API3_Exception
    */
-  private static function createInstalments($recurringContribution, $lineItems) {
+  private static function createInstalments($recurringContribution, $lineItems, $createUpfrontContributions) {
     self::createFirstInstalment($recurringContribution, $lineItems);
-    self::createRemainingInstalments($recurringContribution['id']);
+
+    if ($createUpfrontContributions) {
+      self::createRemainingInstalments($recurringContribution['id']);
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
Here we set the "next scheduled contribution date"  according to the new v5 specs when creating offline payment plan memberships through the admin form.

## Before

Creating an offline payment plan membership through the admin form will result in an empty "next scheduled contribution date"
 : 

![130268706-75e73e8e-b4fe-4423-bc21-1e681892f4c9](https://user-images.githubusercontent.com/6275540/130677632-ad2b5a32-2150-492a-a0ac-3f4dfc15ca6e.gif)


## After

Creating an offline payment plan membership through the admin form, will result in updating the "next scheduled contribution date" according to the following logic:

- If it is a monthly payment plan (12 installments) with 1-year membership, the date will be +1 month from the last contribution "receive date" in that payment plan.

![Animation](https://user-images.githubusercontent.com/6275540/130678730-31e1a903-cab0-485d-9b1f-ecfef307b082.gif)


- If it is a quarterly payment plan (4 installments) with 1-year membership, the date will be +3 months from the last contribution "receive date" in that payment plan.

![Animation](https://user-images.githubusercontent.com/6275540/130678915-912d0c56-db50-46e9-90ea-42b6aa290dba.gif)


- If it is a yearly (annual) payment plan (1 installment per year) with 1-year membership, the date will be +1 year from the last contribution "receive date" in that payment plan.

![Animation](https://user-images.githubusercontent.com/6275540/130679107-964cdbea-f421-4404-b2a5-6ba79e3f9343.gif)


- If it is a monthly payment plan with 1-month membership (1 installment each month) , the date will be +1 month from the last contribution "receive date" in that payment plan.

![Animation](https://user-images.githubusercontent.com/6275540/130679241-65cee358-a7d1-4e82-acb9-472da11b666d.gif)


- Direct debit date calculation rules are also reflected on the value of this field: 

![sdsdsewew](https://user-images.githubusercontent.com/6275540/130679493-42574f8d-1ac0-40e3-b3d9-425dfd50393e.gif)
