### PR TITLE
MAE-684: Prevent user from user selecting membership type with different period and duration

### DIFF
--- a/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
+++ b/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
@@ -6,5 +6,6 @@ class CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment extends Exc
   const QUARTERLY_NOT_SUPPORT = "Quarterly instalments for fixed period membership types are not supported.";
   const DURATION_INTERVAL = "Membership types must be 1 month, 1 year or 1 life time only";
   const DAY_DURATION = "Day duration unit is not supported";
+  const SAME_PERIOD_AND_DURATION = "You have selected membership types with different period types (i.e. rolling and fixed) and/or different duration units. Please only select memberships with the same period types and duration units.";
 
 }

--- a/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
+++ b/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
@@ -1,7 +1,6 @@
 <?php
 class CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment extends Exception {
   const ONE_YEAR_DURATION = "All membership types must have a duration of one year!";
-  const PERIOD_TYPE = "All membership types must have same period type.";
   const SAME_PERIOD_START_DAY = "All Membership types must have same period start day";
   const QUARTERLY_NOT_SUPPORT = "Quarterly instalments for fixed period membership types are not supported.";
   const DURATION_INTERVAL = "Membership types must be 1 month, 1 year or 1 life time only";

--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
@@ -72,18 +72,21 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
 
     $fixedPeriodStartDays = [];
     $periodTypes = [];
+    $durationUnits = [];
+
     foreach ($membershipTypes as $membershipType) {
       $periodTypes[] = $membershipType['period_type'];
+      $durationUnits[] = $membershipType['duration_unit'];
+
       if ($membershipType['period_type'] == 'fixed') {
         $fixedPeriodStartDays[] = $membershipType['fixed_period_start_day'];
       }
     }
 
     $periodTypes = array_unique($periodTypes);
-    if (!empty($periodTypes)) {
-      if (!empty($periodTypes) && count($periodTypes) != 1) {
-        $this->errors['price_set_id'] = InvalidMembershipTypeInstalment::PERIOD_TYPE;
-      }
+    $durationUnits = array_unique($durationUnits);
+    if (!empty($periodTypes) && (count($periodTypes) != 1 || count($durationUnits) != 1)) {
+      $this->errors['price_set_id'] = InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION;
     }
 
     $fixedPeriodStartDays = array_unique($fixedPeriodStartDays);

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -220,6 +220,8 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
   private function validateMembershipTypeForInstalment() {
     $fixedPeriodStartDays = [];
     $periodTypes = [];
+    $durationUnits = [];
+
     foreach ($this->membershipTypes as $membershipType) {
       if ($membershipType->duration_interval != 1) {
         throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::DURATION_INTERVAL));
@@ -236,6 +238,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
         }
       }
       $periodTypes[] = $membershipType->period_type;
+      $durationUnits[] = $membershipType->duration_unit;
     }
 
     $hasFixedMembershipType = in_array('fixed', $periodTypes);
@@ -244,8 +247,8 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
       throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::QUARTERLY_NOT_SUPPORT));
     }
 
-    if ($hasFixedMembershipType && in_array('rolling', $periodTypes)) {
-      throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::PERIOD_TYPE));
+    if (count(array_unique($periodTypes)) != 1 || count(array_unique($durationUnits)) != 1) {
+      throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION));
     }
 
     if ($hasFixedMembershipType) {

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembesPaymentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembesPaymentPlanTest.php
@@ -42,7 +42,55 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlanTest extends B
     ];
     $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
     $paymentPlanValidation->validate();
-    $this->assertEquals(InvalidMembershipTypeInstalment::PERIOD_TYPE, $this->errors['price_set_id']);
+    $this->assertEquals(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION, $this->errors['price_set_id']);
+  }
+
+  /**
+   * Tests error when mixed period membership type price field values are submitted.
+   */
+  public function testErrorWhenMixedDurationUnitMembershipTypePriceFieldValuesAreSubmitted() {
+    $priceSet = $this->mockPriceSet();
+    $priceField = $this->mockPriceField($priceSet['id'], 'Test Field Set 1');
+    $memType1 = $this->mockMembershipType('rolling', 'year');
+    $memType2 = $this->mockMembershipType('rolling', 'month');
+    $priceFieldValue1 = $this->mockPriceFieldValue($priceField['id'], $memType1['id']);
+    $priceFieldValue2 = $this->mockPriceFieldValue($priceField['id'], $memType2['id']);
+
+    $fields = [];
+    $fields['price_set_id'] = $priceSet['id'];
+    $mockedPriceFieldKey = 'price_' . (string) $priceField['id'];
+    //Simulate check boxes with different period membership period type attach to price field values
+    $fields[$mockedPriceFieldKey] = [
+      $priceFieldValue1['id'] => 1,
+      $priceFieldValue2['id'] => 1,
+    ];
+    $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
+    $paymentPlanValidation->validate();
+    $this->assertEquals(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION, $this->errors['price_set_id']);
+  }
+
+  /**
+   * Tests error when mixed period membership type price field values are submitted.
+   */
+  public function testErrorWhenMixedDurationUnitAndPeriodMembershipTypePriceFieldValuesAreSubmitted() {
+    $priceSet = $this->mockPriceSet();
+    $priceField = $this->mockPriceField($priceSet['id'], 'Test Field Set 1');
+    $memType1 = $this->mockMembershipType('rolling', 'year');
+    $memType2 = $this->mockMembershipType('fixed', 'month');
+    $priceFieldValue1 = $this->mockPriceFieldValue($priceField['id'], $memType1['id']);
+    $priceFieldValue2 = $this->mockPriceFieldValue($priceField['id'], $memType2['id']);
+
+    $fields = [];
+    $fields['price_set_id'] = $priceSet['id'];
+    $mockedPriceFieldKey = 'price_' . (string) $priceField['id'];
+    //Simulate check boxes with different period membership period type attach to price field values
+    $fields[$mockedPriceFieldKey] = [
+      $priceFieldValue1['id'] => 1,
+      $priceFieldValue2['id'] => 1,
+    ];
+    $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
+    $paymentPlanValidation->validate();
+    $this->assertEquals(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION, $this->errors['price_set_id']);
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR prevents a user from selecting membership types with different `period type` and `duration unit`. should in case a user selects multiple membership types with different `period type` or `different unit` the following error is displayed `You have selected membership types with different period types (i.e. rolling and fixed) and/or different duration units. Please only select memberships with the same period types and duration units.`  

## Before
Error `All membership types must have a same period type.` is only displayed when multiple membership types with different period types are selected.

## After
The new error message is displayed when multiple membership types with different `period types` or different `duration units` are selected.
![b](https://user-images.githubusercontent.com/85277674/166925768-6911315d-b246-4bc5-88e8-7060fe3e28f9.gif)
