### PR TITLE
MAE-612: Changes to autorenewal job trigger and migrating upgrader

### DIFF
--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -489,10 +489,11 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
 
   /**
    * As of Membershipextras v5 we are using next_sched_contribution_date
-   * to control the autorenewal instead of using the payment plan related
-   * memberships end dates. In this upgrader we update this field value for
-   * all offline payment plans so it equals the minimum membership end date
-   * that is attached to it, so it can support this new autorenewal behaviour.
+   * to calculate the installments receive dates after autorenewal
+   * instead of using the payment plan related memberships end dates.
+   * In this upgrader we update this field value for all offline payment plans
+   * so it equals the minimum membership end date that is attached to it,
+   * so it can support this new autorenewal behaviour.
    */
   private function migratePaymentPlansToSupportNextContributionDateAutorenewal() {
     CRM_Core_DAO::executeQuery('CREATE TABLE recur_conts_to_update (`recur_id` int(11), `next_cont_date` varchar(255))');

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -481,7 +481,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     CRM_Core_DAO::executeQuery($query);
   }
 
-  public function upgrade_0007() {
+  public function upgrade_0008() {
     $this->migratePaymentPlansToSupportNextContributionDateAutorenewal();
 
     return TRUE;
@@ -492,8 +492,11 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
    * to calculate the installments receive dates after autorenewal
    * instead of using the payment plan related memberships end dates.
    * In this upgrader we update this field value for all offline payment plans
-   * so it equals the minimum membership end date that is attached to it,
-   * so it can support this new autorenewal behaviour.
+   * so it equals:
+   * - For annual payment plans, take max contribution receive date and add 1 year to it.
+   * - For monthly payment plans, take max contribution receive date and add 1 month to it.
+   * - For quarterly payment plans, take max contribution receive date and add 3 months to it.
+   * - For any payment plans that are not any of the above, take min membership end date + 1 day
    */
   private function migratePaymentPlansToSupportNextContributionDateAutorenewal() {
     CRM_Core_DAO::executeQuery('CREATE TABLE recur_conts_to_update (`recur_id` int(11), `next_cont_date` varchar(255))');
@@ -502,9 +505,47 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     $manualPaymentProcessorIDs = array_merge([$payLaterProcessorID], CRM_MembershipExtras_Service_ManualPaymentProcessors::getIDs());
     $manualPaymentProcessorIDs = implode(',', $manualPaymentProcessorIDs);
     $cancelledStatusID = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionRecur', 'contribution_status_id', 'Cancelled');
+
+    // updating annual payment plans
     $query = "
               INSERT INTO recur_conts_to_update
-              SELECT ccr.id as recur_id, min(cm.end_date) as next_cont_date FROM civicrm_contribution_recur ccr
+              SELECT ccr.id as recur_id, DATE_ADD(max(cc.receive_date), INTERVAL 1 YEAR) as next_cont_date FROM civicrm_contribution_recur ccr
+              INNER JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id
+              WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorIDs}))
+              AND ccr.auto_renew = 1
+              AND ccr.contribution_status_id != {$cancelledStatusID}
+              AND ccr.frequency_unit = 'year'
+              GROUP BY ccr.id";
+    CRM_Core_DAO::executeQuery($query);
+
+    // updating monthly payment plans
+    $query = "
+              INSERT INTO recur_conts_to_update
+              SELECT ccr.id as recur_id, DATE_ADD(max(cc.receive_date), INTERVAL 1 MONTH) as next_cont_date FROM civicrm_contribution_recur ccr
+              INNER JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id
+              WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorIDs}))
+              AND ccr.auto_renew = 1
+              AND ccr.contribution_status_id != {$cancelledStatusID}
+              AND ccr.frequency_unit = 'month' AND ccr.installments = 12
+              GROUP BY ccr.id";
+    CRM_Core_DAO::executeQuery($query);
+
+    // updating quarterly payment plans
+    $query = "
+              INSERT INTO recur_conts_to_update
+              SELECT ccr.id as recur_id, DATE_ADD(max(cc.receive_date), INTERVAL 3 MONTH) as next_cont_date FROM civicrm_contribution_recur ccr
+              INNER JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id
+              WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$manualPaymentProcessorIDs}))
+              AND ccr.auto_renew = 1
+              AND ccr.contribution_status_id != {$cancelledStatusID}
+              AND ccr.frequency_unit = 'month' AND ccr.installments = 4
+              GROUP BY ccr.id";
+    CRM_Core_DAO::executeQuery($query);
+
+    // updating payment plans that are not annual, monthly or quarterly
+    $query = "
+              INSERT INTO recur_conts_to_update
+              SELECT ccr.id as recur_id, DATE_ADD(min(cm.end_date), INTERVAL 1 DAY) as next_cont_date FROM civicrm_contribution_recur ccr
               INNER JOIN civicrm_contribution cc ON ccr.id = cc.contribution_recur_id
               INNER JOIN civicrm_membership_payment cmp ON cc.id = cmp.contribution_id
               INNER JOIN civicrm_membership cm ON cmp.membership_id = cm.id
@@ -512,6 +553,10 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
               AND ccr.auto_renew = 1
               AND ccr.contribution_status_id != {$cancelledStatusID}
               AND cm.contribution_recur_id IS NOT NULL
+              AND (
+               (ccr.frequency_unit = 'month' AND ccr.installments NOT IN (4, 12))
+               OR (ccr.frequency_unit = 'year' AND ccr.installments > 1)
+              )
               GROUP BY ccr.id";
     CRM_Core_DAO::executeQuery($query);
 

--- a/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultiInstalmentPlanTest.php
@@ -63,9 +63,8 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     ])['values'][0];
   }
 
-  public function testRenewalWithNextContributionDateLessThanTodayDateWillRenew() {
+  public function testRenewalWithMembershipEndDateLessThanTodayDateWillRenew() {
     $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
-    $paymentPlanMembershipOrder->nextContributionDate = date('Y-m-d', strtotime('-1 day'));
     $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-2 year -1 month'));
     $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
     $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
@@ -88,10 +87,9 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     $this->assertTrue($this->isPaymentPlanMembershipRenewed($paymentPlan['id'], '-1 month -1 day'));
   }
 
-  public function testRenewalWithNextContributionDateEqualsTodayDateWillRenew() {
+  public function testRenewalWithMembershipEndDateEqualTodayDateWillRenew() {
     $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
-    $paymentPlanMembershipOrder->nextContributionDate = date('Y-m-d');
-    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-2 year -1 month'));
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year +1 day'));
     $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
     $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
     $paymentPlanMembershipOrder->lineItems[] = [
@@ -110,13 +108,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     $multipleInstalmentRenewal = new MultipleInstalmentRenewalJob();
     $multipleInstalmentRenewal->run();
 
-    $this->assertTrue($this->isPaymentPlanMembershipRenewed($paymentPlan['id'], '-1 month -1 day'));
+    $this->assertTrue($this->isPaymentPlanMembershipRenewed($paymentPlan['id'], '+1 year'));
   }
 
-  public function testRenewalWithNextContributionDateLargerThanTodayDateWillNotRenew() {
+  public function testRenewalWithMembershipEndDateLargerThanTodayDateWillNotRenew() {
     $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
-    $paymentPlanMembershipOrder->nextContributionDate = date('Y-m-d', strtotime('+1 day'));
-    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-2 year -1 month'));
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year +2 day'));
     $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
     $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
     $paymentPlanMembershipOrder->lineItems[] = [
@@ -218,13 +215,12 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     $this->assertFalse($this->isPaymentPlanMembershipRenewed($paymentPlan['id'], '+1 year -1 month -1 day'));
   }
 
-  public function testRenewalWithNextContributionDateWithinDateToRenewInAdvanceLimitWillRenew() {
+  public function testRenewalWithMembershipEndDateLargerThanDateToRenewInAdvanceWillRenew() {
     civicrm_api3('Setting', 'create', [
       'membershipextras_paymentplan_days_to_renew_in_advance' => 10,
     ]);
 
     $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
-    $paymentPlanMembershipOrder->nextContributionDate = date('Y-m-d', strtotime('+5 day'));
     $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year +2 day'));
     $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
     $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
@@ -247,14 +243,13 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     $this->assertTrue($this->isPaymentPlanMembershipRenewed($paymentPlan['id'], '+1 year +1 day'));
   }
 
-  public function testRenewalWithNextContributionDateOutsideDateToRenewInAdvanceLimitWillNotRenew() {
+  public function testRenewalWithMembershipEndDateLessThanDateToRenewInAdvanceWillNotRenew() {
     civicrm_api3('Setting', 'create', [
-      'membershipextras_paymentplan_days_to_renew_in_advance' => 10,
+      'membershipextras_paymentplan_days_to_renew_in_advance' => 5,
     ]);
 
     $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
-    $paymentPlanMembershipOrder->nextContributionDate = date('Y-m-d', strtotime('+11 day'));
-    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year +2 day'));
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year +15 day'));
     $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
     $paymentPlanMembershipOrder->paymentPlanStatus = 'Completed';
     $paymentPlanMembershipOrder->lineItems[] = [
@@ -273,7 +268,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultiInstalmentPlanTest extend
     $multipleInstalmentRenewal = new MultipleInstalmentRenewalJob();
     $multipleInstalmentRenewal->run();
 
-    $this->assertFalse($this->isPaymentPlanMembershipRenewed($paymentPlan['id'], '+1 year +1 day'));
+    $this->assertFalse($this->isPaymentPlanMembershipRenewed($paymentPlan['id'], '+1 year +14 day'));
   }
 
   public function testRenewalWithUpdateStartDateOnRenewalSettingOffWillNotUpdateMembershipStartDate() {


### PR DESCRIPTION
## Overview

There was a misunderstanding that the trigger for autorenewal should be the next scheduled contribution date. There is a risk that this date may be before or after the end date of the membership (specially in Direct debit payment plans).

As such we changed the "trigger" for the autorenwal job to be the end date of the membership (taking into account the payment plan setting Days to renew in advance), or the minimum membership end date if there are more than one membership in the payment plan with different end dates as it used to be the case before. 

The installments receive dates  is still being calculated based on the next scheduled contribution date,

## Before

The next scheduled contribution date is what we use to trigger the autorenewal.

## After

The membership end date (or the minimum membership end date if there are more that one) is what triggers that autorenewal. Which meant reverting most of the work I did here: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/393.


## Other notes

I also updated the migrating upgrader that updates the next scheduled contribution date for all payment plans, so it now uses the max contribution receive date plus:

- +1 year for annual payment plans
-  +1 month for monthly payment plans
-  +3 months for quarterly payment plans
-  minimum membership end date + 1 day for other manual payment plans. (I do that because having non annual, monthly or quarterly payment plans is no longer supported in v5, and it is hard to know what the next contribution date should be for these non standard payment plans, so the safest option I found is just to set it to the minimum membership end date among all the memberships attached to it, plus 1 day so equals the new membership start date if it get renewed).
