### PR TITLE
MAE-476: Hides the auto-renew option field when the contribution tab is opened

### DIFF
--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -10,6 +10,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
       moveMembershipFormFields();
       setMembershipFormEvents();
       initializeMembershipForm();
+      hideOfflineAutorenewField();
     });
 
     /**
@@ -47,6 +48,20 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
       $(tabSelector).addClass('ui-tabs-active');
       $('[name=contribution_type_toggle]').val(tabOptionId);
       updateContributionPaymentPlanView(tabOptionId);
+    }
+
+    /**
+     * Hides the auto renew option field when the contribution tab is opened.
+     */
+    function hideOfflineAutorenewField() {
+      const autoRenewSelector = '.custom-group-offline_autorenew_option';
+
+      waitForElement($, '#customData', 
+        element => isPaymentPlanTabActive()
+          ? $(autoRenewSelector).show()
+          : $(autoRenewSelector).hide()
+      );
+      $('a[href="#contribution-subtab"]').click( event => $(autoRenewSelector).hide());
     }
 
     /**
@@ -393,6 +408,21 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
     function isRenewMembershipForm() {
       return !!$('#MembershipRenewal').length;
     }
+
+    /**
+     * Triggers callback when element attribute changes.
+     * 
+     * @param {object} $ 
+     * @param {string} elementPath 
+     * @param {object} callBack 
+     */
+    function waitForElement($, elementPath, callBack) {
+      (new MutationObserver(function(mutations) {
+        callBack($(elementPath));
+      })).observe(document.querySelector(elementPath), {
+        attributes: true
+      });
+    };
   });
 
 }


### PR DESCRIPTION
## Overview
This PR hides the auto-renew option field when the contribution tab is opened

## Before
The auto-renew option field is visible irrespective of the current tab.
![poo](https://user-images.githubusercontent.com/85277674/165465609-815309a8-0efe-44bb-b57c-5c0a136f7a6e.gif)

## After
The auto-renew option field is only opened when the payment tab is opened. it is hidden by default.
![poo-B](https://user-images.githubusercontent.com/85277674/165465937-22d66c6d-03c7-4a05-bf26-fba07283b549.gif)
