### PR TITLE
MAE-686: Disable the “Number of terms” field when creating new Price Set

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/PriceOptionEdit.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/PriceOptionEdit.php
@@ -4,14 +4,14 @@ class CRM_MembershipExtras_Hook_BuildForm_PriceOptionEdit {
 
 
   /**
-   * @var CRM_Price_Form_Option
+   * @var CRM_Core_Form
    */
   private $form;
 
   /**
-   * @param \CRM_Price_Form_Option $form
+   * @param \CRM_Core_Form $form
    */
-  public function __construct(CRM_Price_Form_Option $form) {
+  public function __construct(CRM_Core_Form $form) {
     $this->form = $form;
   }
 
@@ -25,12 +25,28 @@ class CRM_MembershipExtras_Hook_BuildForm_PriceOptionEdit {
    * not also sell multiple terms via price sets.
    */
   private function disableNumberOfTerms() {
-    if (!$this->form->elementExists('membership_num_terms')) {
-      return;
+    if ($this->form->elementExists('membership_num_terms')) {
+      $this->setToReadOnly('membership_num_terms');
     }
 
-    $numOfTermElement = $this->form->getElement('membership_num_terms');
-    $numOfTermElement->setValue(1);
+    foreach ($this->form->_elementIndex as $key => $index) {
+      if (preg_match('/membership_num_terms\[[\d]+\]/', $key)) {
+        $this->setToReadOnly($key);
+      }
+    }
+  }
+
+  /**
+   * Prevents ediitng a form field
+   *
+   * @param string $field
+   *  The form field to set to readonly.
+   * @param mixed $value
+   *  Thoe form feild default value.
+   */
+  private function setToReadOnly($field, $value = 1) {
+    $numOfTermElement = $this->form->getElement($field);
+    $numOfTermElement->setValue($value);
     $numOfTermElement->setAttribute('readonly', TRUE);
   }
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -313,7 +313,7 @@ function membershipextras_civicrm_buildForm($formName, &$form) {
     Civi::$statics[E::LONG_NAME]['paymentType'] = $form->getVar('_paymentType');
   }
 
-  if ($formName === 'CRM_Price_Form_Option') {
+  if ($formName === 'CRM_Price_Form_Option' || $formName === 'CRM_Price_Form_Field') {
     $priceFieldHook = new CRM_MembershipExtras_Hook_BuildForm_PriceOptionEdit($form);
     $priceFieldHook->buildForm();
   }


### PR DESCRIPTION
## Overview
This PR is a follow up to this [PR](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/426), where users are prevented from editing the "Number of Terms" field. in this PR we ensure the "Number of Terms" field is also disabled when creating a new membership Price Set.

## Before
![image](https://user-images.githubusercontent.com/85277674/168617784-020ee952-ba4d-4268-a3e3-9685d2655b52.png)

## After
<img width="1417" alt="Screenshot 2022-05-16 at 15 37 03" src="https://user-images.githubusercontent.com/85277674/168618046-8cfede64-34fe-41ce-936c-47714f22588a.png">

