### PR TITLE
HCSASPRT-66: Fix Manage Instalments page issues when number of instalments is NULL

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddLineItem.php
@@ -137,7 +137,7 @@ abstract class CRM_MembershipExtras_Form_RecurringContribution_AddLineItem exten
       ],
     ];
 
-    $installments = CRM_Utils_Array::value('installments', $this->recurringContribution, 0);
+    $installments = CRM_Utils_Array::value('installments', $this->recurringContribution, 1);
     if ($installments <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }

--- a/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
@@ -199,7 +199,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
       ],
     ];
 
-    $installments = CRM_Utils_Array::value('installments', $this->recurringContribution, 0);
+    $installments = CRM_Utils_Array::value('installments', $this->recurringContribution, 1);
     if ($installments <= 1) {
       $params['end_date'] = ['IS NULL' => 1];
     }

--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -251,7 +251,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       'start_date' => ['IS NOT NULL' => 1],
     ];
 
-    $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 0);
+    $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 1);
     if ($installments <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }
@@ -354,7 +354,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       'is_removed' => 0,
     ];
 
-    $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 0);
+    $installments = CRM_Utils_Array::value('installments', $this->contribRecur, 1);
     if ($installments <= 1) {
       $conditions['end_date'] = ['IS NULL' => 1];
     }

--- a/CRM/MembershipExtras/Service/PaymentPlanStatusCalculator.php
+++ b/CRM/MembershipExtras/Service/PaymentPlanStatusCalculator.php
@@ -31,7 +31,7 @@ class CRM_MembershipExtras_Service_PaymentPlanStatusCalculator {
       $contributionStatusValueMap[$currentStatus['name']] = $currentStatus['value'];
     }
 
-    $this->contributionStatusValueMap =  $contributionStatusValueMap;
+    $this->contributionStatusValueMap = $contributionStatusValueMap;
   }
 
   private function setRecurContributionDetails() {
@@ -41,7 +41,7 @@ class CRM_MembershipExtras_Service_PaymentPlanStatusCalculator {
       'id' => $this->recurContributionId,
     ])['values'][0];
 
-    $this->installmentsCount = CRM_Utils_Array::value('installments', $recurContribution, 0);
+    $this->installmentsCount = CRM_Utils_Array::value('installments', $recurContribution, 1);
     $this->currentStatusId = $recurContribution['contribution_status_id'];
   }
 
@@ -50,9 +50,6 @@ class CRM_MembershipExtras_Service_PaymentPlanStatusCalculator {
    * plan (recuring contribution) based
    * on its current status and the related
    * contributions statuses.
-   *
-   * @param int $recurContributionId
-   *   DateTime acceptable format
    *
    * @return string
    */
@@ -79,12 +76,12 @@ class CRM_MembershipExtras_Service_PaymentPlanStatusCalculator {
     $allPaid = $paidInstallmentsCount >= $this->installmentsCount;
     $moreThanOneInstallment = $this->installmentsCount > 1;
 
-    switch (true) {
+    switch (TRUE) {
       case $moreThanOneInstallment && $allPaid:
         $status = self::CONTRIBUTION_STATUS_COMPLETED;
         break;
 
-      case $paidInstallmentsCount >= 1 || $partiallyPaidInstallmentsCount >=  1:
+      case $paidInstallmentsCount >= 1 || $partiallyPaidInstallmentsCount >= 1:
         $status = self::CONTRIBUTION_STATUS_INPROGRESS;
         break;
 
@@ -94,4 +91,5 @@ class CRM_MembershipExtras_Service_PaymentPlanStatusCalculator {
 
     return $status;
   }
+
 }


### PR DESCRIPTION
## Overview

"Manage instalments" screen on payment plans with count of instalments = NULL (which we treat as if it = 1, which is annual payment plan) is not loading.

## Before

"Manage instalments"  does not load for payment plans with instalments count = NULL:

<img width="831" alt="image" src="https://user-images.githubusercontent.com/6275540/174910912-9d2810fb-ad57-4007-b562-cfba0092a07d.png">


## After

The manage instalments screen loads fine:

<img width="958" alt="image" src="https://user-images.githubusercontent.com/6275540/174911062-518861ce-83e2-4311-8d2d-5a3aba77e09e.png">


## Technical details

When the recurring contribution number of instalments field is NULL and you open the manage instalments page, 
the following error is thrown:

```
Brick\Math\Exception\NumberFormatException: "The given value "INF" does not represent a valid number."

#0 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/vendor/brick/math/src/BigNumber.php(81): Brick\Math\BigNumber::Brick\Math\{closure}()
#1 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/vendor/brick/money/src/Money.php(192): Brick\Math\BigNumber::of("INF")
#2 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Utils/Money.php(209): Brick\Money\Money::of(INF, Object(Brick\Money\Currency), Object(Brick\Money\Context\CustomContext), 5)
#3 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Utils/Money.php(88): CRM_Utils_Money::formatUSLocaleNumericRounded(INF, 2)
#4 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Core/Smarty/plugins/modifier.crmMoney.php(32): CRM_Utils_Money::format(INF, "GBP")
#5 /var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_GB/%%85/859/859925E2%%NextPeriodTab.tpl.php(46): smarty_modifier_crmMoney(INF)
#6 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/packages/Smarty/Smarty.class.php(1914): include("/var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_G...")
#7 /var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_GB/%%A3/A38/A3845E80%%EditContributionRecurLineItems.tpl.php(51): Smarty->_smarty_include((Array:2))
#8 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/packages/Smarty/Smarty.class.php(1914): include("/var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_G...")
#9 /var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_GB/%%F7/F77/F77C7890%%CMSPrint.tpl.php(64): Smarty->_smarty_include((Array:2))
#10 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/packages/Smarty/Smarty.class.php(1914): include("/var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_G...")
#11 /var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_GB/%%06/069/0693F89E%%drupal.tpl.php(6): Smarty->_smarty_include((Array:2))
#12 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/packages/Smarty/Smarty.class.php(1273): include("/var/www/default/htdocs/httpdocs/sites/default/files/civicrm/templates_c/en_G...")
#13 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Core/Smarty.php(185): Smarty->fetch("CRM/common/drupal.tpl", NULL, NULL, FALSE)
#14 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Core/Page.php(212): CRM_Core_Smarty->fetch("CRM/common/drupal.tpl")
#15 /var/www/default/htdocs/httpdocs/sites/all/civicrm_extensions/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php(240): CRM_Core_Page->run()
#16 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Core/Invoke.php(313): CRM_MembershipExtras_Page_EditContributionRecurLineItems->run((Array:3), NULL)
#17 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Core/Invoke.php(69): CRM_Core_Invoke::runItem((Array:13))
#18 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/CRM/Core/Invoke.php(36): CRM_Core_Invoke::_invoke((Array:3))
#19 /var/www/default/htdocs/httpdocs/sites/all/modules/contrib/civicrm/drupal/civicrm.module(458): CRM_Core_Invoke::invoke((Array:3))
#20 /var/www/default/htdocs/httpdocs/includes/menu.inc(527): civicrm_invoke("recurring-contribution", "edit-lineitems")
#21 /var/www/default/htdocs/httpdocs/index.php(21): menu_execute_active_handler()
#22 {main}
```


It seems that in that page controller we default the instalments count to 0 if its value in the database is NULL, which we later use as a divisor in one of the calculations in that page, which result in dividing by zero, which is infinity and presented in PHP as "INF", which is what we see above in the error log.

Here I am changing the default value for the instalments field to 1 instead of 0 in code, in case its value in the database is NULL,
not just in the affected page but also in other places that are not really affected, just as precaution.
