### PR TITLE
MAE-592: Use 'next scheduled contribution date' instead of membership end date for autorenewal

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
@@ -1,6 +1,5 @@
 <?php
 use CRM_MembershipExtras_Service_MembershipInstalmentsHandler as MembershipInstalmentsHandler;
-use CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator as InstalmentReceiveDateCalculator;
 use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
 
 /**
@@ -13,15 +12,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
    * least one line item ready to be renewed (ie. has an end date, is not
    * removed and is set to auto renew), meeting these conditions:
    *
-   * 1- is using an offline payment processor (payment manual class).
-   * 2- has an end date.
-   * 3- is set to auto-renew
-   * 4- is not in status cancelled
-   * 5- "Next Payment Plan Period" is empty
-   * 6- has either of the following conditions:
-   *    - end date of at least one membership is equal to or smaller than today
-   *    - there are no related line items with memberships to be renewed and
-   *      line items have an end date
+   * - is using an offline payment processor (payment manual class).
+   * - is set to auto-renew
+   * - is not in status cancelled or refunded
+   * - is active
+   * - has at least one autorenewal subscription line item
+   * - next scheduled contribution date is less or equal current date (with 'days to renew in advance' setting in mind)
    *
    * @return array
    */
@@ -35,8 +31,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
       SELECT ccr.id as contribution_recur_id, ccr.installments
         FROM civicrm_contribution_recur ccr
    LEFT JOIN membershipextras_subscription_line msl ON msl.contribution_recur_id = ccr.id
-   LEFT JOIN civicrm_line_item cli ON msl.line_item_id = cli.id
-   LEFT JOIN civicrm_membership cm ON (cm.id = cli.entity_id AND cli.entity_table = 'civicrm_membership')
    LEFT JOIN civicrm_value_payment_plan_extra_attributes ppea ON ppea.entity_id = ccr.id
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorsIDs}))
          AND ccr.installments > 1
@@ -45,15 +39,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
           ccr.contribution_status_id != {$cancelledStatusID}
           AND ccr.contribution_status_id != {$refundedStatusID}
          )
-         AND (ppea.is_active = 1)
+         AND ppea.is_active = 1
          AND msl.auto_renew = 1
          AND msl.is_removed = 0
+         AND ccr.next_sched_contribution_date IS NOT NULL
+         AND DATE(ccr.next_sched_contribution_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
     GROUP BY ccr.id
-      HAVING MIN(cm.end_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
-          OR (
-            COUNT(cm.id) = 0
-            AND COUNT(msl.id) > 0
-          )
     ";
     $recurContributions = CRM_Core_DAO::executeQuery($query);
 
@@ -98,7 +89,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
     $paymentProcessorID = !empty($currentRecurContribution['payment_processor_id']) ? $currentRecurContribution['payment_processor_id'] : NULL;
 
     $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate();
-    $this->paymentPlanStartDate = $this->calculateNewPeriodStartDate();
+    $this->paymentPlanStartDate = $this->currentRecurringContribution['next_sched_contribution_date'];
     $paymentInstrumentName = $this->getPaymentMethodNameFromItsId($currentRecurContribution['payment_instrument_id']);
 
     $newRecurringContribution = civicrm_api3('ContributionRecur', 'create', [
@@ -130,41 +121,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
 
     $this->newRecurringContribution = $newRecurringContribution;
     $this->newRecurringContributionID = $newRecurringContribution['id'];
-  }
-
-  /**
-   * Calculates the new period's start date.
-   *
-   * @return string
-   *   The new period's start date.
-   * @throws \Exception
-   */
-  private function calculateNewPeriodStartDate() {
-    $instalmentReceiveDateCalculator = new InstalmentReceiveDateCalculator($this->currentRecurringContribution);
-    $instalmentReceiveDateCalculator->setStartDate($this->membershipsStartDate);
-    return $instalmentReceiveDateCalculator->calculate();
-  }
-
-  /**
-   * Obtains membership identified with provided ID.
-   *
-   * @param int $id
-   *   ID of the membership.
-   *
-   * @return array
-   *   Membership's data.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  private function getMembership($id) {
-    if (empty($id)) {
-      return [];
-    }
-
-    return civicrm_api3('Membership', 'getsingle', [
-      'sequential' => 1,
-      'id' => $id,
-    ]);
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
@@ -14,7 +14,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
    *
    * - is using an offline payment processor (payment manual class).
    * - is set to auto-renew
-   * - is not in status cancelled or refunded
+   * - is not in status cancelled
    * - is active
    * - has at least one autorenewal subscription line item
    * - next scheduled contribution date is less or equal current date (with 'days to renew in advance' setting in mind)
@@ -23,8 +23,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
    */
   protected function getRecurringContributions() {
     $manualPaymentProcessorsIDs = implode(',', $this->manualPaymentProcessorIDs);
-    $cancelledStatusID = $this->contributionStatusesNameMap['Cancelled'];
-    $refundedStatusID = $this->contributionStatusesNameMap['Refunded'];
+    $cancelledStatusID = $this->recurContributionStatusesNameMap['Cancelled'];
     $daysToRenewInAdvance = $this->daysToRenewInAdvance;
 
     $query = "
@@ -35,10 +34,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorsIDs}))
          AND ccr.installments > 1
          AND ccr.auto_renew = 1
-         AND (
-          ccr.contribution_status_id != {$cancelledStatusID}
-          AND ccr.contribution_status_id != {$refundedStatusID}
-         )
+         AND ccr.contribution_status_id != {$cancelledStatusID}
          AND ppea.is_active = 1
          AND msl.auto_renew = 1
          AND msl.is_removed = 0

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -100,7 +100,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    *
    * @var array
    */
-  protected $contributionStatusesNameMap;
+  protected $recurContributionStatusesNameMap;
 
   /**
    * Number of days in advance a membership shuld be renewed.
@@ -129,7 +129,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
 
     $this->setUseMembershipLatestPrice();
     $this->setContributionPendingStatusValue();
-    $this->setContributionStatusesNameMap();
+    $this->setRecurContributionStatusesNameMap();
     $this->setManualPaymentProcessorIDs();
     $this->setDaysToRenewInAdvance();
   }
@@ -175,24 +175,22 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   }
 
   /**
-   * Gets contribution Statuses Name to value Mapping
-   *
-   * @return array $contributionStatusesNameMap
+   * Sets recur contribution Statuses Name to Value mapping
    */
-  private function setContributionStatusesNameMap() {
-    $contributionStatuses = civicrm_api3('OptionValue', 'get', [
+  private function setRecurContributionStatusesNameMap() {
+    $recurContributionStatuses = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'return' => ['name', 'value'],
-      'option_group_id' => 'contribution_status',
+      'option_group_id' => 'contribution_recur_status',
       'options' => ['limit' => 0],
     ])['values'];
 
-    $contributionStatusesNameMap = [];
-    foreach ($contributionStatuses as $status) {
-      $contributionStatusesNameMap[$status['name']] = $status['value'];
+    $recurContributionStatusesNameMap = [];
+    foreach ($recurContributionStatuses as $status) {
+      $recurContributionStatusesNameMap[$status['name']] = $status['value'];
     }
 
-    $this->contributionStatusesNameMap = $contributionStatusesNameMap;
+    $this->recurContributionStatusesNameMap = $recurContributionStatusesNameMap;
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -535,7 +535,6 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    */
   protected function renewPaymentPlanMemberships($sourceRecurringContribution) {
     $recurringLineItems = $this->getRecurringContributionLineItemsToBeRenewed($sourceRecurringContribution);
-    $existingMembershipID = NULL;
 
     foreach ($recurringLineItems as $lineItem) {
       $priceFieldValue = !empty($lineItem['price_field_value_id']) ? $this->getPriceFieldValue($lineItem['price_field_value_id']) : [];

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
@@ -1,6 +1,5 @@
 <?php
 use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtilities;
-use CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator as InstalmentReceiveDateCalculator;
 
 /**
  * Renews the payment plan and the related memberships if it paid by once and
@@ -16,20 +15,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
    * Obtains list of payment plans with a single instalment that are ready to
    * be renewed. This means:
    *
-   * 1- Recurring contribution is a manual payment plan
-   * 2- Recurring contribution is set to auto-renew.
-   * 3- Recurring contribution has no end date.
-   * 4- Recurring contribution is not cancelled nor complete.
-   * 5- Recurring contribution has either:
-   *   - At least one auto-renew, un-removed line item for a membership with an
-   *     end date before today + $daysToRenewInAdvance.
-   *   - At least one auto-renew, un-removed line item and NO memberships, and
-   *     next_run_date(*) is before today + $daysToRenewInAdvance.
-   *
-   * (*) next_run_date corresponds to either maximum end date of all line items
-   * related to the recurring contribution + 1 period, or the start date of the
-   * recurring contribution + 1 period, if there are no line items with end
-   * dates.
+   * - Recurring contribution is a manual payment plan
+   * - Recurring contribution is set to auto-renew.
+   * - Recurring contribution has no end date.
+   * - Recurring contribution is active
+   * - Recurring contribution is not cancelled or refunded.
+   * - next scheduled contribution date is less or equal current date (with 'days to renew in advance' setting in mind)
    *
    * @return array
    */
@@ -40,46 +31,14 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
     $daysToRenewInAdvance = $this->daysToRenewInAdvance;
 
     $query = "
-      SELECT ccr.id as contribution_recur_id, ccr.installments,
-        CASE
-          WHEN frequency_unit = 'day' THEN DATE_ADD(
-            CASE
-              WHEN MAX(msl.end_date) IS NULL THEN ccr.start_date
-              ELSE MAX(msl.end_date)
-            END,
-            INTERVAL frequency_interval DAY
-          )
-          WHEN frequency_unit = 'week' THEN DATE_ADD(
-            CASE
-              WHEN MAX(msl.end_date) IS NULL THEN ccr.start_date
-              ELSE MAX(msl.end_date)
-            END,
-            INTERVAL frequency_interval WEEK
-          )
-          WHEN frequency_unit = 'month' THEN DATE_ADD(
-            CASE
-              WHEN MAX(msl.end_date) IS NULL THEN ccr.start_date
-              ELSE MAX(msl.end_date)
-            END,
-            INTERVAL frequency_interval MONTH
-          )
-          WHEN frequency_unit = 'year' THEN DATE_ADD(
-            CASE
-              WHEN MAX(msl.end_date) IS NULL THEN ccr.start_date
-              ELSE MAX(msl.end_date)
-            END,
-            INTERVAL frequency_interval YEAR
-          )
-        END AS next_run_date
+      SELECT ccr.id as contribution_recur_id, ccr.installments
         FROM civicrm_contribution_recur ccr
    LEFT JOIN membershipextras_subscription_line msl ON msl.contribution_recur_id = ccr.id
-   LEFT JOIN civicrm_line_item cli ON msl.line_item_id = cli.id
-   LEFT JOIN civicrm_membership cm ON (cm.id = cli.entity_id AND cli.entity_table = 'civicrm_membership')
    LEFT JOIN civicrm_value_payment_plan_extra_attributes ppea ON ppea.entity_id = ccr.id
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorsIDs}))
          AND ccr.end_date IS NULL
          AND (
-          ccr.installments < 2
+          ccr.installments <= 1
           OR ccr.installments IS NULL
          )
          AND ccr.auto_renew = 1
@@ -91,13 +50,9 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
          AND msl.auto_renew = 1
          AND msl.is_removed = 0
          AND msl.end_date IS NULL
-
+         AND ccr.next_sched_contribution_date IS NOT NULL
+         AND DATE(ccr.next_sched_contribution_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
     GROUP BY ccr.id
-      HAVING MIN(cm.end_date) <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
-      OR (
-        COUNT(cm.id) = 0
-        AND next_run_date <= DATE_ADD(CURDATE(), INTERVAL {$daysToRenewInAdvance} DAY)
-      )
     ";
     $recurContributions = CRM_Core_DAO::executeQuery($query);
 
@@ -116,11 +71,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
    */
   public function renew() {
     $this->membershipsStartDate = $this->calculateRenewedMembershipsStartDate();
-    $this->paymentPlanStartDate = $this->membershipsStartDate;
-
-    if (!$this->areAnyMembershipsFixed()) {
-      $this->paymentPlanStartDate = $this->calculateNoInstalmentsPaymentPlanStartDate();
-    }
+    $this->paymentPlanStartDate = $this->currentRecurringContribution['next_sched_contribution_date'];
 
     $this->endCurrentLineItemsAndCreateNewOnesForNextPeriod($this->currentRecurContributionID);
     $this->updateRecurringContributionAmount($this->currentRecurContributionID);
@@ -132,28 +83,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
 
     $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->newRecurringContributionID);
     $nextContributionDateService->calculateAndUpdate();
-  }
-
-  /**
-   * Checks if any of the memberships in the plan are fixed.
-   *
-   * @return bool
-   */
-  private function areAnyMembershipsFixed() {
-    $currentPeriodLines = $this->getRecurringContributionLineItemsToBeRenewed($this->currentRecurContributionID);
-
-    foreach ($currentPeriodLines as $lineItem) {
-      if ($lineItem['entity_table'] != 'civicrm_membership') {
-        continue;
-      }
-
-      if ($lineItem['period_type'] === 'fixed') {
-        return TRUE;
-      }
-
-    }
-
-    return FALSE;
   }
 
   /**
@@ -225,22 +154,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
       'id' => $lineID,
       'end_date' => $endDate->format('Y-m-d'),
     ]);
-  }
-
-  /**
-   * Calculates the new start date for the payment plan
-   * if its paid with no instalments.
-   * @return string
-   */
-  private function calculateNoInstalmentsPaymentPlanStartDate() {
-    $currentRecurContribution = civicrm_api3('ContributionRecur', 'get', [
-      'sequential' => 1,
-      'id' => $this->currentRecurContributionID,
-    ])['values'][0];
-    $instalmentReceiveDateCalculator = new InstalmentReceiveDateCalculator($currentRecurContribution);
-    $instalmentReceiveDateCalculator->setStartDate($this->membershipsStartDate);
-
-    return $instalmentReceiveDateCalculator->calculate();
   }
 
   /**

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
@@ -19,15 +19,14 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
    * - Recurring contribution is set to auto-renew.
    * - Recurring contribution has no end date.
    * - Recurring contribution is active
-   * - Recurring contribution is not cancelled or refunded.
+   * - Recurring contribution is not cancelled
    * - next scheduled contribution date is less or equal current date (with 'days to renew in advance' setting in mind)
    *
    * @return array
    */
   protected function getRecurringContributions() {
     $manualPaymentProcessorsIDs = implode(',', $this->manualPaymentProcessorIDs);
-    $cancelledStatusID = $this->contributionStatusesNameMap['Cancelled'];
-    $refundedStatusID = $this->contributionStatusesNameMap['Refunded'];
+    $cancelledStatusID = $this->recurContributionStatusesNameMap['Cancelled'];
     $daysToRenewInAdvance = $this->daysToRenewInAdvance;
 
     $query = "
@@ -42,10 +41,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
           OR ccr.installments IS NULL
          )
          AND ccr.auto_renew = 1
-         AND (
-          ccr.contribution_status_id != {$cancelledStatusID}
-          AND ccr.contribution_status_id != {$refundedStatusID}
-         )
+         AND ccr.contribution_status_id != {$cancelledStatusID}
          AND ppea.is_active = 1
          AND msl.auto_renew = 1
          AND msl.is_removed = 0

--- a/CRM/MembershipExtras/Service/CycleDayCalculator.php
+++ b/CRM/MembershipExtras/Service/CycleDayCalculator.php
@@ -23,7 +23,7 @@ class CRM_MembershipExtras_Service_CycleDayCalculator {
   public static function calculate($targetDate, $frequencyUnit) {
     if ($frequencyUnit == 'month') {
       $recurContStartDate = new DateTime($targetDate);
-      return  $recurContStartDate->format('j');
+      return $recurContStartDate->format('j');
     }
 
     return 1;

--- a/CRM/MembershipExtras/Service/CycleDayCalculator.php
+++ b/CRM/MembershipExtras/Service/CycleDayCalculator.php
@@ -5,7 +5,12 @@ class CRM_MembershipExtras_Service_CycleDayCalculator {
   /**
    * Calculates the cycle date for
    * the recurring contribution given the
-   * date (or start date) and the frequency unit.
+   * date (or start date).
+   *
+   * hence that we are currently only support cycle
+   * day for monthly payment plans, so for everything
+   * else we return 1 which is the default value for
+   * this field in CiviCRM.
    *
    * @param string $targetDate
    *   DateTime acceptable format
@@ -16,23 +21,12 @@ class CRM_MembershipExtras_Service_CycleDayCalculator {
    * @return int
    */
   public static function calculate($targetDate, $frequencyUnit) {
-    $recurContStartDate = new DateTime($targetDate);
-
-    switch ($frequencyUnit) {
-      case 'week':
-        $cycleDay =  $recurContStartDate->format('N');
-        break;
-      case 'month':
-        $cycleDay =  $recurContStartDate->format('j');
-        break;
-      case 'year':
-        $cycleDay =  (int) $recurContStartDate->format('z') + 1;
-        break;
-      default:
-        $cycleDay = 1;
+    if ($frequencyUnit == 'month') {
+      $recurContStartDate = new DateTime($targetDate);
+      return  $recurContStartDate->format('j');
     }
 
-    return $cycleDay;
+    return 1;
   }
 
 }

--- a/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php
+++ b/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php
@@ -53,18 +53,10 @@ class CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator {
    * @return string
    */
   public function calculate($contributionNumber = 1) {
-    $receiveDate = $this->calculateReceiveDate($contributionNumber);
-    $newReceiveDate = $this->rectifyMonthlyPaymentPlanReceiveDateBasedOnCurrentCycleDay($receiveDate);
-
-    return $newReceiveDate->format('Y-m-d');
-  }
-
-  private function calculateReceiveDate($contributionNumber) {
-    $firstDate = $this->startDate;
     $intervalFrequency = $this->recurContribution['frequency_interval'];
     $frequencyUnit = $this->recurContribution['frequency_unit'];
 
-    $receiveDate = new DateTime($firstDate);
+    $receiveDate = new DateTime($this->startDate);
     $numberOfIntervals = ($contributionNumber - 1) * $intervalFrequency;
 
     switch ($frequencyUnit) {
@@ -88,7 +80,7 @@ class CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator {
         break;
     }
 
-    return $receiveDate;
+    return $receiveDate->format('Y-m-d');
   }
 
   /**
@@ -132,50 +124,6 @@ class CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator {
     $day = sprintf('%02s', $day);
 
     return new DateTime("$year-$month-$day");
-  }
-
-  /**
-   * Corrects monthly payment plan installments receive date based on their current cycle day.
-   *
-   * Hence that Starting from version 5, we are supporting cycle day only
-   * for monthly payment plans.
-   *
-   * @param $receiveDate
-   * @return DateTime|mixed
-   */
-  private function rectifyMonthlyPaymentPlanReceiveDateBasedOnCurrentCycleDay($receiveDate) {
-    $frequencyUnit = $this->recurContribution['frequency_unit'];
-
-    if ($frequencyUnit != 'month') {
-      return $receiveDate;
-    }
-
-    $originalCycleDay = CRM_MembershipExtras_Service_CycleDayCalculator::calculate(
-      $receiveDate->format('Y-m-d'),
-      $frequencyUnit
-    );
-    $currentCycleDay = $this->recurContribution['cycle_day'];
-    $daysToAddOrSubtract = $currentCycleDay - $originalCycleDay;
-
-    if ($daysToAddOrSubtract == 0) {
-      return $receiveDate;
-    }
-
-    return $this->changeDayOfMonthInDate($receiveDate, $currentCycleDay);
-  }
-
-  private function changeDayOfMonthInDate($receiveDate, $newMonthDay) {
-    $month = (int) $receiveDate->format('n');
-    $year = (int) $receiveDate->format('Y');
-    $numberOfDaysInMonth = (new DateTime("$year-$month-01"))->format('t');
-    $newDay = $newMonthDay;
-    if ($newDay > $numberOfDaysInMonth) {
-      $newDay = $numberOfDaysInMonth;
-    }
-
-    $newDay = sprintf('%02s', $newDay);
-
-    return new DateTime("$year-$month-$newDay");
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
@@ -68,16 +68,19 @@ abstract class CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodT
    * @param float $taxAmount
    */
   protected function generateLineItem(int $financialTypeId, float $amount, float $taxAmount) {
-    $subTotal = MoneyUtils::roundToPrecision($amount, 2) * MoneyUtils::roundToPrecision($this->quantity, 2);
-    $totalAmount = $subTotal + MoneyUtils::roundToPrecision($taxAmount, 2);
+    $roundedAmount = MoneyUtils::roundToPrecision($amount, 2);
+    $roundedTaxAmount = MoneyUtils::roundToPrecision($taxAmount, 2);
+
+    $subTotal = $roundedAmount * $this->quantity;
+    $totalAmount = $subTotal + $roundedTaxAmount;
     $taxRate = $this->instalmentTaxAmountCalculator->getTaxRateByFinancialTypeId($financialTypeId);
     $scheduleInstalmentLineItem = new CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem();
     $scheduleInstalmentLineItem->setFinancialTypeId($financialTypeId);
     $scheduleInstalmentLineItem->setQuantity($this->quantity);
-    $scheduleInstalmentLineItem->setUnitPrice($amount);
+    $scheduleInstalmentLineItem->setUnitPrice($roundedAmount);
     $scheduleInstalmentLineItem->setSubTotal($subTotal);
     $scheduleInstalmentLineItem->setTaxRate($taxRate);
-    $scheduleInstalmentLineItem->setTaxAmount($taxAmount);
+    $scheduleInstalmentLineItem->setTaxAmount($roundedTaxAmount);
     $scheduleInstalmentLineItem->setTotalAmount($totalAmount);
     $this->lineItems[] = $scheduleInstalmentLineItem;
   }

--- a/CRM/MembershipExtras/Test/Entity/PaymentPlanMembershipOrder.php
+++ b/CRM/MembershipExtras/Test/Entity/PaymentPlanMembershipOrder.php
@@ -29,6 +29,8 @@ class CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder {
 
   public $paymentPlanStartDate;
 
+  public $nextContributionDate;
+
   public $financialType;
 
   public $paymentPlanFrequency;

--- a/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
+++ b/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
@@ -26,6 +26,7 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
     self::updatePaymentPlanMissingParams();
 
     $recurringContribution = self::createRecurringContribution();
+    self::updateNextContributionDate($recurringContribution['id']);
     $lineItems = self::createRecurringLineItems($recurringContribution);
     self::updateRecurringContributionAmount($recurringContribution);
     self::createInstalments($recurringContribution, $lineItems, $createUpfrontContributions);
@@ -76,6 +77,10 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
 
     if (empty(self::$paymentPlanMembershipOrder->paymentPlanStartDate)) {
       self::$paymentPlanMembershipOrder->paymentPlanStartDate = self::$paymentPlanMembershipOrder->membershipStartDate;
+    }
+
+    if (empty(self::$paymentPlanMembershipOrder->nextContributionDate)) {
+      self::$paymentPlanMembershipOrder->nextContributionDate = self::$paymentPlanMembershipOrder->membershipStartDate;
     }
 
     return self::$paymentPlanMembershipOrder;
@@ -133,6 +138,14 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
     ];
 
     return RecurringContributionFabricator::fabricate($recurringContributionParams);
+  }
+
+  public static function updateNextContributionDate($recurringContributionId) {
+    $query = 'UPDATE civicrm_contribution_recur SET next_sched_contribution_date = %1 WHERE id = %2';
+    CRM_Core_DAO::executeQuery($query, [
+      1 => [self::$paymentPlanMembershipOrder->nextContributionDate, 'String'],
+      2 => [$recurringContributionId, 'Integer'],
+    ]);
   }
 
   /**
@@ -266,7 +279,7 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
       'is_pay_later' => TRUE,
       'skipLineItem' => 1,
       'skipCleanMoney' => TRUE,
-      'receive_date' => self::$paymentPlanMembershipOrder->paymentPlanStartDate,
+      'receive_date' => self::$paymentPlanMembershipOrder->nextContributionDate,
       'contribution_recur_id' => $recurringContribution['id'],
       'contact_id' => $recurringContribution['contact_id'],
       'fee_amount' => 0,

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -475,10 +475,52 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
    *
    */
   private function migrateRelatedPeriodsCustomGroupToIsActiveCustomField() {
-    $query = "INSERT INTO civicrm_value_payment_plan_extra_attributes (entity_id, is_active)  
-               SELECT ccr.id as id, IF(rppp.next_period IS NULL, 1, 0) as is_active FROM civicrm_contribution_recur ccr 
+    $query = "INSERT INTO civicrm_value_payment_plan_extra_attributes (entity_id, is_active)
+               SELECT ccr.id as id, IF(rppp.next_period IS NULL, 1, 0) as is_active FROM civicrm_contribution_recur ccr
                LEFT JOIN civicrm_value_payment_plan_periods rppp ON ccr.id = rppp.entity_id";
     CRM_Core_DAO::executeQuery($query);
+  }
+
+  public function upgrade_0007() {
+    $this->migratePaymentPlansToSupportNextContributionDateAutorenewal();
+
+    return TRUE;
+  }
+
+  /**
+   * As of Membershipextras v5 we are using next_sched_contribution_date
+   * to control the autorenewal instead of using the payment plan related
+   * memberships end dates. In this upgrader we update this field value for
+   * all offline payment plans so it equals the minimum membership end date
+   * that is attached to it, so it can support this new autorenewal behaviour.
+   */
+  private function migratePaymentPlansToSupportNextContributionDateAutorenewal() {
+    CRM_Core_DAO::executeQuery('CREATE TABLE recur_conts_to_update (`recur_id` int(11), `next_cont_date` varchar(255))');
+
+    $payLaterProcessorID = 0;
+    $manualPaymentProcessorIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
+    $manualPaymentProcessorIDs = implode(',', $manualPaymentProcessorIDs);
+    $cancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Cancelled');
+    $query = "
+              INSERT INTO recur_conts_to_update
+              SELECT ccr.id as recur_id, min(cm.end_date) as next_cont_date FROM civicrm_contribution_recur ccr
+              INNER JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id
+              INNER JOIN civicrm_membership_payment cmp ON cc.id = cmp.contribution_id
+              INNER JOIN civicrm_membership cm ON cmp.membership_id = cm.id
+              WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorIDs}))
+              AND ccr.auto_renew = 1
+              AND ccr.contribution_status_id != {$cancelledStatusID}
+              AND cm.contribution_recur_id IS NOT NULL
+              GROUP BY ccr.id";
+    CRM_Core_DAO::executeQuery($query);
+
+    $query = "
+              UPDATE civicrm_contribution_recur ccr
+              INNER JOIN recur_conts_to_update ctu ON ccr.id = ctu.recur_id
+              SET ccr.next_sched_contribution_date = ctu.next_cont_date";
+    CRM_Core_DAO::executeQuery($query);
+
+    CRM_Core_DAO::executeQuery('DROP TABLE IF Exists recur_conts_to_update');
   }
 
 }

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/ContributionTest.php
@@ -75,7 +75,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionT
     $this->assertEquals('27', $recurringContribution['cycle_day']);
   }
 
-  public function testYearlyCycleDayIsCalculatedFromReceiveDate() {
+  public function testYearlyCycleDayDefaultsToValueOne() {
     $_REQUEST['payment_plan_schedule'] = 'annual';
 
     $contact = ContactFabricator::fabricate();
@@ -117,7 +117,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_ContributionT
       'options' => ['limit' => 0],
     ])['values'][0];
 
-    $this->assertEquals('32', $recurringContribution['cycle_day']);
+    $this->assertEquals('1', $recurringContribution['cycle_day']);
   }
 
   public function testReceiveDateCalculationHookChangesReceiveDate() {


### PR DESCRIPTION
## Overview

Some of the current criteria we have for autorenewal are:

- Are any of the memberships that are attached to the payment plan has an end date that is less or equal today date (with `days to renew in advance` setting in mind).
- Or if there are no memberships attached to the payment plan, then check if there are any active autorenewal subscription line items attached to the payment plan (though to be clear we are not officially supporting payment plans without memberships yet).

And if any of these conditions apply, then we proceed with the autorenewal.

Here I change this to use the payment plan "next scheduled contribution date"  as a condition for auto-renewal, so if this field value is less or equal today date (with `days to renew in advance` setting in mind) then we renew the payment plan, otherwise we don't. 

And as part of this, we now set the new first installment receive date to equal the "next scheduled contribution date" instead of using the new membership "start date", where the rest of the installments follow the first installment date same as before.

This simplify the autorenewal by removing the dependency on the related membership dates, and allows for better flexibility in controlling when the renewal should happen and controlling the new installment dates.

Hence that this does not mean we removed other autorenewal conditions, such as that you still need to have active renewal subscription line items for the renewal to happen, and that the payment plan should not be cancelled ..etc


As part of this PR, I also did the following: 

1- Created an upgrader to update the "next scheduled contribution date" for all existing offline payment plans to equal the minimum membership end date attached to it, which should ensure that the renewals should happen next time at their correct dates.
2- I changed the autorenewal job to use the "recurring contribution status" option group instead of "contribution status" option group,  it is just happened that the Values for the option values in each option group are almost similar such as for the  "Cancelled" status were both equal 3. Also the refunded status does not exist for recurring contributions, so I removed it from the query that get the recurring contributions to renew and just kept the part where it check for non cancelled recurring contributions.
