### PR TITLE
MAE-739: Validate next_schedule_contribution_date/cycle_day when updating a recurring contribution

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
@@ -33,8 +33,8 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
    */
   private $recurringContribution;
 
-  const INVALID_NEXT_CONTRIB_DATE_MONTH = 'Not all months have more than 28 days. As such monthly or quarterly payment plans must renew on or before the 28th of the month. Please select another date on or before the 28th of the month.';
-  const INVALID_NEXT_CONTRIB_DATE_YEAR = 'Not all years have a 29th of Feb. As such annual payment plans must renew on any other day of the year!';
+  const INVALID_NEXT_CONTRIBUTION_DATE_MONTH = 'Not all months have more than 28 days. As such monthly or quarterly payment plans must renew on or before the 28th of the month. Please select another date on or before the 28th of the month.';
+  const INVALID_NEXT_CONTRIBUTION_DATE_YEAR = 'Not all years have a 29th of Feb. As such annual payment plans must renew on any other day of the year!';
 
   /**
    * CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription constructor.
@@ -59,24 +59,36 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
   }
 
   public function validateCycleDay() {
-    $frequency = $this->recurringContribution['frequency_unit'];
     $cycleDay = $this->fields['cycle_day'];
+    $frequency = $this->recurringContribution['frequency_unit'];
+
     if ($cycleDay > 28 && $frequency === 'month') {
-      $this->errors['cycle_day'] = ts(self::INVALID_NEXT_CONTRIB_DATE_MONTH);
+      $this->errors['cycle_day'] = ts(self::INVALID_NEXT_CONTRIBUTION_DATE_MONTH);
     }
   }
 
   private function validateNextContributionDate() {
     $frequency = $this->recurringContribution['frequency_unit'];
-    $nextContribDate = $this->fields['next_sched_contribution_date'];
-    $nextContribDay = date('j', strtotime($nextContribDate));
-    $nextContibMonth = date('n', strtotime($nextContribDate));
-    if ($nextContribDay > 28 && $frequency === 'month') {
-      $this->errors['next_sched_contribution_date'] = ts(self::INVALID_NEXT_CONTRIB_DATE_MONTH);
-    }
+    $nextContributionDate = $this->fields['next_sched_contribution_date'];
+
+    $this->validateNextContributionDateIsNotLeapYear($nextContributionDate, $frequency);
+    $this->validateNextContributionDateDayIsNotBeyond28($nextContributionDate, $frequency);
+  }
+
+  private function validateNextContributionDateIsNotLeapYear(string $nextContributionDate, string $frequency) {
+    $nextContribDay = date('j', strtotime($nextContributionDate));
+    $nextContibMonth = date('n', strtotime($nextContributionDate));
 
     if ($nextContribDay > 28 && $nextContibMonth == '2' && $frequency === 'year') {
-      $this->errors['next_sched_contribution_date'] = ts(self::INVALID_NEXT_CONTRIB_DATE_YEAR);
+      $this->errors['next_sched_contribution_date'] = ts(self::INVALID_NEXT_CONTRIBUTION_DATE_YEAR);
+    }
+  }
+
+  private function validateNextContributionDateDayIsNotBeyond28(string $nextContributionDate, string $frequency) {
+    $nextContribDay = date('j', strtotime($nextContributionDate));
+
+    if ($nextContribDay > 28 && $frequency === 'month') {
+      $this->errors['next_sched_contribution_date'] = ts(self::INVALID_NEXT_CONTRIBUTION_DATE_MONTH);
     }
   }
 

--- a/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
@@ -54,7 +54,16 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
    * Validates the subscription form submission
    */
   public function validate() {
+    $this->validateCycleDay();
     $this->validateNextContributionDate();
+  }
+
+  public function validateCycleDay() {
+    $frequency = $this->recurringContribution['frequency_unit'];
+    $cycleDay = $this->fields['cycle_day'];
+    if ($cycleDay > 28 && $frequency === 'month') {
+      $this->errors['cycle_day'] = ts(self::INVALID_NEXT_CONTRIB_DATE_MONTH);
+    }
   }
 
   private function validateNextContributionDate() {

--- a/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription
+ *
+ * Validates Membership Type Form
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
+
+  /**
+   * Form object that is being validated.
+   *
+   * @var \CRM_Member_Form_Membership
+   */
+  private $form;
+
+  /**
+   * @var array
+   *   List of the submitted fields and their values passed from the hook.
+   */
+  private $fields;
+
+  /**
+   * @var array
+   *   List of form validation errors passed from the hook.
+   */
+  private $errors;
+
+  /**
+   * Array with the data of the recurring contribution that is being updated.
+   *
+   * @var array
+   */
+  private $recurringContribution;
+
+  const INVALID_NEXT_CONTRIB_DATE_MONTH = 'Not all months have more than 28 days. As such monthly or quarterly payment plans must renew on or before the 28th of the month. Please select another date on or before the 28th of the month.';
+  const INVALID_NEXT_CONTRIB_DATE_YEAR = 'Not all years have a 29th of Feb. As such annual payment plans must renew on any other day of the year!';
+
+  /**
+   * CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription constructor.
+   *
+   * @param \CRM_Contribute_Form_UpdateSubscription $form
+   * @param $fields
+   * @param $errors
+   */
+  public function __construct($form, &$fields, &$errors) {
+    $this->form = $form;
+    $this->fields = &$fields;
+    $this->errors = &$errors;
+    $this->setRecurringContribution();
+  }
+
+  /**
+   * Validates the subscription form submission
+   */
+  public function validate() {
+    $this->validateNextContributionDate();
+  }
+
+  private function validateNextContributionDate() {
+    $frequency = $this->recurringContribution['frequency_unit'];
+    $nextContribDate = $this->fields['next_sched_contribution_date'];
+    $nextContribDay = date('j', strtotime($nextContribDate));
+    $nextContibMonth = date('n', strtotime($nextContribDate));
+    if ($nextContribDay > 28 && $frequency === 'month') {
+      $this->errors['next_sched_contribution_date'] = ts(self::INVALID_NEXT_CONTRIB_DATE_MONTH);
+    }
+
+    if ($nextContribDay > 28 && $nextContibMonth == '2' && $frequency === 'year') {
+      $this->errors['next_sched_contribution_date'] = ts(self::INVALID_NEXT_CONTRIB_DATE_YEAR);
+    }
+  }
+
+  /**
+   * Loads data for recurring contribution identified by 'crid' parameter in
+   * http request.
+   */
+  private function setRecurringContribution() {
+    $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
+    $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
+      'sequential' => 1,
+      'id' => $recurringContributionID,
+    ])['values'][0];
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
@@ -93,11 +93,11 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
   }
 
   /**
-   * Loads data for recurring contribution identified by 'crid' parameter in
-   * http request.
+   * Loads data for the currently edited recurring contribution.
    */
   private function setRecurringContribution() {
-    $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
+    $recurringContributionID = $this->form->getVar('contributionRecurID');
+
     $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
       'sequential' => 1,
       'id' => $recurringContributionID,

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -381,6 +381,12 @@ function membershipextras_civicrm_validateForm($formName, &$fields, &$files, &$f
     $membershipUpdateValidationHook = new CRM_MembershipExtras_Hook_ValidateForm_MembershipUpdate($form, $fields, $errors);
     $membershipUpdateValidationHook->validate();
   }
+
+  $isUpdateSubcriptionForm = $formName === 'CRM_Contribute_Form_UpdateSubscription' && ($formAction & CRM_Core_Action::UPDATE);
+  if ($isUpdateSubcriptionForm) {
+    $subscriptionUpdateValidationHook = new CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription($form, $fields, $errors);
+    $subscriptionUpdateValidationHook->validate();
+  }
 }
 
 /**

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
@@ -33,7 +33,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
   public function testErrorIsThrownWhenNextContribDateDayIsAbove28ForMonthlyMembership() {
     $fields = [];
     $recurringContribution = $this->createRecurContribution();
-    $this->form->set('crid', $recurringContribution['id']);
+    $this->form->setVar('contributionRecurID', $recurringContribution['id']);
     $fields['next_sched_contribution_date'] = '2020-12-31';
     $fields['cycle_day'] = $recurringContribution['cycle_day'];
 
@@ -47,7 +47,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
   public function testErrorIsNotThrownWhenNextContribDateDayIsBelow29ForMonthlyMembership() {
     $fields = [];
     $recurringContribution = $this->createRecurContribution();
-    $this->form->set('crid', $recurringContribution['id']);
+    $this->form->setVar('contributionRecurID', $recurringContribution['id']);
     $fields['next_sched_contribution_date'] = '2020-12-28';
     $fields['cycle_day'] = $recurringContribution['cycle_day'];
 
@@ -60,7 +60,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
   public function testErrorIsThrownWhenNextContribDateIsLeapDateForAnnualMembership() {
     $fields = [];
     $recurringContribution = $this->createRecurContribution(['frequency_unit' => 'year']);
-    $this->form->set('crid', $recurringContribution['id']);
+    $this->form->setVar('contributionRecurID', $recurringContribution['id']);
     $fields['next_sched_contribution_date'] = '2020-02-29';
     $fields['cycle_day'] = $recurringContribution['cycle_day'];
 
@@ -74,7 +74,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
   public function testErrorIsThrownWhenCycleDayIsAbove28ForMonthlyMembership() {
     $fields = [];
     $recurringContribution = $this->createRecurContribution(['frequency_unit' => 'month']);
-    $this->form->set('crid', $recurringContribution['id']);
+    $this->form->setVar('contributionRecurID', $recurringContribution['id']);
     $fields['next_sched_contribution_date'] = $recurringContribution['next_sched_contribution_date'];
     $fields['cycle_day'] = 29;
 

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
@@ -16,11 +16,11 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
    *
    * @var \CRM_Contribute_Form_UpdateSubscription
    */
-  private $form = null;
+  private $form = NULL;
 
   /**
    * Array of errors.
-   * 
+   *
    * @var array
    */
   private $errors;
@@ -64,12 +64,25 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
     $fields['next_sched_contribution_date'] = '2020-02-29';
     $fields['cycle_day'] = $recurringContribution['cycle_day'];
 
-
     $updateSubscriptionValidation = new UpdateSubscription($this->form, $fields, $this->errors);
     $updateSubscriptionValidation->validate();
 
     $this->assertArrayHasKey('next_sched_contribution_date', $this->errors);
     $this->assertEquals($this->errors['next_sched_contribution_date'], UpdateSubscription::INVALID_NEXT_CONTRIB_DATE_YEAR);
+  }
+
+  public function testErrorIsThrownWhenCycleDayIsAbove28ForMonthlyMembership() {
+    $fields = [];
+    $recurringContribution = $this->createRecurContribution(['frequency_unit' => 'month']);
+    $this->form->set('crid', $recurringContribution['id']);
+    $fields['next_sched_contribution_date'] = $recurringContribution['next_sched_contribution_date'];
+    $fields['cycle_day'] = 29;
+
+    $updateSubscriptionValidation = new UpdateSubscription($this->form, $fields, $this->errors);
+    $updateSubscriptionValidation->validate();
+
+    $this->assertArrayHasKey('cycle_day', $this->errors);
+    $this->assertEquals($this->errors['cycle_day'], UpdateSubscription::INVALID_NEXT_CONTRIB_DATE_MONTH);
   }
 
   public function setUpUpdateSubscriptionForm() {
@@ -103,7 +116,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
   }
 
   public function tearDown() {
-    $this->form = null;
+    $this->form = NULL;
     $this->errors = [];
   }
 

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
@@ -41,7 +41,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
     $updateSubscriptionValidation->validate();
 
     $this->assertArrayHasKey('next_sched_contribution_date', $this->errors);
-    $this->assertEquals($this->errors['next_sched_contribution_date'], UpdateSubscription::INVALID_NEXT_CONTRIB_DATE_MONTH);
+    $this->assertEquals($this->errors['next_sched_contribution_date'], UpdateSubscription::INVALID_NEXT_CONTRIBUTION_DATE_MONTH);
   }
 
   public function testErrorIsNotThrownWhenNextContribDateDayIsBelow29ForMonthlyMembership() {
@@ -57,7 +57,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
     $this->assertArrayNotHasKey('next_sched_contribution_date', $this->errors);
   }
 
-  public function testErrorIsThrownWhenNextContribDateDayIsFeb29ForAnnualMembership() {
+  public function testErrorIsThrownWhenNextContribDateIsLeapDateForAnnualMembership() {
     $fields = [];
     $recurringContribution = $this->createRecurContribution(['frequency_unit' => 'year']);
     $this->form->set('crid', $recurringContribution['id']);
@@ -68,7 +68,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
     $updateSubscriptionValidation->validate();
 
     $this->assertArrayHasKey('next_sched_contribution_date', $this->errors);
-    $this->assertEquals($this->errors['next_sched_contribution_date'], UpdateSubscription::INVALID_NEXT_CONTRIB_DATE_YEAR);
+    $this->assertEquals($this->errors['next_sched_contribution_date'], UpdateSubscription::INVALID_NEXT_CONTRIBUTION_DATE_YEAR);
   }
 
   public function testErrorIsThrownWhenCycleDayIsAbove28ForMonthlyMembership() {
@@ -82,7 +82,7 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends Base
     $updateSubscriptionValidation->validate();
 
     $this->assertArrayHasKey('cycle_day', $this->errors);
-    $this->assertEquals($this->errors['cycle_day'], UpdateSubscription::INVALID_NEXT_CONTRIB_DATE_MONTH);
+    $this->assertEquals($this->errors['cycle_day'], UpdateSubscription::INVALID_NEXT_CONTRIBUTION_DATE_MONTH);
   }
 
   public function setUpUpdateSubscriptionForm() {

--- a/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscriptionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription as UpdateSubscription;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+
+/**
+ * Class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscriptionTest extends BaseHeadlessTest {
+
+  /**
+   * Form object that is being validated.
+   *
+   * @var \CRM_Contribute_Form_UpdateSubscription
+   */
+  private $form = null;
+
+  /**
+   * Array of errors.
+   * 
+   * @var array
+   */
+  private $errors;
+
+  public function setUp() {
+    $this->setupUpdateSubscriptionForm();
+    $this->errors = [];
+  }
+
+  public function testErrorIsThrownWhenNextContribDateDayIsAbove28ForMonthlyMembership() {
+    $fields = [];
+    $recurringContribution = $this->createRecurContribution();
+    $this->form->set('crid', $recurringContribution['id']);
+    $fields['next_sched_contribution_date'] = '2020-12-31';
+    $fields['cycle_day'] = $recurringContribution['cycle_day'];
+
+    $updateSubscriptionValidation = new UpdateSubscription($this->form, $fields, $this->errors);
+    $updateSubscriptionValidation->validate();
+
+    $this->assertArrayHasKey('next_sched_contribution_date', $this->errors);
+    $this->assertEquals($this->errors['next_sched_contribution_date'], UpdateSubscription::INVALID_NEXT_CONTRIB_DATE_MONTH);
+  }
+
+  public function testErrorIsNotThrownWhenNextContribDateDayIsBelow29ForMonthlyMembership() {
+    $fields = [];
+    $recurringContribution = $this->createRecurContribution();
+    $this->form->set('crid', $recurringContribution['id']);
+    $fields['next_sched_contribution_date'] = '2020-12-28';
+    $fields['cycle_day'] = $recurringContribution['cycle_day'];
+
+    $updateSubscriptionValidation = new UpdateSubscription($this->form, $fields, $this->errors);
+    $updateSubscriptionValidation->validate();
+
+    $this->assertArrayNotHasKey('next_sched_contribution_date', $this->errors);
+  }
+
+  public function testErrorIsThrownWhenNextContribDateDayIsFeb29ForAnnualMembership() {
+    $fields = [];
+    $recurringContribution = $this->createRecurContribution(['frequency_unit' => 'year']);
+    $this->form->set('crid', $recurringContribution['id']);
+    $fields['next_sched_contribution_date'] = '2020-02-29';
+    $fields['cycle_day'] = $recurringContribution['cycle_day'];
+
+
+    $updateSubscriptionValidation = new UpdateSubscription($this->form, $fields, $this->errors);
+    $updateSubscriptionValidation->validate();
+
+    $this->assertArrayHasKey('next_sched_contribution_date', $this->errors);
+    $this->assertEquals($this->errors['next_sched_contribution_date'], UpdateSubscription::INVALID_NEXT_CONTRIB_DATE_YEAR);
+  }
+
+  public function setUpUpdateSubscriptionForm() {
+    $controller = new CRM_Core_Controller();
+    $this->form = new CRM_Contribute_Form_UpdateSubscription();
+    $this->form->controller = $controller;
+  }
+
+  public function createRecurContribution($params = []) {
+    $contact = ContactFabricator::fabricate();
+    $params = array_merge([
+      'sequential' => 1,
+      'contact_id' => $contact['id'],
+      'amount' => 0,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'auto_renew' => 1,
+      'cycle_day' => 1,
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'EFT',
+      'start_date' => date('Y-m-d'),
+    ], $params);
+
+    $recurringContribution = RecurringContributionFabricator::fabricate($params);
+
+    return $recurringContribution;
+  }
+
+  public function tearDown() {
+    $this->form = null;
+    $this->errors = [];
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds new validation to the edit recurring contribution screen, such that the following scenarios would return an error

- frequency_unit is monthly; changing the next_schedule_contribution date to a day after 28 
- frequency_unit is yearly; changing the next_schedule_contribution date to Feb 29
- frequency_unit is monthly; changing the cycle_day to a day after 28

## Before
Validation does not exist

## After
A validation error is thrown when any of the invalid scenarios happen:

_frequency_unit is monthly; changing the next_schedule_contribution date to a day after 28_ 
![contrib](https://user-images.githubusercontent.com/85277674/173300716-a8ba17b7-ce7f-404a-a0a2-bb5ddaa4154b.gif)

 _frequency_unit is yearly; changing the next_schedule_contribution date to Feb 29_
![contrib_yr](https://user-images.githubusercontent.com/85277674/173301398-dea608a6-9430-41c8-a55b-4ff4af569e2c.gif)

 _frequency_unit is monthly; changing the cycle_day to a day after 28_
![cycleday](https://user-images.githubusercontent.com/85277674/173302154-e74e98cc-af50-43d8-a689-a1891a47b143.gif)

