### PR TITLE
MAE-769: Use membershipextra custom logic for adding date to calculate next instalment dates for an annual recurring contribution

### DIFF
--- a/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php
+++ b/CRM/MembershipExtras/Service/InstalmentReceiveDateCalculator.php
@@ -75,8 +75,7 @@ class CRM_MembershipExtras_Service_InstalmentReceiveDateCalculator {
         break;
 
       case 'year':
-        $interval = "P{$numberOfIntervals}Y";
-        $receiveDate->add(new DateInterval($interval));
+        $receiveDate = $this->getSameDayNextMonth($receiveDate, 12 * $numberOfIntervals);
         break;
     }
 

--- a/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
+++ b/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
@@ -86,7 +86,12 @@ class CRM_MembershipExtras_Service_PaymentPlanNextContributionDate {
       $receiveDateCalculator->setStartDate($lastContribution['receive_date']);
       $nextScheduledDate = $receiveDateCalculator->calculate(2);
       $nextScheduledDate = new DateTime($nextScheduledDate);
-      $nextScheduledDate->setDate($nextScheduledDate->format('Y'), $nextScheduledDate->format('m'), min($nextScheduledDate->format('d'), 28));
+      $frequencyUnit = $this->recurContribution['frequency_unit'];
+
+      if ($frequencyUnit != 'year' || $nextScheduledDate->format('n') == 2) {
+        $nextScheduledDate->setDate($nextScheduledDate->format('Y'), $nextScheduledDate->format('m'), min($nextScheduledDate->format('d'), 28));
+      }
+
       return $nextScheduledDate->format('Y-m-d');
     }
   }

--- a/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/PostProcess/MembershipPaymentPlanProcessorTest.php
@@ -212,7 +212,7 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
     $this->assertEquals($expectedNextDate, $nextDate);
   }
 
-  public function testPaymentPlanNextContributionDateDayWillNotExceed28ForRollingMemberships() {
+  public function testPaymentPlanNextContributionDateDayWillNotExceed28ForMonthlyRollingMemberships() {
     $this->simulateMembershipSignupForm('monthly', 'rolling', date('2020-01-31'));
     $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form, 'creation');
     $processor->postProcess();
@@ -221,6 +221,46 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
       'return' => 'contribution_recur_id',
       'id' => $this->form->_id,
     ]);
+
+    $nextDate = civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => 'next_sched_contribution_date',
+      'id' => $recurContributionId,
+    ]);
+
+    $this->assertEquals(28, date('d', strtotime((string) $nextDate)));
+  }
+
+  public function testPaymentPlanNextContributionDateDayWillUseMembershipEndDateForAnnualRollingMemberships() {
+    $this->simulateMembershipSignupForm('annual', 'rolling', date('2022-01-31'));
+
+    $recurContributionId = civicrm_api3('Membership', 'getvalue', [
+      'return' => 'contribution_recur_id',
+      'id' => $this->form->_id,
+    ]);
+    $this->updateLastContributionReceiveDate($recurContributionId, '2022-01-31');
+
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form, 'creation');
+    $processor->postProcess();
+
+    $nextDate = civicrm_api3('ContributionRecur', 'getvalue', [
+      'return' => 'next_sched_contribution_date',
+      'id' => $recurContributionId,
+    ]);
+
+    $this->assertEquals(31, date('d', strtotime((string) $nextDate)));
+  }
+
+  public function testPaymentPlanNextContributionDateDayIsNotLeapDateForAnnualRollingMemberships() {
+    $this->simulateMembershipSignupForm('annual', 'rolling', date('2020-02-29'));
+
+    $recurContributionId = civicrm_api3('Membership', 'getvalue', [
+      'return' => 'contribution_recur_id',
+      'id' => $this->form->_id,
+    ]);
+    $this->updateLastContributionReceiveDate($recurContributionId, '2020-02-29');
+
+    $processor = new MembershipPaymentPlanProcessor(self::$NEW_MEMBERSHIP_FORM_NAME, $this->form, 'creation');
+    $processor->postProcess();
 
     $nextDate = civicrm_api3('ContributionRecur', 'getvalue', [
       'return' => 'next_sched_contribution_date',
@@ -364,6 +404,20 @@ class CRM_MembershipExtras_Hook_PostProcess_MembershipPaymentPlanProcessorTest e
     return civicrm_api3('MembershipPayment', 'get', [
       'sequential' => 1,
       'membership_id' => $membershipId,
+    ]);
+  }
+
+  private function updateLastContributionReceiveDate($recurContributionId, $date) {
+    $lastContribution = civicrm_api3('Contribution', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $recurContributionId,
+      'options' => ['limit' => 1, 'sort' => 'id DESC'],
+    ]);
+
+    civicrm_api3('Contribution', 'create', [
+      'sequential' => 1,
+      'id' => $lastContribution['id'],
+      'receive_date' => $date,
     ]);
   }
 

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipEndDateCalculatorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipEndDateCalculatorTest.php
@@ -62,6 +62,13 @@ class CRM_MembershipExtras_Service_MembershipEndDateCalculatorTest extends BaseH
         'expected_next_end_date' => '20251231',
         'expected_previous_end_date' => '20191231',
       ],
+      'leap year 02/29 => 02/28' => [
+        'duration_interval' => 2,
+        'duration_unit' => 'year',
+        'start_date' => '2020-02-29',
+        'expected_next_end_date' => '20240228',
+        'expected_previous_end_date' => '20200228',
+      ],
       'current date' => [
         'duration_interval' => 12,
         'duration_unit' => 'month',


### PR DESCRIPTION
## Overview
Before now, the PHP builtin `date->add` method is used to get the next instalment dates for an annual recurring contribution, in this PR we change this and use the custom logic in `getSameDayNextMonth`. This will enable the proper handling of leap dates.

Also in a [previous work](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/432) we prevented the next scheduled contribution date day from exceeding 28, in this PR we limit it such that this will not affect the next scheduled contribution date day of annual recurring contribution whose month is not February


## Before
If the last contribution date is 02/29 - the next scheduled date is 03-01
![MAE-770](https://user-images.githubusercontent.com/85277674/177165133-06ef2d93-d698-465f-8f9b-3049d403d44e.gif)

## After
If the last contribution date is 02/29 - the next scheduled date is 02-28
![aaaasas](https://user-images.githubusercontent.com/85277674/177165920-9bd4c34d-d165-4e25-97ee-03500b472fd6.gif)

## Before
The next scheduled contribution date of annual recurring contribution can't exceed 28 for all months
![aaa](https://user-images.githubusercontent.com/85277674/177163972-efc527d3-e931-4fcc-b7a1-c6f87ebd54a7.gif)

## After
The next scheduled contribution date of annual recurring contribution can exceed 28 so far it is not in the month of February
![aaaasas](https://user-images.githubusercontent.com/85277674/177167870-e252304e-79cb-4277-9bf1-d1fba4e9ec8c.gif)
