### PR TITLE
PROD-57: Fix next scheduled contribution date calculation for fixed memberships

### DIFF
--- a/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
+++ b/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessor.php
@@ -30,15 +30,21 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
   private $membershipTypeId;
 
   /**
+   * @var string
+   */
+  private $operation;
+
+  /**
    * @var int
    */
   private $recurContributionID;
 
-  public function __construct($formName, &$form) {
+  public function __construct($formName, &$form, $operation) {
     $this->formName = $formName;
     $this->form = &$form;
     $this->formSubmittedValues = $this->form->exportValues();
     $this->membershipTypeId = $this->getMembershipTypeId();
+    $this->operation = $operation;
   }
 
   /**
@@ -152,7 +158,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor {
   }
 
   private function updateNextScheduledContributionDate() {
-    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->recurContributionID);
+    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->recurContributionID, $this->operation);
     $nextContributionDateService->calculateAndUpdate();
   }
 

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/MultipleInstalmentPlan.php
@@ -72,7 +72,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_MultipleInstalmentPlan extends
     $instalmentsHandler = new MembershipInstalmentsHandler($this->newRecurringContributionID);
     $instalmentsHandler->createRemainingInstalmentContributionsUpfront();
 
-    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->newRecurringContributionID);
+    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->newRecurringContributionID, 'renewal');
     $nextContributionDateService->calculateAndUpdate();
   }
 

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
@@ -121,7 +121,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
     $this->setTotalAndTaxAmount();
     $this->recordPaymentPlanFirstContribution();
 
-    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->newRecurringContributionID);
+    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($this->newRecurringContributionID, 'renewal');
     $nextContributionDateService->calculateAndUpdate();
   }
 

--- a/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
+++ b/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
@@ -3,22 +3,44 @@
 class CRM_MembershipExtras_Service_PaymentPlanNextContributionDate {
 
   /**
-   * @var int
+   * @var array
    */
-  private $recurContributionID;
+  private $recurContribution;
 
-  public function __construct($recurContributionID) {
-    $this->recurContributionID = $recurContributionID;
+  /**
+   * @var string
+   */
+  private $operation;
+
+  /**
+   * @param int $recurContributionID
+   * @param string $operation
+   *   Payment plan "Creation" or "Renewal"
+   */
+  public function __construct($recurContributionID, $operation) {
+    $this->recurContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'return' => ['id', 'start_date', 'frequency_interval', 'frequency_unit', 'cycle_day'],
+      'id' => $recurContributionID,
+      'options' => ['limit' => 1],
+    ])['values'][0];
+
+    $this->operation = $operation;
   }
 
   /**
    * Calculates and Updates the recurring contribution `Next scheduled contribution date'.
    *
    * The `Next scheduled contribution date' will be used to control autorenewal,
-   * so we here update its value according to the following:
+   * so we here update its value according to the following if the
+   * membership type period is "Rolling":
    *  - Monthly payment plan: +1 month from the last contribution receive date.
    *  - Quarterly: +3 months from the last contribution receive date.
    *  - Yearly: +1 year from the last contribution receive date
+   * If the membership type period is "Fixed" (or if it is a priceset with fixed memberships)
+   * then we instead:
+   * - Calculate the date to be the membership end date plus 1 day (which is the start  date of the new period)
+   * - Then correct the date to match the cycle day
    */
   public function calculateAndUpdate() {
     $nextContributionDate = $this->calculateNextScheduledContributionDate();
@@ -29,40 +51,74 @@ class CRM_MembershipExtras_Service_PaymentPlanNextContributionDate {
     $query = 'UPDATE civicrm_contribution_recur SET next_sched_contribution_date = %1 WHERE id = %2';
     CRM_Core_DAO::executeQuery($query, [
       1 => [$nextContributionDate, 'String'],
-      2 => [$this->recurContributionID, 'Integer'],
+      2 => [$this->recurContribution['id'], 'Integer'],
     ]);
   }
 
   private function calculateNextScheduledContributionDate() {
-    $lastContributionReceiveDate = $this->getLastContributionReceiveDate();
-    if (empty($lastContributionReceiveDate)) {
+    $lastContribution = $this->getLastContribution();
+    if (empty($lastContribution)) {
       return NULL;
     }
 
-    $contributionRecur = civicrm_api3('ContributionRecur', 'get', [
-      'sequential' => 1,
-      'return' => ['id', 'start_date', 'frequency_interval', 'frequency_unit', 'cycle_day'],
-      'id' => $this->recurContributionID,
-      'options' => ['limit' => 1],
-    ])['values'][0];
-    $receiveDateCalculator = new CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator($contributionRecur);
-    $receiveDateCalculator->setStartDate($lastContributionReceiveDate);
+    $relatedMemberships = $this->getRelatedMemberships($lastContribution['id']);
+    $atLeastOneFixedMembershipExist = FALSE;
+    foreach ($relatedMemberships as $membership) {
+      if ($membership['period_type'] == 'fixed') {
+        $atLeastOneFixedMembershipExist = TRUE;
+        $calculationMembership = $membership;
+        break;
+      }
+    }
 
-    return $receiveDateCalculator->calculate(2);
+    if ($atLeastOneFixedMembershipExist && $this->operation == 'creation') {
+      $nextScheduledDate = date('Y-m-d', strtotime($calculationMembership['end_date'] . '00:00:00 +1 day'));
+      $nextScheduledDateCycleDay = CRM_MembershipExtras_Service_CycleDayCalculator::calculate($nextScheduledDate, 'month');
+      $paymentPlanCycleDay = $this->recurContribution['cycle_day'];
+      $adjustmentDaysAmount = $paymentPlanCycleDay - $nextScheduledDateCycleDay;
+
+      $nextScheduledDate = new DateTime($nextScheduledDate);
+      $nextScheduledDate->modify("$adjustmentDaysAmount day");
+      return $nextScheduledDate->format('Y-m-d 00:00:00');
+    }
+    else {
+      $receiveDateCalculator = new CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator($this->recurContribution);
+      $receiveDateCalculator->setStartDate($lastContribution['receive_date']);
+      return $receiveDateCalculator->calculate(2);
+    }
   }
 
-  private function getLastContributionReceiveDate() {
-    $lastContributionReceiveDate = civicrm_api3('Contribution', 'get', [
+  private function getLastContribution() {
+    $lastContribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
-      'return' => ['receive_date'],
-      'contribution_recur_id' => $this->recurContributionID,
+      'contribution_recur_id' => $this->recurContribution['id'],
       'options' => ['limit' => 1, 'sort' => 'id DESC'],
     ]);
-    if ($lastContributionReceiveDate['count'] != 1) {
+    if ($lastContribution['count'] != 1) {
       return NULL;
     }
 
-    return $lastContributionReceiveDate['values'][0]['receive_date'];
+    return $lastContribution['values'][0];
+  }
+
+  private function getRelatedMemberships($contributionId) {
+    $query = '
+      SELECT cm.id as membership_id, cm.end_date, cmt.period_type FROM civicrm_membership cm
+      INNER JOIN civicrm_membership_payment cmp ON cm.id = cmp.membership_id
+      INNER JOIN civicrm_membership_type cmt ON cm.membership_type_id = cmt.id
+      WHERE cmp.contribution_id = %1
+      ORDER BY cmp.membership_id ASC
+    ';
+    $results = CRM_Core_DAO::executeQuery($query, [
+      1 => [$contributionId, 'Integer'],
+    ]);
+
+    $result = [];
+    while ($results->fetch()) {
+      $result[] = $results->toArray();
+    }
+
+    return $result;
   }
 
 }

--- a/CRM/MembershipExtras/WebformAPI/PaymentPlanNextContributionDateUpdater.php
+++ b/CRM/MembershipExtras/WebformAPI/PaymentPlanNextContributionDateUpdater.php
@@ -6,7 +6,9 @@
 class CRM_MembershipExtras_WebformAPI_PaymentPlanNextContributionDateUpdater {
 
   public static function update($contributionRecurId) {
-    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($contributionRecurId);
+    // For offline payment plans memberships, we only offer create new ones through webforms, manual renewal is not supported.
+    $operation = 'Creation';
+    $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($contributionRecurId, $operation);
     $nextContributionDateService->calculateAndUpdate();
   }
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -248,7 +248,8 @@ function membershipextras_civicrm_postProcess($formName, &$form) {
       return;
     }
 
-    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor($formName, $form);
+    $operation = $isAddAction ? 'creation' : 'renewal';
+    $paymentPlanProcessor = new CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessor($formName, $form, $operation);
     $paymentPlanProcessor->postProcess();
 
     if ($formName == 'CRM_Member_Form_Membership') {


### PR DESCRIPTION
## Overview
Fixing how  "next scheduled contribution date" is calculated for fixed memberships payment plans to be based on the membership end date + cycle day, instead of last contribution date.  

## Before
As part of of the work we did in MAE-372 Epic, we changed how installments (contributions) "receive date" is calculated upon autorenewal to be based on the payment plan (recurring contribution) "**next scheduled contribution date**" .

But with fixed memberships this result in some problems, here is an example:

1- Create new "Fixed" membership type with duration of "1 Year" and  period start day = "1st of December" and period rollover day  = "30th of November":

![2021-12-22 13_41_05-Calendar](https://user-images.githubusercontent.com/6275540/147087526-dc95472b-e7c8-49b9-a7f3-26e026cc600f.png)

2- Create new membership using Membership creation form through CiviCRM, use "Payment Plan" as a method of payment, set Schedule to "Annual, and set the membership start and join dates to : "3rd of July 2020"

![2021-12-30 02_52_55-](https://user-images.githubusercontent.com/6275540/147713316-8372f418-f4f6-4aad-a2f4-d9d00673fb5a.png)


3- The created contribution date will be "3rd of July 2020" since we by default set the first installment date (in case on non direct debit payments) to equal the membership start date (which is also "3rd of July 2020" as we set it above during the membership creation).

4- But based on the current logic, the "Next scheduled contribution date" will be "last contribution receive date + 1 year" for annual payment plans, so in this case it will be "3rd of July 2021":

![2021-12-30 03_14_21-Photos](https://user-images.githubusercontent.com/6275540/147714042-3dfa300c-720d-4986-a9ed-4bd6d9044179.png)

This means when the autorenewal happen, the newly created installment (contribution) will have its receive date set to "3rd of July 2021", but the membership new start date will be "1st of December 2020", so the payment will be collected about 7 months ahead of the membership new term after renewal, which is too far and does not make sense to be the case.


## After

The above is solved by adding new rule for "Fixed" memberships, so if we are creating a fixed membership with payment plan we do the following steps:

1- Use the membership end date + 1 day as a base to calculate the "next scheduled contribution date", so in the example above the it will be "1st of December 2020" (30th of November 2020 [the membership end date] + 1 day), so upon renewal the new contribution receive date will also be "1st of December 2020".

2- Adjust the date to match the cycle day in case of monthly payment plans. In our example it is an annual payment plan where cycle day does not apply, so the next scheduled contribution date will be  "1st of December 2020".

![image](https://user-images.githubusercontent.com/6275540/147714276-a76eacb5-9cf2-4b88-b015-191b575d7079.png)


The above steps are only applied when new payment plan is created for the first time, and does not apply to renewals, because on renewals the memberships will be renewed for full period and not for partial period as it might be when it gets created for the first time, also if this logic was force on renewals, it will cause issues when the user change the "next schedule contribution date manually" and will result in it getting ignored which is against of what we are doing with this field in other cases, so it was important to exclude the renewal logic .


The above also raises the following questions:

1- Does the issue happen when buying fixed memberships using monthly or quarterly payment plans?

It should not, given in such cases only the first installment "receive date" might be off, but the rest of the installments will have dates that are properly spread across the remaining period of the membership, so our original logic will still work correctly for them. But in this PR I did not add an exception for them and applied the logic here to them too to keep the code easier to understand, and because both the current and the new logic should end up in the same result for both of them.

2- What if someone set up a Priceset with one fixed membership and one rolling membership ? 

We don't allow that anymore in Membershipextras, like you can still create such priceset, but in the membership form it will show the following error: 
![2021-12-22 01_43_57-Calendar](https://user-images.githubusercontent.com/6275540/147090972-9df990d2-d56e-4bee-8e45-0566ee0a4f47.png)

3- What if someone set up a Priceset with two fixed memberships but each one has different period start date and period rollover date ?

We also don't allow that anymore in Membershipextras, like you can still create such priceset, but in the membership form it will show the following error: 

![2021-12-22 01_46_39-dadas dasds _ civi5352v5](https://user-images.githubusercontent.com/6275540/147091162-69abc352-d890-4350-9cbb-083058f019b7.png)

4- What about webforms?

Given the logic we have in this PR is also called by webforms to calculate the "next scheduled contribution date", then we have them covered.

Though the rules we specified in point 2 and 3 above are not enforced on webforms and only work on Admin forms, so it is the person who configure the webform responsibility to  make sure that such kind of configurations does not happen. (though it is something we should improve at some point and enforce in code instead of relying on users to not do such kind of things)

## Technical Details
I've updated the PaymentPlanNextContributionDate service which is the service that is responsible for calculating the "next contribution date" across the extension, so it gets the payment plan memberships and checks if there is a fixed membership, if so then it will add one day to it, then correct it to match the cycle day, and then use it to be the "next contribution date". I also added new parameter to it called "$operation" so it knows if the who request this service is form payment plan creation context or renewal context, so it know if the logic we added for fixed membership should apply or not.
