### PR TITLE
MAE-684: Remove validation that prevents creating membership of multiple months or years.

### DIFF
--- a/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
+++ b/CRM/MembershipExtras/Exception/InvalidMembershipTypeInstalment.php
@@ -4,7 +4,10 @@ class CRM_MembershipExtras_Exception_InvalidMembershipTypeInstalment extends Exc
   const SAME_PERIOD_START_DAY = "All Membership types must have same period start day";
   const QUARTERLY_NOT_SUPPORT = "Quarterly instalments for fixed period membership types are not supported.";
   const DURATION_INTERVAL = "Membership types must be 1 month, 1 year or 1 life time only";
+  const ONE_LIFETIME_DURATION = "Membership types can only have a duration of one lifetime!";
   const DAY_DURATION = "Day duration unit is not supported";
   const SAME_PERIOD_AND_DURATION = "You have selected membership types with different period types (i.e. rolling and fixed) and/or different duration units. Please only select memberships with the same period types and duration units.";
+  const MONTHLY_INSTALMENT_FOR_MONTH_UNIT = "Quarterly or Yearly installments not supported for rolling period membership types with monthly duration unit";
+  const LIFETIME_DURATION = "Lifetime memberships must be purchased with a one off fee. Please select the contribution tab to record a payment";
 
 }

--- a/CRM/MembershipExtras/Validate/PaymentPlan/MembershipType.php
+++ b/CRM/MembershipExtras/Validate/PaymentPlan/MembershipType.php
@@ -110,13 +110,13 @@ class CRM_MembershipExtras_Validate_PaymentPlan_MembershipType {
 
     foreach ($this->membershipTypes as $membershipType) {
       $membershipType = (array) $membershipType;
-      if ($membershipType['duration_interval'] != 1) {
-        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::DURATION_INTERVAL);
-      }
 
       if ($membershipType['period_type'] == 'fixed') {
         if ($membershipType['duration_unit'] != 'year') {
           $this->errorBag[] = ts(InvalidMembershipTypeInstalment::ONE_YEAR_DURATION);
+        }
+        if ($membershipType['duration_interval'] != 1) {
+          $this->errorBag[] = ts(InvalidMembershipTypeInstalment::DURATION_INTERVAL);
         }
         $fixedPeriodStartDays[] = $membershipType['fixed_period_start_day'];
       }
@@ -126,17 +126,16 @@ class CRM_MembershipExtras_Validate_PaymentPlan_MembershipType {
         }
       }
 
+      if ($membershipType['duration_unit'] == 'lifetime') {
+        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::LIFETIME_DURATION);
+      }
+
       $periodTypes[] = $membershipType['period_type'];
       $durationUnits[] = $membershipType['duration_unit'];
     }
 
     $hasFixedMembershipType = in_array('fixed', $periodTypes);
-
-    if (!empty($this->schedule)) {
-      if ($hasFixedMembershipType && $this->schedule == self::QUARTERLY) {
-        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::QUARTERLY_NOT_SUPPORT);
-      }
-    }
+    $hasRollingMembershipType = in_array('rolling', $periodTypes);
 
     if (count(array_unique($periodTypes)) != 1 || count(array_unique($durationUnits)) != 1) {
       $this->errorBag[] = ts(InvalidMembershipTypeInstalment::SAME_PERIOD_AND_DURATION);
@@ -146,6 +145,16 @@ class CRM_MembershipExtras_Validate_PaymentPlan_MembershipType {
       $fixedPeriodStartDays = array_unique($fixedPeriodStartDays);
       if (!empty($fixedPeriodStartDays) && count($fixedPeriodStartDays) != 1) {
         $this->errorBag[] = ts(InvalidMembershipTypeInstalment::SAME_PERIOD_START_DAY);
+      }
+    }
+
+    if (!empty($this->schedule)) {
+      if ($hasFixedMembershipType && $this->schedule == self::QUARTERLY) {
+        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::QUARTERLY_NOT_SUPPORT);
+      }
+
+      if ($this->schedule != self::MONTHLY && $hasRollingMembershipType && $durationUnits[0] == 'month') {
+        $this->errorBag[] = ts(InvalidMembershipTypeInstalment::MONTHLY_INSTALMENT_FOR_MONTH_UNIT);
       }
     }
 

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
@@ -54,16 +54,17 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
   }
 
   /**
-   * Tests getting instalment for life time duration unit for rolling membership type.
+   * Tests exception is thrown when membership type duration unit is one (1) lifetime
    */
-  public function testOneLifeTimeUnitRollingMembershipType() {
-    $rollingLifetimeType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams,
+  public function testExceptionIsThrownIfMembershipTypeDurationUnitIsOneLifeTime() {
+    $invalidMembershipType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams,
       ['duration_unit' => 'lifetime', 'duration_interval' => 1, 'name' => 'xyz', 'period_type' => 'rolling']
     ));
-    $membershipType = CRM_Member_BAO_MembershipType::findById($rollingLifetimeType['id']);
-    $schedule = $this->getMembershipSchedule([$membershipType], MembershipInstalmentsSchedule::MONTHLY);
-    //Expected instalment equals 1 for life time duration
-    $this->assertCount(1, $schedule['instalments']);
+
+    $membershipType = CRM_Member_BAO_MembershipType::findById($invalidMembershipType['id']);
+    $this->expectException(InvalidMembershipTypeInstalment::class);
+    $this->expectExceptionMessage(InvalidMembershipTypeInstalment::LIFETIME_DURATION);
+    $this->getMembershipInstalmentsSchedule([$membershipType], MembershipInstalmentsSchedule::ANNUAL);
   }
 
   /**
@@ -616,18 +617,6 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
   public function testExceptionIsThrownIfMembershipTypeDurationUnitIsDay() {
     $invalidMembershipType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams,
       ['duration_unit' => 'day', 'duration_interval' => 1, 'name' => 'xyz', 'period_type' => 'rolling']
-    ));
-    $membershipType = CRM_Member_BAO_MembershipType::findById($invalidMembershipType['id']);
-    $this->expectException(InvalidMembershipTypeInstalment::class);
-    $this->getMembershipInstalmentsSchedule([$membershipType], MembershipInstalmentsSchedule::ANNUAL);
-  }
-
-  /**
-   * Tests exception is thrown when membership type duration is not one (1)
-   */
-  public function testExceptionIsThrownIfMembershipTypeDurationIntervalIsNotOne() {
-    $invalidMembershipType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams,
-      ['duration_unit' => 'year', 'duration_interval' => 2, 'name' => 'xyz', 'period_type' => 'rolling']
     ));
     $membershipType = CRM_Member_BAO_MembershipType::findById($invalidMembershipType['id']);
     $this->expectException(InvalidMembershipTypeInstalment::class);


### PR DESCRIPTION
## Overview
In this PR, the validation that prevents users from creating rolling membership with multiple months or years duration is removed.

Also, users are prevented from creating a payment plan membership with a lifetime duration

## Before
![apap2](https://user-images.githubusercontent.com/85277674/168602201-1fbd74b0-a711-47a5-90fe-37840a8bbdfc.gif)


## After
![apap](https://user-images.githubusercontent.com/85277674/168601548-34814f13-429b-49e3-a8e8-c556670e17fd.gif)

Users are prevented from creating payment plan membership with life time duration
<img width="1402" alt="Screenshot 2022-05-16 at 14 19 01" src="https://user-images.githubusercontent.com/85277674/168601681-7e1244b3-dcda-4e1c-9d12-570e427df1bf.png">

