### PR TITLE
MAE-609: Fix upfront contributions date calculation for Direct debit webforms

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
@@ -243,12 +243,17 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
    */
   private function dispatchReceiveDateCalculationHook($contributionNumber, &$params) {
     $receiveDate = $params['receive_date'];
+    $paymentPlanSchedule = CRM_MembershipExtras_Utils_InstalmentSchedule::getPaymentPlanSchedule(
+      $this->currentRecurContribution['frequency_unit'],
+      $this->currentRecurContribution['frequency_interval'],
+      $this->currentRecurContribution['installments']
+    );
 
     $contributionReceiveDateParams = [
       'membership_id' => $this->getMembership()['membership_id.id'],
       'contribution_recur_id' => $this->currentRecurContribution['id'],
       'previous_instalment_date' => $this->previousInstalmentDate->format('Y-m-d'),
-      'payment_schedule' => CRM_MembershipExtras_Utils_InstalmentSchedule::getPaymentPlanSchedule(),
+      'payment_schedule' => $paymentPlanSchedule,
       'payment_instrument_id' => $params['payment_instrument_id'],
       'membership_start_date' => $this->getMembership()['membership_id.start_date'],
       'frequency_interval' => $this->currentRecurContribution['frequency_interval'],

--- a/CRM/MembershipExtras/Utils/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Utils/InstalmentSchedule.php
@@ -93,20 +93,29 @@ class CRM_MembershipExtras_Utils_InstalmentSchedule {
    *
    * @return bool
    */
-  public static function isPaymentPlanWithSchedule() {
-    $paymentPlanSchedule = self::getPaymentPlanSchedule();
+  public static function isPaymentPlanPayment() {
     $isSavingContribution = CRM_Utils_Request::retrieve('record_contribution', 'Int');
     $contributionIsPaymentPlan = CRM_Utils_Request::retrieve('contribution_type_toggle', 'String') === 'payment_plan';
 
-    if ($isSavingContribution && $contributionIsPaymentPlan && $paymentPlanSchedule) {
+    if ($isSavingContribution && $contributionIsPaymentPlan) {
       return TRUE;
     }
 
     return FALSE;
   }
 
-  public static function getPaymentPlanSchedule() {
-    return CRM_Utils_Request::retrieve('payment_plan_schedule', 'String');
+  public static function getPaymentPlanSchedule($frequencyUnit, $frequencyInterval, $installmentsCount) {
+    if ($frequencyUnit == 'month' && $frequencyInterval == 1 && $installmentsCount == 12) {
+      return InstalmentsSchedule::MONTHLY;
+    }
+
+    if ($frequencyUnit == 'month' && $frequencyInterval == 3 && $installmentsCount == 4) {
+      return InstalmentsSchedule::QUARTERLY;
+    }
+
+    if ($frequencyUnit == 'year' && $frequencyInterval == 1 && $installmentsCount == 1) {
+      return InstalmentsSchedule::ANNUAL;
+    }
   }
 
 }

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -183,7 +183,7 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   }
 
   static $isFirstPaymentPlanContribution = TRUE;
-  $isPaymentPlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanWithSchedule();
+  $isPaymentPlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanPayment();
   $isContributionCreation = ($objectName === 'Contribution' && $op === 'create');
   if ($isContributionCreation && $isPaymentPlanPayment && $isFirstPaymentPlanContribution) {
     $paymentPlanProcessor = new CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution($params);
@@ -381,7 +381,7 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
 
   $formAction = $form->getAction();
   $isNewMembershipForm = ($formName === 'CRM_Member_Form_Membership' && ($formAction & CRM_Core_Action::ADD));
-  $isPaymentPlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanWithSchedule();
+  $isPaymentPlanPayment = CRM_MembershipExtras_Utils_InstalmentSchedule::isPaymentPlanPayment();
   if ($isNewMembershipForm && $isPaymentPlanPayment) {
     $paymentPlanValidateHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($form, $fields, $errors);
     $paymentPlanValidateHook->validate();


### PR DESCRIPTION
## Overview

When submitting a direct debit webform and the creation of upfront contributions starts, it results in calling **membershipextras_calculateContributionReceiveDate** hook which results in calling **CRM_MembershipExtras_Utils_InstalmentSchedule::getPaymentPlanSchedule** method that is used to determine the payment plan schedule and then decides if  the direct debit dates calculation logic should be performed or not (since it is only done on monthly payment plans), but because it depends on reading the payment schedule value from the $_REQUEST variable which is only set if the request is coming from the admin form submission, the method end up returning NULL which prevents from running the direct debit date calculation logic on the payment plan, here I changed the method so it determine the schedule based on the payment plan frequency information stored in the database (frequency unit, frequency interval and number of installments), which is guaranteed to be set at both admin form and webforms.


## Before

The receive dates starting from the 2nd (direct debit) contribution onward are wrong.

this is how it is after webform submission, the 2nd contribution in this example starts at 23 of November 
![2021-09-21 19_10_37-mdsadsa@ad com mdsadsa@ad com _ civi5352v5](https://user-images.githubusercontent.com/6275540/134207344-940e7768-d49d-42d0-945c-ec4f960d1748.png)

Though according to the current configuration, the 2nd installment should start at the same date as the first contribution
![2021-09-21 19_11_05-](https://user-images.githubusercontent.com/6275540/134207442-006ddfcf-a8be-4320-98fa-77cbd4275218.png)

here is how it will look like (correctly) if it was submitted from admin webform

![2021-09-21 19_10_51-Groove Music](https://user-images.githubusercontent.com/6275540/134207596-0e2106d8-182b-4084-8a57-a684f0548920.png)

## After

The receive dates starting from the 2nd (direct debit) contribution onward are correct.

![2021-09-21 19_13_56-kkadsdas@adda com kkadsdas@adda com _ civi5352v5](https://user-images.githubusercontent.com/6275540/134207792-3396d3e6-9911-4a34-91c4-c0fba8f35cf6.png)



## Side notes

I also renamed isPaymentPlanWithSchedule method to isPaymentPlanPayment given that all payment plans should have schedule information if they are submitted from the admin form so it does not make sense to check if the schedule parameter is there or not.