### PR TITLE
MAE-693:  Add support for multi years/month rolling membership

### DIFF
--- a/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
+++ b/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
@@ -52,7 +52,7 @@ trait CRM_MembershipExtras_Helper_InstalmentHelperTrait {
       return 1;
     }
 
-    return CRM_MembershipExtras_Helper_InstalmentSchedule::getInstalmentCountBySchedule($schedule);
+    return CRM_MembershipExtras_Helper_InstalmentSchedule::getInstalmentCountBySchedule($schedule, (int) $membershipType->duration_interval);
   }
 
 }

--- a/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
+++ b/CRM/MembershipExtras/Helper/InstalmentHelperTrait.php
@@ -48,8 +48,12 @@ trait CRM_MembershipExtras_Helper_InstalmentHelperTrait {
     }
 
     $durationUnit = $membershipType->duration_unit;
-    if ($membershipType->period_type == 'rolling' && ($durationUnit == 'month' || $durationUnit == 'lifetime')) {
+    if ($membershipType->period_type == 'rolling' && $durationUnit == 'lifetime') {
       return 1;
+    }
+
+    if ($membershipType->period_type == 'rolling' && $durationUnit == 'month') {
+      return (int) $membershipType->duration_interval;
     }
 
     return CRM_MembershipExtras_Helper_InstalmentSchedule::getInstalmentCountBySchedule($schedule, (int) $membershipType->duration_interval);

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -23,12 +23,16 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
     ])['values'][0]['api.MembershipType.get']['values'][0];
 
     $durationUnit = $membershipType['duration_unit'];
-    if ($membershipType['period_type'] == 'rolling' && ($durationUnit == 'lifetime' || $durationUnit == 'month')) {
+    if ($membershipType['period_type'] == 'rolling' && ($durationUnit == 'lifetime')) {
       $instalmentDetails['instalments_count'] = 1;
+    }
+    elseif ($membershipType['period_type'] == 'rolling' && $durationUnit == 'month') {
+      $instalmentDetails['instalments_count'] = (int) $membershipType['duration_interval'];
     }
     else {
       $instalmentDetails['instalments_count'] = self::getInstalmentCountBySchedule($schedule, (int) $membershipType['duration_interval']);
     }
+
     $instalmentDetails['instalments_frequency'] = self::getFrequencyInterval($schedule);
     $instalmentDetails['instalments_frequency_unit'] = self::getFrequencyUnit($schedule, $instalmentDetails['instalments_frequency']);
 

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -27,7 +27,7 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
       $instalmentDetails['instalments_count'] = 1;
     }
     else {
-      $instalmentDetails['instalments_count'] = self::getInstalmentCountBySchedule($schedule);
+      $instalmentDetails['instalments_count'] = self::getInstalmentCountBySchedule($schedule, (int) $membershipType['duration_interval']);
     }
     $instalmentDetails['instalments_frequency'] = self::getFrequencyInterval($schedule);
     $instalmentDetails['instalments_frequency_unit'] = self::getFrequencyUnit($schedule, $instalmentDetails['instalments_frequency']);
@@ -68,10 +68,12 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
    * Gets Instalment interval number by given schedule
    *
    * @param $schedule
+   * 
+   * @param $interval
    *
    * @return int
    */
-  public static function getInstalmentCountBySchedule($schedule) {
+  public static function getInstalmentCountBySchedule($schedule, $interval) {
     switch ($schedule) {
       case InstalmentsSchedule::MONTHLY:
         $instalmentInterval = InstalmentsSchedule::MONTHLY_INSTALMENT_COUNT;
@@ -85,7 +87,7 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
         $instalmentInterval = InstalmentsSchedule::ANNUAL_INTERVAL_COUNT;
     }
 
-    return $instalmentInterval;
+    return $instalmentInterval * $interval;
   }
 
   /**

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -68,7 +68,7 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
    * Gets Instalment interval number by given schedule
    *
    * @param $schedule
-   * 
+   *
    * @param $interval
    *
    * @return int

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -110,7 +110,7 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
     return FALSE;
   }
 
-  public static function getPaymentPlanSchedule($frequencyUnit, $frequencyInterval, $installmentsCount) {
+  public static function getPaymentPlanSchedule($frequencyUnit, $frequencyInterval) {
     if ($frequencyUnit == 'month' && $frequencyInterval == 1) {
       return InstalmentsSchedule::MONTHLY;
     }

--- a/CRM/MembershipExtras/Helper/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Helper/InstalmentSchedule.php
@@ -107,15 +107,15 @@ class CRM_MembershipExtras_Helper_InstalmentSchedule {
   }
 
   public static function getPaymentPlanSchedule($frequencyUnit, $frequencyInterval, $installmentsCount) {
-    if ($frequencyUnit == 'month' && $frequencyInterval == 1 && $installmentsCount == 12) {
+    if ($frequencyUnit == 'month' && $frequencyInterval == 1) {
       return InstalmentsSchedule::MONTHLY;
     }
 
-    if ($frequencyUnit == 'month' && $frequencyInterval == 3 && $installmentsCount == 4) {
+    if ($frequencyUnit == 'month' && $frequencyInterval == 3) {
       return InstalmentsSchedule::QUARTERLY;
     }
 
-    if ($frequencyUnit == 'year' && $frequencyInterval == 1 && $installmentsCount == 1) {
+    if ($frequencyUnit == 'year' && $frequencyInterval == 1) {
       return InstalmentsSchedule::ANNUAL;
     }
   }

--- a/CRM/MembershipExtras/Service/CycleDayCalculator.php
+++ b/CRM/MembershipExtras/Service/CycleDayCalculator.php
@@ -23,7 +23,8 @@ class CRM_MembershipExtras_Service_CycleDayCalculator {
   public static function calculate($targetDate, $frequencyUnit) {
     if ($frequencyUnit == 'month') {
       $recurContStartDate = new DateTime($targetDate);
-      return $recurContStartDate->format('j');
+      $day = $recurContStartDate->format('j');
+      return min($day, 28);
     }
 
     return 1;

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
@@ -245,8 +245,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
     $receiveDate = $params['receive_date'];
     $paymentPlanSchedule = CRM_MembershipExtras_Helper_InstalmentSchedule::getPaymentPlanSchedule(
       $this->currentRecurContribution['frequency_unit'],
-      $this->currentRecurContribution['frequency_interval'],
-      $this->currentRecurContribution['installments']
+      $this->currentRecurContribution['frequency_interval']
     );
 
     $contributionReceiveDateParams = [

--- a/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
+++ b/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
@@ -84,7 +84,10 @@ class CRM_MembershipExtras_Service_PaymentPlanNextContributionDate {
     else {
       $receiveDateCalculator = new CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator($this->recurContribution);
       $receiveDateCalculator->setStartDate($lastContribution['receive_date']);
-      return $receiveDateCalculator->calculate(2);
+      $nextScheduledDate = $receiveDateCalculator->calculate(2);
+      $nextScheduledDate = new DateTime($nextScheduledDate);
+      $nextScheduledDate->setDate($nextScheduledDate->format('Y'), $nextScheduledDate->format('m'), min($nextScheduledDate->format('d'), 28));
+      return $nextScheduledDate->format('Y-m-d');
     }
   }
 

--- a/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
+++ b/CRM/MembershipExtras/Test/Fabricator/PaymentPlanOrder.php
@@ -129,7 +129,7 @@ class CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder {
       'contribution_status_id' => self::$paymentPlanMembershipOrder->paymentPlanStatus,
       'is_test' => 0,
       'auto_renew' => isset(self::$paymentPlanMembershipOrder->autoRenew) ? self::$paymentPlanMembershipOrder->autoRenew : 1,
-      'cycle_day' => 1,
+      'cycle_day' => CRM_MembershipExtras_Service_CycleDayCalculator::calculate(self::$paymentPlanMembershipOrder->paymentPlanStartDate, $frequencyUnit),
       'payment_processor_id' => self::$paymentPlanMembershipOrder->paymentProcessor,
       'financial_type_id' => self::$paymentPlanMembershipOrder->financialType,
       'payment_instrument_id' => self::$paymentPlanMembershipOrder->paymentMethod,

--- a/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessorTest.php
@@ -212,6 +212,42 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
     $this->assertEquals($expectedNextDate, $nextDate);
   }
 
+  public function testPaymentPlanNextContributionDateDayWillNotExceed28ForRollingMemberships() {
+    $this->simulateMembershipSignupForm('monthly', 'rolling', date('2020-01-31'));
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form, 'creation');
+    $processor->postProcess();
+
+    $recurContributionId = civicrm_api3('Membership', 'getvalue', [
+      'return' => 'contribution_recur_id',
+      'id' => $this->form->_id,
+    ]);
+
+    $nextDate = civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => 'next_sched_contribution_date',
+      'id' => $recurContributionId,
+    ]);
+
+    $this->assertEquals(28, date('d', strtotime((string) $nextDate)));
+  }
+
+  public function testPaymentPlanCycleDayWillNotExceed28ForRollingMemberships() {
+    $this->simulateMembershipSignupForm('monthly', 'rolling', date('2020-01-31'));
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form, 'creation');
+    $processor->postProcess();
+
+    $recurContributionId = civicrm_api3('Membership', 'getvalue', [
+      'return' => 'contribution_recur_id',
+      'id' => $this->form->_id,
+    ]);
+
+    $cycle_day = civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => 'cycle_day',
+      'id' => $recurContributionId,
+    ]);
+
+    $this->assertEquals(28, $cycle_day);
+  }
+
   /**
    * Sets Membership Form
    */

--- a/tests/phpunit/CRM/MembershipExtras/Service/CycleDayCalculatorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/CycleDayCalculatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Service_CycleDayCalculatorTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Service_CycleDayCalculatorTest extends BaseHeadlessTest {
+
+  /**
+   * Tests Cycle day defaults to 1 for non monthly memberships.
+   */
+  public function testCycleDayDefaultsToOneForAnnualMembership() {
+    $nextScheduledDate = '2022-01-01';
+    $nextScheduledDateCycleDay = CRM_MembershipExtras_Service_CycleDayCalculator::calculate($nextScheduledDate, 'year');
+
+    $this->assertEquals(1, $nextScheduledDateCycleDay);
+  }
+
+  /**
+   * Tests Cycle Day is next contribution scheduled date day for monthly memberships.
+   */
+  public function testCycleDayIsNextScheduledDateDayForMonthlySubscription() {
+    $nextScheduledDate = '2022-01-25';
+    $nextScheduledDateCycleDay = CRM_MembershipExtras_Service_CycleDayCalculator::calculate($nextScheduledDate, 'month');
+
+    $this->assertEquals(25, $nextScheduledDateCycleDay);
+  }
+
+  /**
+   * Tests Cycle Day for monthly membership doesn't exceed 28.
+   */
+  public function testCycleDayForMonthlySubscriptionDoesntExceed28() {
+    $nextScheduledDate = '2022-01-31';
+    $nextScheduledDateCycleDay = CRM_MembershipExtras_Service_CycleDayCalculator::calculate($nextScheduledDate, 'month');
+
+    $this->assertEquals(28, $nextScheduledDateCycleDay);
+  }
+
+}

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipEndDateCalculatorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipEndDateCalculatorTest.php
@@ -48,6 +48,20 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculatorTest extends BaseH
         'expected_next_end_date' => '20030531',
         'expected_previous_end_date' => '20010531',
       ],
+      'normal year 0/01 => 12/30' => [
+        'duration_interval' => 6,
+        'duration_unit' => 'month',
+        'start_date' => '2020-01-01',
+        'expected_next_end_date' => '20201230',
+        'expected_previous_end_date' => '20191230',
+      ],
+      'normal year 0/01 => 12/30' => [
+        'duration_interval' => 3,
+        'duration_unit' => 'year',
+        'start_date' => '2020-01-01',
+        'expected_next_end_date' => '20251231',
+        'expected_previous_end_date' => '20191231',
+      ],
       'current date' => [
         'duration_interval' => 12,
         'duration_unit' => 'month',

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
@@ -102,6 +102,23 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
   }
 
   /**
+   * Tests getting instalment for multi month duration unit for rolling membership type
+   */
+  public function testMultiMonthUnitRollingMembershipType() {
+    $interval = rand(2, 12);
+    $rollingOneMonthType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams, [
+      'duration_unit' => 'month',
+      'duration_interval' => $interval,
+      'name' => 'xyz',
+      'period_type' => 'rolling',
+    ]));
+    $membershipType = CRM_Member_BAO_MembershipType::findById($rollingOneMonthType['id']);
+    $schedule = $this->getMembershipSchedule([$membershipType], MembershipInstalmentsSchedule::MONTHLY);
+    //Expected instalment equals membership type interval, e.g. 6 instalments for 6 month duration
+    $this->assertCount($interval, $schedule['instalments']);
+  }
+
+  /**
    * Tests rolling membership type schedulesub sub total, total tax amount and total amount
    */
   public function testRollingMembershipTypeScheduleTotalAmounts() {

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
@@ -68,6 +68,40 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
   }
 
   /**
+   * Tests getting instalment for multi year duration unit for rolling membership type with monthly schedule.
+   */
+  public function testMultiYearUnitRollingMembershipTypeMonthlySchedule() {
+    $interval = rand(1, 3);
+    $rollingOneMonthType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams, [
+      'duration_unit' => 'year',
+      'duration_interval' => $interval,
+      'name' => 'xyz',
+      'period_type' => 'rolling',
+    ]));
+    $membershipType = CRM_Member_BAO_MembershipType::findById($rollingOneMonthType['id']);
+    $schedule = $this->getMembershipSchedule([$membershipType], MembershipInstalmentsSchedule::MONTHLY);
+    //Expected instalment equals membership type interval * schedule, e.g. 12 instalments for 1 year duration
+    $this->assertCount($interval * 12, $schedule['instalments']);
+  }
+
+  /**
+   * Tests getting instalment for multi year duration unit for rolling membership type with monthly schedule.
+   */
+  public function testMultiYearUnitRollingMembershipTypeQuarterlySchedule() {
+    $interval = rand(1, 3);
+    $rollingOneMonthType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams, [
+      'duration_unit' => 'year',
+      'duration_interval' => $interval,
+      'name' => 'xyz',
+      'period_type' => 'rolling',
+    ]));
+    $membershipType = CRM_Member_BAO_MembershipType::findById($rollingOneMonthType['id']);
+    $schedule = $this->getMembershipSchedule([$membershipType], MembershipInstalmentsSchedule::QUARTERLY);
+    //Expected instalment equals membership type interval * schedule, e.g. 4 instalments for 1 year duration
+    $this->assertCount($interval * 4, $schedule['instalments']);
+  }
+
+  /**
    * Tests rolling membership type schedulesub sub total, total tax amount and total amount
    */
   public function testRollingMembershipTypeScheduleTotalAmounts() {


### PR DESCRIPTION
## Overview
In this PR,
- we add support for multi-year rolling membership
- we add support for multi-month rolling membership
- we ensure cycle day doesn't exceed 28
- we ensure the next scheduled contribution date day doesn't exceed 28

## Before
Multi year/month memberships can not be created
<img width="1403" alt="Screenshot 2022-06-07 at 10 01 28" src="https://user-images.githubusercontent.com/85277674/172341047-696ad52a-d9c2-4323-bc0c-5eda22b9aaed.png">

## After
Users can now create X year membership and appropriate instalment count for the selected schedule, for example when X is 3, 36 instalments are created for the monthly schedule, 12 instalments are created for the quarterly schedule and 3 instalments are created for the annual schedule.
![3year](https://user-images.githubusercontent.com/85277674/172334456-73748e71-a0ba-4d06-965e-69b762912bdb.gif)

On renewal, the membership period is extended by the membership duration, and a new recurring contribution is created.
![3yearrenwal](https://user-images.githubusercontent.com/85277674/172334901-9e114f6c-09a4-4640-a7e1-1e70eb4977db.gif)

Users can now create X month membership and appropriate instalment count for the selected schedule, for example when X is 6, 6 instalments are created for the monthly schedule.
![multimonth](https://user-images.githubusercontent.com/85277674/172364060-98bee19b-c327-4992-b5fd-2ac6dfd9e228.gif)

On renewal, the membership period is extended by the membership duration, and a new recurring contribution is created.
![multimonthrenewal](https://user-images.githubusercontent.com/85277674/172370575-56f92f63-442c-4cb6-b637-687481d88d47.gif)


Cycle day and the next scheduled contribution date day doesn't exceed 28 irrespective of the first/last contribution date
<img width="940" alt="Screenshot 2022-06-08 at 12 24 52" src="https://user-images.githubusercontent.com/85277674/172622688-48a8d8a9-4aca-4047-9fc2-96080ae0c341.png">

