### PR TITLE
[draft] MAE-690: Add support for multi months rolling payment plan membership

### DIFF
--- a/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
+++ b/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
@@ -56,7 +56,7 @@ trait CRM_MembershipExtras_Helper_InstalmentHelperTrait {
       return (int) $membershipType->duration_interval;
     }
 
-    return CRM_MembershipExtras_Helper_InstalmentSchedule::getInstalmentCountBySchedule($schedule);
+    return CRM_MembershipExtras_Helper_InstalmentSchedule::getInstalmentCountBySchedule($schedule, (int) $membershipType->duration_interval);
   }
 
 }

--- a/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
+++ b/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
@@ -48,8 +48,12 @@ trait CRM_MembershipExtras_Helper_InstalmentHelperTrait {
     }
 
     $durationUnit = $membershipType->duration_unit;
-    if ($membershipType->period_type == 'rolling' && ($durationUnit == 'month' || $durationUnit == 'lifetime')) {
+    if ($membershipType->period_type == 'rolling' && $durationUnit == 'lifetime') {
       return 1;
+    }
+
+    if ($membershipType->period_type == 'rolling' && $durationUnit == 'month') {
+      return (int) $membershipType->duration_interval;
     }
 
     return CRM_MembershipExtras_Helper_InstalmentSchedule::getInstalmentCountBySchedule($schedule);

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -30,7 +30,7 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
       $instalmentDetails['instalments_count'] = (int) $membershipType['duration_interval'];
     }
     else {
-      $instalmentDetails['instalments_count'] = self::getInstalmentCountBySchedule($schedule);
+      $instalmentDetails['instalments_count'] = self::getInstalmentCountBySchedule($schedule, (int) $membershipType['duration_interval']);
     }
 
     $instalmentDetails['instalments_frequency'] = self::getFrequencyInterval($schedule);
@@ -73,9 +73,11 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
    *
    * @param $schedule
    *
+   * @param $interval
+   *
    * @return int
    */
-  public static function getInstalmentCountBySchedule($schedule) {
+  public static function getInstalmentCountBySchedule($schedule, $interval) {
     switch ($schedule) {
       case InstalmentsSchedule::MONTHLY:
         $instalmentInterval = InstalmentsSchedule::MONTHLY_INSTALMENT_COUNT;
@@ -89,7 +91,7 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
         $instalmentInterval = InstalmentsSchedule::ANNUAL_INTERVAL_COUNT;
     }
 
-    return $instalmentInterval;
+    return $instalmentInterval * $interval;
   }
 
   /**

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -23,12 +23,16 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
     ])['values'][0]['api.MembershipType.get']['values'][0];
 
     $durationUnit = $membershipType['duration_unit'];
-    if ($membershipType['period_type'] == 'rolling' && ($durationUnit == 'lifetime' || $durationUnit == 'month')) {
+    if ($membershipType['period_type'] == 'rolling' && $durationUnit == 'lifetime') {
       $instalmentDetails['instalments_count'] = 1;
+    }
+    elseif ($membershipType['period_type'] == 'rolling' && $durationUnit == 'month') {
+      $instalmentDetails['instalments_count'] = (int) $membershipType['duration_interval'];
     }
     else {
       $instalmentDetails['instalments_count'] = self::getInstalmentCountBySchedule($schedule);
     }
+
     $instalmentDetails['instalments_frequency'] = self::getFrequencyInterval($schedule);
     $instalmentDetails['instalments_frequency_unit'] = self::getFrequencyUnit($schedule, $instalmentDetails['instalments_frequency']);
 

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -111,15 +111,15 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
   }
 
   public static function getPaymentPlanSchedule($frequencyUnit, $frequencyInterval, $installmentsCount) {
-    if ($frequencyUnit == 'month' && $frequencyInterval == 1 && $installmentsCount == 12) {
+    if ($frequencyUnit == 'month' && $frequencyInterval == 1) {
       return InstalmentsSchedule::MONTHLY;
     }
 
-    if ($frequencyUnit == 'month' && $frequencyInterval == 3 && $installmentsCount == 4) {
+    if ($frequencyUnit == 'month' && $frequencyInterval == 3) {
       return InstalmentsSchedule::QUARTERLY;
     }
 
-    if ($frequencyUnit == 'year' && $frequencyInterval == 1 && $installmentsCount == 1) {
+    if ($frequencyUnit == 'year' && $frequencyInterval == 1) {
       return InstalmentsSchedule::ANNUAL;
     }
   }

--- a/CRM/MembershipExtras/Service/CycleDayCalculator.php
+++ b/CRM/MembershipExtras/Service/CycleDayCalculator.php
@@ -21,8 +21,12 @@ class CRM_MembershipExtras_Service_CycleDayCalculator {
    * @return int
    */
   public static function calculate($targetDate, $frequencyUnit) {
+    $recurContStartDate = new DateTime($targetDate);
+    if ($frequencyUnit == 'month' && in_array($recurContStartDate->format('j'), [29, 30, 31])) {
+      return 1;
+    }
+
     if ($frequencyUnit == 'month') {
-      $recurContStartDate = new DateTime($targetDate);
       return $recurContStartDate->format('j');
     }
 

--- a/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php
+++ b/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php
@@ -88,7 +88,7 @@ class CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator {
    * class will render the date in a way that
    * we do not desire, for example adding one month
    * to 2018-01-31 will result in 2018-03-03 but
-   * we want it to be 2018-02-28 instead.
+   * we want it to be 2018-03-01 instead.
    *
    * This method ensure that adding months
    * to a date get calculated properly.
@@ -100,30 +100,13 @@ class CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator {
    * @return DateTime
    */
   public function getSameDayNextMonth(DateTime $startDate, $numberOfMonthsToAdd = 1) {
-    $startDateDay = (int) $startDate->format('j');
-    $startDateMonth = (int) $startDate->format('n');
-    $startDateYear = (int) $startDate->format('Y');
-
-    $numberOfYearsToAdd = floor(($startDateMonth + $numberOfMonthsToAdd) / 12);
-    if ((($startDateMonth + $numberOfMonthsToAdd) % 12) === 0) {
-      $numberOfYearsToAdd--;
+    $intervalSpec = "P{$numberOfMonthsToAdd}M";
+    if (in_array($startDate->format('j'), [29, 30, 31])) {
+      $startDate->modify('first day of next month');
     }
-    $year = $startDateYear + $numberOfYearsToAdd;
+    $startDate->add(new DateInterval($intervalSpec));
 
-    $month = ($startDateMonth + $numberOfMonthsToAdd) % 12;
-    if ($month === 0) {
-      $month = 12;
-    }
-    $month = sprintf('%02s', $month);
-
-    $numberOfDaysInMonth = (new DateTime("$year-$month-01"))->format('t');
-    $day = $startDateDay;
-    if ($startDateDay > $numberOfDaysInMonth) {
-      $day = $numberOfDaysInMonth;
-    }
-    $day = sprintf('%02s', $day);
-
-    return new DateTime("$year-$month-$day");
+    return $startDate;
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -149,7 +149,11 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
         $params['previous_instalment_date'] = $previousInstalmentDate;
 
         $instalmentDate = new DateTime($previousInstalmentDate);
+        if (in_array($instalmentDate->format('j'), [29, 30, 31])) {
+          $instalmentDate->modify('first day of next month');
+        }
         $instalmentDate->add(new DateInterval($intervalSpec));
+
         $instalmentDate = $instalmentDate->format('Y-m-d');
 
         $dispatchedInstalmentDate = $instalmentDate;

--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -11,7 +11,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
       setMembershipFormEvents();
       initializeMembershipForm();
       hideOfflineAutorenewField();
-      toggleNumOfTermsField();
+      togglePaymentPlanDisabledFields();
     });
 
     /**
@@ -412,17 +412,22 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
     }
 
     /**
-     * Disable the “Number of Terms" if payment tab is selected,
-     * otherwise enable.
+     * Disable the fields that shouldnt be editable for payment plan membership.
+     * 
+     * e.g. “Number of Terms", "End Date"
      */
-    function toggleNumOfTermsField() {
+    function togglePaymentPlanDisabledFields() {
+      var endDatePointerEvents = {true: "none", false: "all"};
+
       $('#num_terms').val(1);
       $('#num_terms').prop("readonly", isPaymentPlanTabActive());
+      $('#end-date-editable').css("pointer-events", endDatePointerEvents[isPaymentPlanTabActive()]);
 
       waitForElement($, 'input[name=contribution_type_toggle]', 
         element => {
           $('#num_terms').val(1);
           $('#num_terms').prop("readonly", isPaymentPlanTabActive());
+          $('#end-date-editable').css("pointer-events", endDatePointerEvents[isPaymentPlanTabActive()]);
         }
       );
     }

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
@@ -54,6 +54,23 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
   }
 
   /**
+   * Tests getting instalment for one month duration unit for rolling membership type
+   */
+  public function testMultiMonthUnitRollingMembershipType() {
+    $interval = rand(1, 12);
+    $rollingOneMonthType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams, [
+      'duration_unit' => 'month',
+      'duration_interval' => $interval,
+      'name' => 'xyz',
+      'period_type' => 'rolling',
+    ]));
+    $membershipType = CRM_Member_BAO_MembershipType::findById($rollingOneMonthType['id']);
+    $schedule = $this->getMembershipSchedule([$membershipType], MembershipInstalmentsSchedule::MONTHLY);
+    //Expected instalment equals membership type interval, e.g. 6 instalments for 6 month duration
+    $this->assertCount($interval, $schedule['instalments']);
+  }
+
+  /**
    * Tests getting instalment for life time duration unit for rolling membership type.
    */
   public function testOneLifeTimeUnitRollingMembershipType() {


### PR DESCRIPTION
## Overview
This PR adds support for multi months of rolling payment plan membership, it is a continuation of the work started in this [PR](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/427).


## Before
_membership can only have one-month interval_

## After
Months can be multiple. e.g. creating a membership with 6 months interval
![mem1](https://user-images.githubusercontent.com/85277674/168767733-f8e2e365-d6b2-4553-8dfb-1a958c554877.gif)

Users are prevented from editing the membership end date when creating a payment plan membership 
![enddate](https://user-images.githubusercontent.com/85277674/168779015-52cf3ef5-76a8-4b7d-a54c-6a089854df74.gif)



## Technical Details
In this PR also we change how `sameDayNextMonth` is calculated, for example, the `sameDayNextMonth` for `2018-01-31` is `2018-02-28`, now the `sameDayNextMonth` for `2018-01-31` is `2018-03-01`. i.e. if the day of the previous month is any of 29/30/31, the`sameDayNextMonth` is the 1st day of the next two months.


