### PR TITLE
PROD-33: Add civicrm_contribution_recur to LineItem supported entity options

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -477,3 +477,17 @@ function _membershipextras_appendJSToModifyRecurringContributionPage(&$page) {
     ['contribution_frequency' => $frequency]
   );
 }
+
+/**
+ * Implements fieldOptions hook().
+ *
+ * @param string $entity
+ * @param string $field
+ * @param array $options
+ * @param array $params
+ */
+function membershipextras_civicrm_fieldOptions($entity, $field, &$options, $params) {
+  if (in_array($entity, ['FinancialItem', 'LineItem']) && $field == 'entity_table') {
+    $options['civicrm_contribution_recur'] = ts('Recurring Contribution');
+  }
+}


### PR DESCRIPTION
## Overview
CiviCRM decided to limit the supported entity_table options to some predefined tables as seen in this PR https://github.com/civicrm/civicrm-core/pull/20464, this is now causing error in this extension,  because this extension allow users to add LineItems to civicrm_contribution_recur table which is not part of the predefined tables.

## Before
![343d1bc5-732a-4a6c-bdd7-fb3cee8f9b01](https://user-images.githubusercontent.com/85277674/138888025-5d073926-2211-4e36-9d7c-19a91733f255.gif)

## After
![after-line-item](https://user-images.githubusercontent.com/85277674/138893330-ad4d7e63-9c46-4894-b88a-384c2321926e.gif)

## Technical Details
implement the hook_civicrm_fieldOptions hook to add civicrm_contribution_recur to the LineItem options.


