### PR TITLE
MAE-685: Simplify payment instalment validation logic

### DIFF
--- a/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
+++ b/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
@@ -6,5 +6,6 @@ class CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment extends Exc
   const QUARTERLY_NOT_SUPPORT = "Quarterly instalments for fixed period membership types are not supported.";
   const DURATION_INTERVAL = "Membership types must be 1 month, 1 year or 1 life time only";
   const DAY_DURATION = "Day duration unit is not supported";
+  const SAME_PERIOD_AND_DURATION = "You have selected membership types with different period types (i.e. rolling and fixed) and/or different duration units. Please only select memberships with the same period types and duration units.";
 
 }

--- a/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
+++ b/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
@@ -1,7 +1,6 @@
 <?php
 class CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment extends Exception {
   const ONE_YEAR_DURATION = "All membership types must have a duration of one year!";
-  const PERIOD_TYPE = "All membership types must have same period type.";
   const SAME_PERIOD_START_DAY = "All Membership types must have same period start day";
   const QUARTERLY_NOT_SUPPORT = "Quarterly instalments for fixed period membership types are not supported.";
   const DURATION_INTERVAL = "Membership types must be 1 month, 1 year or 1 life time only";

--- a/CRM/MembershipExtras/Helper/InstalmentValidator.php
+++ b/CRM/MembershipExtras/Helper/InstalmentValidator.php
@@ -1,0 +1,155 @@
+<?php
+
+use CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment as InvalidMembershipTypeInstalment;
+
+/**
+ * Validates the membership types passed in to ensure they meets the criteria for calculating installment.
+ */
+class CRM_MembershipExtras_Helper_InstalmentValidator {
+
+  const MONTHLY = 'monthly';
+  const QUARTERLY = 'quarterly';
+  const ANNUAL = 'annual';
+
+  const MONTHLY_INSTALMENT_COUNT = 12;
+  const QUARTERLY_INSTALMENT_COUNT = 4;
+  const ANNUAL_INTERVAL_COUNT = 1;
+
+  /**
+   * @var array
+   *  The array of errors.
+   */
+  private $errorBag = [];
+
+  /**
+   * @var array
+   *  The array of membership types to validate
+   */
+  private $membershipTypes;
+
+  /**
+   * @var string
+   *  The Installment schedule
+   */
+  private $schedule;
+
+  /**
+   * CRM_MembershipExtras_Helper_InstalmentValidator constructor.
+   *
+   * @param array $membershipTypes
+   * @param string $schedule
+   *
+   * @throws CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment
+   */
+  public function __construct(array $membershipTypes, $schedule = NULL) {
+    $this->membershipTypes = $membershipTypes;
+    $this->schedule = $schedule;
+    $this->validateMembershipTypeForInstalment();
+  }
+
+  /**
+   * Determines if the data fails the validation rules.
+   *
+   * @return bool
+   */
+  public function passes() {
+    return count($this->errorBag) == 0;
+  }
+
+  /**
+   * Determines if the data fails the validation rules.
+   *
+   * @return bool
+   */
+  public function fails() {
+    return !$this->passes();
+  }
+
+  /**
+   * "Break" on first validation error.
+   *
+   * @throws InvalidMembershipTypeInstalment
+   */
+  public function validateBail() {
+    if ($this->fails()) {
+      throw new InvalidMembershipTypeInstalment($this->errorBag[0]);
+    }
+  }
+
+  /**
+   * Returns the list of errors.
+   *
+   * @return array
+   */
+  public function errors() {
+    return $this->errorBag;
+  }
+
+  /**
+   * Returns the last error encountered otherwise null.
+   *
+   * @return string
+   */
+  public function lastError() {
+    if ($this->passes()) {
+      return NULL;
+    }
+
+    return $this->errorBag[count($this->errorBag) - 1];
+  }
+
+  /**
+   * Performs validation logic.
+   *
+   * @return self
+   */
+  private function validateMembershipTypeForInstalment() {
+    $periodTypes = [];
+    $durationUnits = [];
+    $fixedPeriodStartDays = [];
+
+    foreach ($this->membershipTypes as $membershipType) {
+      $membershipType = (array) $membershipType;
+      if ($membershipType['duration_interval'] != 1) {
+        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::DURATION_INTERVAL);
+      }
+
+      if ($membershipType['period_type'] == 'fixed') {
+        if ($membershipType['duration_unit'] != 'year') {
+          $this->errorBag[] = ts(InvalidMembershipTypeInstalment::ONE_YEAR_DURATION);
+        }
+        $fixedPeriodStartDays[] = $membershipType['fixed_period_start_day'];
+      }
+      else {
+        if ($membershipType['duration_unit'] == 'day') {
+          $this->errorBag[] = ts(InvalidMembershipTypeInstalment::DAY_DURATION);
+        }
+      }
+
+      $periodTypes[] = $membershipType['period_type'];
+      $durationUnits[] = $membershipType['duration_unit'];
+    }
+
+    $hasFixedMembershipType = in_array('fixed', $periodTypes);
+
+    if (!empty($this->schedule)) {
+      if ($hasFixedMembershipType && $this->schedule == self::QUARTERLY) {
+        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::QUARTERLY_NOT_SUPPORT);
+      }
+    }
+
+    if (count(array_unique($periodTypes)) != 1 || count(array_unique($durationUnits)) != 1) {
+      $this->errorBag[] = ts(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION);
+    }
+
+    if ($hasFixedMembershipType) {
+      $fixedPeriodStartDays = array_unique($fixedPeriodStartDays);
+      if (!empty($fixedPeriodStartDays) && count($fixedPeriodStartDays) != 1) {
+        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::SAME_PERIOD_START_DAY);
+      }
+    }
+
+    return $this;
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
@@ -72,18 +72,21 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
 
     $fixedPeriodStartDays = [];
     $periodTypes = [];
+    $durationUnits = [];
+
     foreach ($membershipTypes as $membershipType) {
       $periodTypes[] = $membershipType['period_type'];
+      $durationUnits[] = $membershipType['duration_unit'];
+
       if ($membershipType['period_type'] == 'fixed') {
         $fixedPeriodStartDays[] = $membershipType['fixed_period_start_day'];
       }
     }
 
     $periodTypes = array_unique($periodTypes);
-    if (!empty($periodTypes)) {
-      if (!empty($periodTypes) && count($periodTypes) != 1) {
-        $this->errors['price_set_id'] = InvalidMembershipTypeInstalment::PERIOD_TYPE;
-      }
+    $durationUnits = array_unique($durationUnits);
+    if (!empty($periodTypes) && (count($periodTypes) != 1 || count($durationUnits) != 1)) {
+      $this->errors['price_set_id'] = InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION;
     }
 
     $fixedPeriodStartDays = array_unique($fixedPeriodStartDays);

--- a/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/MembershipPaymentPlan.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_MembershipExtras_Helper_InstalmentValidator as InstalmentValidator;
+use CRM_MembershipExtras_Validate_PaymentPlan_MembershipType as membershipTypeValidator;
 
 /**
  * Form Validation on payment plan submission.
@@ -75,7 +75,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan {
       return;
     }
 
-    $validator = new InstalmentValidator($membershipTypes);
+    $validator = new membershipTypeValidator($membershipTypes);
 
     if (!$validator->passes()) {
       $this->errors[$errorField] = $validator->lastError();

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment as InvalidMembershipTypeInstalment;
+use CRM_MembershipExtras_Helper_InstalmentValidator as InstalmentValidator;
 use CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator as InstalmentAmountCalculator;
 use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator as FixedPeriodTypeCalculator;
 use CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalculator as RollingPeriodCalculator;
@@ -218,45 +218,8 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
    * @throws InvalidMembershipTypeInstalment
    */
   private function validateMembershipTypeForInstalment() {
-    $fixedPeriodStartDays = [];
-    $periodTypes = [];
-    $durationUnits = [];
-
-    foreach ($this->membershipTypes as $membershipType) {
-      if ($membershipType->duration_interval != 1) {
-        throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::DURATION_INTERVAL));
-      }
-      if ($membershipType->period_type == 'fixed') {
-        if ($membershipType->duration_unit != 'year') {
-          throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::ONE_YEAR_DURATION));
-        }
-        $fixedPeriodStartDays[] = $membershipType->fixed_period_start_day;
-      }
-      else {
-        if ($membershipType->duration_unit == 'day') {
-          throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::DAY_DURATION));
-        }
-      }
-      $periodTypes[] = $membershipType->period_type;
-      $durationUnits[] = $membershipType->duration_unit;
-    }
-
-    $hasFixedMembershipType = in_array('fixed', $periodTypes);
-
-    if ($hasFixedMembershipType && $this->schedule == self::QUARTERLY) {
-      throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::QUARTERLY_NOT_SUPPORT));
-    }
-
-    if (count(array_unique($periodTypes)) != 1 || count(array_unique($durationUnits)) != 1) {
-      throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION));
-    }
-
-    if ($hasFixedMembershipType) {
-      $fixedPeriodStartDays = array_unique($fixedPeriodStartDays);
-      if (!empty($fixedPeriodStartDays) && count($fixedPeriodStartDays) != 1) {
-        throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::SAME_PERIOD_START_DAY));
-      }
-    }
+    $validator = new InstalmentValidator($this->membershipTypes, $this->schedule);
+    $validator->validateBail();
   }
 
   /**

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -220,6 +220,8 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
   private function validateMembershipTypeForInstalment() {
     $fixedPeriodStartDays = [];
     $periodTypes = [];
+    $durationUnits = [];
+
     foreach ($this->membershipTypes as $membershipType) {
       if ($membershipType->duration_interval != 1) {
         throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::DURATION_INTERVAL));
@@ -236,6 +238,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
         }
       }
       $periodTypes[] = $membershipType->period_type;
+      $durationUnits[] = $membershipType->duration_unit;
     }
 
     $hasFixedMembershipType = in_array('fixed', $periodTypes);
@@ -244,8 +247,8 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
       throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::QUARTERLY_NOT_SUPPORT));
     }
 
-    if ($hasFixedMembershipType && in_array('rolling', $periodTypes)) {
-      throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::PERIOD_TYPE));
+    if (count(array_unique($periodTypes)) != 1 || count(array_unique($durationUnits)) != 1) {
+      throw new InvalidMembershipTypeInstalment(ts(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION));
     }
 
     if ($hasFixedMembershipType) {

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_MembershipExtras_Helper_InstalmentValidator as InstalmentValidator;
+use CRM_MembershipExtras_Validate_PaymentPlan_MembershipType as membershipTypeValidator;
 use CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator as InstalmentAmountCalculator;
 use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator as FixedPeriodTypeCalculator;
 use CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalculator as RollingPeriodCalculator;
@@ -218,7 +218,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
    * @throws InvalidMembershipTypeInstalment
    */
   private function validateMembershipTypeForInstalment() {
-    $validator = new InstalmentValidator($this->membershipTypes, $this->schedule);
+    $validator = new membershipTypeValidator($this->membershipTypes, $this->schedule);
     $validator->validateBail();
   }
 

--- a/CRM/MembershipExtras/Validate/PaymentPlan/MembershipType.php
+++ b/CRM/MembershipExtras/Validate/PaymentPlan/MembershipType.php
@@ -5,7 +5,7 @@ use CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment as InvalidMem
 /**
  * Validates the membership types passed in to ensure they meets the criteria for calculating installment.
  */
-class CRM_MembershipExtras_Helper_InstalmentValidator {
+class CRM_MembershipExtras_Validate_PaymentPlan_MembershipType {
 
   const MONTHLY = 'monthly';
   const QUARTERLY = 'quarterly';
@@ -34,7 +34,7 @@ class CRM_MembershipExtras_Helper_InstalmentValidator {
   private $schedule;
 
   /**
-   * CRM_MembershipExtras_Helper_InstalmentValidator constructor.
+   * CRM_MembershipExtras_Validate_PaymentPlan_MembershipType constructor.
    *
    * @param array $membershipTypes
    * @param string $schedule
@@ -44,7 +44,7 @@ class CRM_MembershipExtras_Helper_InstalmentValidator {
   public function __construct(array $membershipTypes, $schedule = NULL) {
     $this->membershipTypes = $membershipTypes;
     $this->schedule = $schedule;
-    $this->validateMembershipTypeForInstalment();
+    $this->validateMembershipTypeFields();
   }
 
   /**
@@ -103,7 +103,7 @@ class CRM_MembershipExtras_Helper_InstalmentValidator {
    *
    * @return self
    */
-  private function validateMembershipTypeForInstalment() {
+  private function validateMembershipTypeFields() {
     $periodTypes = [];
     $durationUnits = [];
     $fixedPeriodStartDays = [];

--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -69,7 +69,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
      * Price set, or Payment Plan Schedule
      */
     function setScheduleEvents() {
-      $('#total_amount, #membership_type_id_1').change(() => {
+      $('#total_amount, #membership_type_id_1, #record_contribution').change(() => {
         if (!isPaymentPlanTabActive()) {
           return;
         }

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembesPaymentPlanTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/MembesPaymentPlanTest.php
@@ -42,7 +42,55 @@ class CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlanTest extends B
     ];
     $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
     $paymentPlanValidation->validate();
-    $this->assertEquals(InvalidMembershipTypeInstalment::PERIOD_TYPE, $this->errors['price_set_id']);
+    $this->assertEquals(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION, $this->errors['price_set_id']);
+  }
+
+  /**
+   * Tests error when mixed period membership type price field values are submitted.
+   */
+  public function testErrorWhenMixedDurationUnitMembershipTypePriceFieldValuesAreSubmitted() {
+    $priceSet = $this->mockPriceSet();
+    $priceField = $this->mockPriceField($priceSet['id'], 'Test Field Set 1');
+    $memType1 = $this->mockMembershipType('rolling', 'year');
+    $memType2 = $this->mockMembershipType('rolling', 'month');
+    $priceFieldValue1 = $this->mockPriceFieldValue($priceField['id'], $memType1['id']);
+    $priceFieldValue2 = $this->mockPriceFieldValue($priceField['id'], $memType2['id']);
+
+    $fields = [];
+    $fields['price_set_id'] = $priceSet['id'];
+    $mockedPriceFieldKey = 'price_' . (string) $priceField['id'];
+    //Simulate check boxes with different period membership period type attach to price field values
+    $fields[$mockedPriceFieldKey] = [
+      $priceFieldValue1['id'] => 1,
+      $priceFieldValue2['id'] => 1,
+    ];
+    $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
+    $paymentPlanValidation->validate();
+    $this->assertEquals(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION, $this->errors['price_set_id']);
+  }
+
+  /**
+   * Tests error when mixed period membership type price field values are submitted.
+   */
+  public function testErrorWhenMixedDurationUnitAndPeriodMembershipTypePriceFieldValuesAreSubmitted() {
+    $priceSet = $this->mockPriceSet();
+    $priceField = $this->mockPriceField($priceSet['id'], 'Test Field Set 1');
+    $memType1 = $this->mockMembershipType('rolling', 'year');
+    $memType2 = $this->mockMembershipType('fixed', 'month');
+    $priceFieldValue1 = $this->mockPriceFieldValue($priceField['id'], $memType1['id']);
+    $priceFieldValue2 = $this->mockPriceFieldValue($priceField['id'], $memType2['id']);
+
+    $fields = [];
+    $fields['price_set_id'] = $priceSet['id'];
+    $mockedPriceFieldKey = 'price_' . (string) $priceField['id'];
+    //Simulate check boxes with different period membership period type attach to price field values
+    $fields[$mockedPriceFieldKey] = [
+      $priceFieldValue1['id'] => 1,
+      $priceFieldValue2['id'] => 1,
+    ];
+    $paymentPlanValidation = new CRM_MembershipExtras_Hook_ValidateForm_MembershipPaymentPlan($this->form, $fields, $this->errors);
+    $paymentPlanValidation->validate();
+    $this->assertEquals(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION, $this->errors['price_set_id']);
   }
 
   /**


### PR DESCRIPTION
## Overview
Before now, the validation performed in the front-end is different from that performed in the back-end when creating a new membership with a payment plan,  in this PR we ensure the same validation happens on both the front-end and back-end.

It also includes the work done in this [PR](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/423) where we prevent users from selecting membership types with different periods and duration.

## Before
Currently, changes in the UI can allow a user to get around the validation, in some cases, this leads to errors, at times the user is able to create a membership with recurring membership bypassing the validation.
![laa-gg](https://user-images.githubusercontent.com/85277674/167402179-37c8d5f2-2879-4404-ab51-969c88d945a6.gif)


## After
Now the validation logic that happens in the backend also happens in the frontend.
![gg](https://user-images.githubusercontent.com/85277674/167399392-744f1a4c-f408-497c-9391-27e375ee50b4.gif)


## Technical Details
We create a new class `CRM_MembershipExtras_Helper_InstalmentValidator` that acts as a helper class in performing necessary validation logic for creating a new membership with a payment plan.