### PR TITLE
COMCL-169: Update CiviCRM version in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.35.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.35.1
+          version: 5.39.1
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
@@ -265,7 +265,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest 
       'is_pay_later' => 1,
       'membership_id' => $membership['id'],
       'tax_amount' => $taxAmount,
-      'skipLineItem' => 0,
+      'skipLineItem' => 1,
       'contribution_recur_id' => NULL,
       'pan_truncation' => NULL,
       'card_type_id' => NULL,


### PR DESCRIPTION
## Overview

- Updating CiviCRM version in tests workflow to match the CiviCRM version on Compuclient 1.29
- After the update, this class tests `CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest ` started to fail:
````
1) CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest::testProRatedPriceSetContributionLineItemOnCalculationByMonthFixedMembershipType
CiviCRM_API3_Exception: passing in incorrect tax amounts is deprecated

/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/api/api.php:134
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Base.php:37
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Contribution.php:[25](https://github.com/compucorp/uk.co.compucorp.membershipextras/runs/5155796730?check_suite_focus=true#step:9:25)
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:[27](https://github.com/compucorp/uk.co.compucorp.membershipextras/runs/5155796730?check_suite_focus=true#step:9:27)4
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:159
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:44
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598

2) CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest::testProRatedPriceSetContributionLineItemOnCalculationByDaysFixedMembershipType
CiviCRM_API3_Exception: passing in incorrect tax amounts is deprecated

/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/api/api.php:134
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Base.php:37
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Contribution.php:25
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:274
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:159
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:72
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598

3) CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest::testAlterNonPriceSetLineItemForFixedMembershipType
CiviCRM_API3_Exception: passing in incorrect tax amounts is deprecated

/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/api/api.php:134
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Base.php:37
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Contribution.php:25
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:274
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:159
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:96
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598

4) CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest::testAlterLineItemForRollingMembershipType
CiviCRM_API3_Exception: passing in incorrect tax amounts is deprecated

/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/api/api.php:134
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Base.php:37
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Test/Fabricator/Contribution.php:25
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:274
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:159
/__w/uk.co.compucorp.membershipextras/uk.co.compucorp.membershipextras/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membershipextras/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php:1[32](https://github.com/compucorp/uk.co.compucorp.membershipextras/runs/5155796730?check_suite_focus=true#step:9:32)
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:[59](https://github.com/compucorp/uk.co.compucorp.membershipextras/runs/5155796730?check_suite_focus=true#step:9:59)8
```

Which is due to a change in CiviCRM BAO class that expects: 

- If `skipLineItem` param is set to 0, and `tax_amount` is set to any value, then there should be `line_items` param where the sum of taxes on these supplied line items should equal the supplied `tax_amount`, or otherwise a deprecation error will appear saying `passing in incorrect tax amounts is deprecated`.
- Given that these tests does not care if these line items are created or not, I just changed `skipLineItem` param to 1 and thus the comparison above won't happen.