### PR TITLE
COMPCRM-58: Return specific field from Membership API

### DIFF
--- a/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
+++ b/CRM/MembershipExtras/Page/EditContributionRecurLineItems.php
@@ -446,6 +446,7 @@ class CRM_MembershipExtras_Page_EditContributionRecurLineItems extends CRM_Core_
       $membership = civicrm_api3('Membership', 'getsingle', [
         'sequential' => 1,
         'id' => $membershipID,
+        'return' => ['start_date', 'end_date', 'id'],
       ]);
       $membership['related_membership_type'] = $this->getMembershipTypeFromMembershipID($membershipID);
       $this->membershipsCache[$membershipID] = $membership;


### PR DESCRIPTION
## Overview
In this PR we return specific fields from the Membership API.

## Before
The `modify instalment` page is broken, and the user cannot perform any action.
![base2](https://user-images.githubusercontent.com/85277674/182548901-bf79d421-2bb3-4479-9cf5-8c5a60530537.gif)

## After
The `modify instalment` page displays as expected, and the user can perform the expected actions.
![base1](https://user-images.githubusercontent.com/85277674/182548582-4beb676d-ef78-4ef4-a226-9a279c3742d9.gif)

## Technical Details
Before now when getting related membership of line items, we return every membership field, and these might include attachment fields also, which can break the page. in this PR we limit the returned membership fields to `'start_date', 'end_date', 'id'`.

`'start_date', 'end_date', 'id'` are the membership fields we recognize are required for now.
