### PR TITLE
MAE-582: Version 5 Cycle day changes

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -59,6 +59,8 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
   }
 
   private function addElements() {
+    $this->form->assign('paymentPlanFrequency', $this->recurringContribution['frequency_unit']);
+
     $amount = $this->form->getElement('amount');
     $amount->setAttribute('readonly', TRUE);
 

--- a/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
+++ b/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
@@ -12,15 +12,27 @@
       <input type="hidden" name="update_installments" id="update_installments" value="0"/>
     </td>
   </tr>
-  <tr id="cycle_day_field">
-    <td class="label">
-      {$form.cycle_day.label}
-    </td>
-    <td>
-      {$form.cycle_day.html}
-      <input type="hidden" name="old_cycle_day" id="old_cycle_day" value="{$form.cycle_day.value}"/>
-    </td>
-  </tr>
+
+  {if $paymentPlanFrequency == 'month'}
+    <tr id="cycle_day_field">
+      <td class="label">
+        {$form.cycle_day.label}
+      </td>
+      <td>
+        {$form.cycle_day.html}
+        <input type="hidden" name="old_cycle_day" id="old_cycle_day" value="{$form.cycle_day.value}"/>
+      </td>
+    </tr>
+  {else}
+    <tr id="cycle_day_field">
+      <td>
+        <input type="hidden" name="cycle_day" id="cycle_day" value="1"/>
+        <input type="hidden" name="old_cycle_day" id="old_cycle_day" value="1"/>
+      </td>
+    </tr>
+  {/if}
+
+
   <tr id="next_sched_contribution_date_field">
     <td class="label">
       {$form.next_sched_contribution_date.label}
@@ -45,7 +57,12 @@
 </table>
 <div id="confirmInstallmentsUpdate" style="display: none;">
   <div class="messages status no-popup">
-    <i aria-hidden="true" class="crm-i fa-info-circle"></i>{ts}Do you want to update any outstanding instalment
+    {if $paymentPlanFrequency == 'month'}
+      <i aria-hidden="true" class="crm-i fa-info-circle"></i>{ts}Do you want to update any outstanding instalment
       contribution with the new Payment Method or Cycle Day?{/ts}
+    {else}
+      <i aria-hidden="true" class="crm-i fa-info-circle"></i>{ts}Do you want to update any outstanding instalment
+      contribution with the new Payment Method?{/ts}
+    {/if}
   </div>
 </div>

--- a/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
+++ b/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
@@ -59,7 +59,8 @@
   <div class="messages status no-popup">
     {if $paymentPlanFrequency == 'month'}
       <i aria-hidden="true" class="crm-i fa-info-circle"></i>{ts}Do you want to update any outstanding instalment
-      contribution with the new Payment Method or Cycle Day?{/ts}
+      contribution with the new Payment Method or Cycle Day? Hence that updating the cycle day will also update the next
+      scheduled contribution date.{/ts}
     {else}
       <i aria-hidden="true" class="crm-i fa-info-circle"></i>{ts}Do you want to update any outstanding instalment
       contribution with the new Payment Method?{/ts}


### PR DESCRIPTION
## Overview

As part of the new changes to how the cycle day and the next scheduled contribution date interact for V5, in this PR I am implementing the following:

- Hiding the "Cycle Day" field for annual payment plans in the payment plan edit screen.
- Updating the "Cycle day" for monthly payment plans will result in updating the "next scheduled contribution date" so the day in which it happen will be same as the new "Cycle day".



## Before

- Cycle day is visible for annual payment plans: 

![2021-09-14 18_31_51-asddsa dsadas _ civi5352v5](https://user-images.githubusercontent.com/6275540/133287881-9613fef6-772c-45a3-9164-5de307c85876.png)

- Updating the cycle day for monthly payment plans is not reflected on the "next scheduled contribution date"

![dsadsa](https://user-images.githubusercontent.com/6275540/133288672-308468e1-bc4b-42bc-982f-5b380436bfdd.gif)


## After

- Cycle day is visible hidden for annual payment plans: 
![2021-09-14 18_32_14-asddsa dsadas _ civi5352v5](https://user-images.githubusercontent.com/6275540/133287945-07151e9d-4ac6-4ab0-88b9-70ab6c5042ce.png)


- Updating the cycle day for monthly payment plans is reflected on the "next scheduled contribution date"
![يشسشيس](https://user-images.githubusercontent.com/6275540/133288410-af53695c-5c15-4d0f-968b-1baf4fc8bcda.gif)

