### PR TITLE
BASW-897: Remove link between contribution and membership when removing membership line item

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -46,7 +46,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
       'api.LineItem.getsingle' => [
         'id' => '$value.line_item_id',
         'entity_table' => ['IS NOT NULL' => 1],
-        'entity_id' => ['IS NOT NULL' => 1]
+        'entity_id' => ['IS NOT NULL' => 1],
       ],
     ]);
 
@@ -64,8 +64,8 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
   }
 
   /**
-  * @inheritdoc
-  */
+   * @inheritdoc
+   */
   public function buildQuickForm() {
     $lineItemLabel = $this->recurringLineItemData['label'];
     CRM_Utils_System::setTitle(E::ts('Remove ' . $lineItemLabel . '?'));
@@ -84,14 +84,14 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
 
     $this->addButtons([
       [
-          'type' => 'submit',
-          'name' => E::ts('Apply'),
-          'isDefault' => TRUE,
+        'type' => 'submit',
+        'name' => E::ts('Apply'),
+        'isDefault' => TRUE,
       ],
       [
-          'type' => 'cancel',
-          'name' => E::ts('Cancel'),
-          'isDefault' => FALSE,
+        'type' => 'cancel',
+        'name' => E::ts('Cancel'),
+        'isDefault' => FALSE,
       ],
     ]);
   }
@@ -125,7 +125,8 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
         "Remove {$this->recurringLineItemData['label']}",
         'success'
       );
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       $tx->rollback();
 
       CRM_Core_Session::setStatus(
@@ -284,9 +285,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
    * @return array
    */
   private function getCorrespondingContributionLineItem($contributionID) {
-    $entityID = $this->recurringLineItemData['entity_table'] == 'civicrm_contribution' ?
-      $contributionID : $this->recurringLineItemData['entity_id']
-    ;
+    $entityID = $this->recurringLineItemData['entity_table'] == 'civicrm_contribution' ? $contributionID : $this->recurringLineItemData['entity_id'];
 
     $lineItem = [];
     try {
@@ -305,7 +304,8 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
       if ($apiResponse['count'] > 0) {
         $lineItem = $apiResponse['values'][0];
       }
-    } catch (Exception $e) {
+    }
+    catch (Exception $e) {
       return [];
     }
 
@@ -319,8 +319,8 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
   private function updateRecurringLineItem() {
     civicrm_api3('ContributionRecurLineItem', 'create', [
       'id' => $this->recurringLineItemData['id'],
-      'auto_renew' => false,
-      'is_removed' => true,
+      'auto_renew' => FALSE,
+      'is_removed' => TRUE,
       'end_date' => $this->lineItemEndDate,
     ]);
   }

--- a/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/RemoveLineItems.php
@@ -242,6 +242,12 @@ class CRM_MembershipExtras_Form_RecurringContribution_RemoveLineItems extends CR
         'label' => $lineItemBefore['label'] . " - Line removed from contribution [{$lineItemBefore['contribution_id']}]",
         'contribution_id' => 'null',
       ]);
+
+      // Remove the link between the membership and the contribution
+      $query = "DELETE FROM civicrm_membership_payment
+                WHERE membership_id = {$this->recurringLineItemData['entity_id']}
+                AND contribution_id = {$contribution['id']}";
+      CRM_Core_DAO::executeQuery($query);
     }
   }
 


### PR DESCRIPTION
## Overview

When a membership line item is deleted from the current period tab in the "manage installments" screen, we unlink the LineItem record for this membership from any future pending contribution in the payment plan, but while investigating BASW-897, I noticed that we still keep the MembershipPayment record that links the Contribution with the Membership, and thus if you open the membership that we removed from the current period tab, you will still see that it is linked to the future  pending contribution even though it has no line items on any of these future  contribution, this PR corrects by removing the MembershipPayment Record that links the two.

## Technical details

I used raw SQL query because MembershipPayment API end point does not support the "delete" action.