### PR TITLE
MAE-610: Hide Cycle day and update Next Contribution Label

### DIFF
--- a/js/modifyAnnualRecuringContributionPage.js
+++ b/js/modifyAnnualRecuringContributionPage.js
@@ -1,0 +1,12 @@
+CRM.$(function () {
+    const frequency = CRM.vars.membershipextras.contribution_frequency;
+
+    CRM.$('.crm-recurcontrib-view-block > table > tbody > tr').each(function() {
+        if(CRM.$('td.label', this).text() === 'Cycle Day' && frequency === 'year') {
+            CRM.$(this).hide();
+        }
+        if(CRM.$('td.label', this).text() === 'Next Contribution') {
+            CRM.$('td.label', this).text('Next Scheduled Contribution Date');
+        }
+    })
+});

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -368,6 +368,8 @@ function membershipextras_civicrm_pageRun($page) {
       'page-header'
     );
   }
+
+  _membershipextras_appendJSToModifyRecurringContributionPage($page);
 }
 
 /**
@@ -456,4 +458,23 @@ function membershipextras_civicrm_preProcess($formName, $form) {
 function membershipextras_civicrm_alterMailParams(&$params, $context) {
   $alterMailParamsHook = new CRM_MembershipExtras_Hook_Alter_MailParamsHandler($params);
   $alterMailParamsHook->handle();
+}
+
+function _membershipextras_appendJSToModifyRecurringContributionPage(&$page) {
+  if (!($page instanceof CRM_Contribute_Page_ContributionRecur)) {
+    return;
+  }
+
+  $contributionData = $page->get_template_vars('recur');
+  $frequency = CRM_Utils_Array::value('frequency_unit', $contributionData, '');
+
+  CRM_Core_Resources::singleton()->addScriptFile(
+    CRM_MembershipExtras_ExtensionUtil::LONG_NAME,
+    'js/modifyAnnualRecuringContributionPage.js',
+    1,
+    'page-header'
+  )->addVars(
+    CRM_MembershipExtras_ExtensionUtil::SHORT_NAME,
+    ['contribution_frequency' => $frequency]
+  );
 }


### PR DESCRIPTION
## Overview
This PR makes the following update on View Recurring contribution form:
1. Hides “Cycle Day” field on 'View Recurring Contribution” form in case of Annual memberships.
2. Change the label name to “ Next Scheduled Contribution Date”.


## Before
![image](https://user-images.githubusercontent.com/85277674/138285107-682f0859-e190-4d0e-be43-de4c323dfc8c.png)


## After
<img width="999" alt="Screenshot 2021-10-21 at 14 18 31" src="https://user-images.githubusercontent.com/85277674/138285913-43f226dc-c288-4a2f-a925-53154023663e.png">

Cycle Day is not hidden when payment frequency is not annual.
<img width="1120" alt="Screenshot 2021-10-21 at 14 16 45" src="https://user-images.githubusercontent.com/85277674/138285509-82ba52e7-885e-4177-8df5-93a235c75586.png">
