### PR TITLE
MAE-619: Fix error with extra amounts being added to total contribution amount

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
@@ -125,8 +125,7 @@ abstract class CRM_MembershipExtras_Form_RecurringContribution_AddLineItem exten
    */
   private function calculateRecurringContributionTotalAmount() {
     $totalAmount = 0;
-
-    $result = civicrm_api3('ContributionRecurLineItem', 'get', [
+    $conditions = [
       'sequential' => 1,
       'contribution_recur_id' => $this->recurringContribution['id'],
       'start_date' => ['IS NOT NULL' => 1],
@@ -136,7 +135,14 @@ abstract class CRM_MembershipExtras_Form_RecurringContribution_AddLineItem exten
         'entity_table' => ['IS NOT NULL' => 1],
         'entity_id' => ['IS NOT NULL' => 1],
       ],
-    ]);
+    ];
+
+    $installments = CRM_Utils_Array::value('installments', $this->recurringContribution, 0);
+    if ($installments <= 1) {
+      $conditions['end_date'] = ['IS NULL' => 1];
+    }
+
+    $result = civicrm_api3('ContributionRecurLineItem', 'get', $conditions);
 
     if ($result['count'] > 0) {
       foreach ($result['values'] as $lineItemData) {


### PR DESCRIPTION
## Overview
This PR ensures that Recurring contribution amount is correct after adding a line item in manage installments view of annual payment plan and that has auto renewal

## Before
![before-contrib](https://user-images.githubusercontent.com/85277674/139071174-87bd2111-f5b5-4176-be18-dd0fee50f02c.gif)


## After
![after-contrib](https://user-images.githubusercontent.com/85277674/139070418-3201691a-0794-4c91-91f0-bec0a0f0aae1.gif)


## Technical Details
When calculating new total amount for recurring contribution, ensure that only amount from line items with end_dates are included (Given that the payment has one or no installment). same condition is applied to every other part of the code where total recurring contribution amount is calculated.
```php
$installments = CRM_Utils_Array::value('installments', $this->recurringContribution, 0);
if ($installments <= 1) {
    $conditions['end_date'] = ['IS NULL' => 1];
}
```
