### PR TITLE
MAE-590: Update payment plan next contribution date on autorenewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
@@ -79,6 +79,9 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
 
     $instalmentsHandler = new MembershipInstalmentsHandler($this->newRecurringContributionID);
     $instalmentsHandler->createRemainingInstalmentContributionsUpfront();
+
+    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->newRecurringContributionID);
+    $nextContributionDateService->calculateAndUpdate();
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
@@ -129,6 +129,9 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
     $this->buildLineItemsParams();
     $this->setTotalAndTaxAmount();
     $this->recordPaymentPlanFirstContribution();
+
+    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->newRecurringContributionID);
+    $nextContributionDateService->calculateAndUpdate();
   }
 
   /**

--- a/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php
@@ -1017,6 +1017,45 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     ]);
   }
 
+  public function testRenewalWillUpdateNextScheduledContributionAmountToOneMonthAfterLastContributionDate() {
+    $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-2 year -1 month'));
+    $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
+    $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
+    $paymentPlanMembershipOrder->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $this->testRollingMembershipTypePriceFieldValue['price_field_id'],
+      'price_field_value_id' => $this->testRollingMembershipTypePriceFieldValue['id'],
+      'label' => $this->testRollingMembershipType['name'],
+      'qty' => 1,
+      'unit_price' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'line_total' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+    ];
+    $paymentPlan = PaymentPlanOrderFabricator::fabricate($paymentPlanMembershipOrder);
+
+    $multipleInstalmentRenewal = new MultipleInstalmentRenewalJob();
+    $multipleInstalmentRenewal->run();
+
+    $nextPeriodID = $this->getTheNewRecurContributionIdFromCurrentOne($paymentPlan['id']);
+
+    $lastContributionReceiveDate = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['receive_date'],
+      'contribution_recur_id' => $nextPeriodID,
+      'options' => ['limit' => 1, 'sort' => 'id DESC'],
+    ])['values'][0]['receive_date'];
+    $expectedNextDate = date('Y-m-d 00:00:00', strtotime('+1 month', strtotime($lastContributionReceiveDate)));
+
+    $nextDate = civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => 'next_sched_contribution_date',
+      'id' => $nextPeriodID,
+    ]);
+
+    $this->assertEquals($expectedNextDate, $nextDate);
+  }
+
   /**
    * Checks the structure of the payment plan follows the given expected values.
    *


### PR DESCRIPTION
## Before

- For monthly renewals, the new recurring contribution will have the "next scheduled contribution date" empty.
- For annual renewals, the recurring contribution will keep having the same "next scheduled contribution date" it had before renewal.

This happen because the work I did here: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/389

## After

I updated the autorenewal so it work according to the new v5 specs, where for monthly renewals it will be +1 month from the new payment plan last contribution, and for annual payment plans it will be +1 year from last contribution.
