### PR TITLE
MAE-751: Consolidate logic for calculating membership instalment dates

### DIFF
--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipInstalmentsScheduleTest.php
@@ -633,7 +633,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
   }
 
   /**
-   * Tests exception is thorwn when membership type duration is day
+   * Tests exception is thrown when membership type duration is day
    */
   public function testExceptionIsThrownIfMembershipTypeDurationUnitIsDay() {
     $invalidMembershipType = MembershipTypeFabricator::fabricate(array_merge($this->defaultRollingMembershipTypeParams,
@@ -642,6 +642,66 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsScheduleTest extends Bas
     $membershipType = CRM_Member_BAO_MembershipType::findById($invalidMembershipType['id']);
     $this->expectException(InvalidMembershipTypeInstalment::class);
     $this->getMembershipInstalmentsSchedule([$membershipType], MembershipInstalmentsSchedule::ANNUAL);
+  }
+
+  /**
+   * Tests that monthly instalments date are calculated properly
+   * for membership start_date greater than 28 and months follows a sequential order.
+   */
+  public function testMonthlyRollingInstalmentDatesAreCalculatedProperlyWhenStartDateIsGreaterThan28() {
+    $startDate = new DateTime('2022-01-31');
+    $membershipTypes = $this->mockRollingMembershipTypes();
+    $schedule = $this->getMembershipSchedule(
+      $membershipTypes,
+      MembershipInstalmentsSchedule::MONTHLY,
+      $startDate
+    );
+
+    $expectedInstalmentDates = [
+      '2022-01-31',
+      '2022-02-28',
+      '2022-03-31',
+      '2022-04-30',
+      '2022-05-31',
+      '2022-06-30',
+      '2022-07-31',
+      '2022-08-31',
+      '2022-09-30',
+      '2022-10-31',
+      '2022-11-30',
+      '2022-12-31',
+    ];
+
+    foreach ($schedule['instalments'] as $index => $instalment) {
+      $instalmentDate = $instalment->getInstalmentDate();
+      $this->assertEquals($expectedInstalmentDates[$index], $instalmentDate->format('Y-m-d'));
+    }
+  }
+
+  /**
+   * Tests that quarterly instalments date are calculated properly
+   * for membership start_date greater than 28 and months follows a sequential order.
+   */
+  public function testQuarterlyRollingInstalmentDatesAreCalculatedProperlyWhenStartDateIsGreaterThan28() {
+    $startDate = new DateTime('2022-01-31');
+    $membershipTypes = $this->mockRollingMembershipTypes();
+    $schedule = $this->getMembershipSchedule(
+      $membershipTypes,
+      MembershipInstalmentsSchedule::QUARTERLY,
+      $startDate
+    );
+
+    $expectedInstalmentDates = [
+      '2022-01-31',
+      '2022-04-30',
+      '2022-07-31',
+      '2022-10-31',
+    ];
+
+    foreach ($schedule['instalments'] as $index => $instalment) {
+      $instalmentDate = $instalment->getInstalmentDate();
+      $this->assertEquals($expectedInstalmentDates[$index], $instalmentDate->format('Y-m-d'));
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
The instalment dates listed on the new membership screen can sometimes not match the contribution instalment dates after creation, this difference is noticeable when using a day above 28. In this PR we use the same logic used in calculating contribution dates to calculate the instalment dates for the new membership screen.

## Before
The instalment dates on the new membership screen.
<img width="896" alt="Screenshot 2022-06-15 at 09 04 37" src="https://user-images.githubusercontent.com/85277674/173775623-5c7ae9ea-b175-4cc2-8011-5d404eefa16d.png">

The new membership screen uses the inbuilt PHP DateTime function to add months to date, and this function behaves in some certain way as we've seen in the screen above, `2022-01-29 + 1month =  2022-03-01` and subsequent months use the day from the previous calculation. 

The actual instalment dates after creation.
<img width="933" alt="date" src="https://user-images.githubusercontent.com/85277674/173777581-9892b1eb-0669-4472-b750-8b1741f9dc75.png">

Whereas when creating the contributions, the instalment dates are calculated using the custom function `getSameDayNextMonth` https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/326e69ed0468cb4f2b40ad6adc0b6630257e84d3/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php#L102 to add months to date, this function helps handle the scenario mentioned above such that `2022-01-29 + 1month =  2022-02-28` and subsequent dates makes use of the day from the first calculation. 

## After
New membership screen using the function `getSameDayNextMonth` to calculate instalment dates
<img width="935" alt="Screenshot 2022-06-15 at 09 31 48" src="https://user-images.githubusercontent.com/85277674/173781896-77c631f1-9c5c-4b27-9cc7-1b567f184dc0.png">
<img width="961" alt="Screenshot 2022-06-15 at 09 32 02" src="https://user-images.githubusercontent.com/85277674/173781952-56ee264f-2458-4ff8-88cd-ad6342abb478.png">
<img width="855" alt="Screenshot 2022-06-15 at 09 32 13" src="https://user-images.githubusercontent.com/85277674/173781970-4acc2ec3-e7a1-4a86-8068-8ed5a1919f4d.png">




