### PR TITLE
BASW-928: Use recurring contribution data to create autorenewal contributions

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -296,10 +296,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
   private function setLastContribution() {
     $contribution = civicrm_api3('Contribution', 'get', [
       'sequential' => 1,
-      'return' => ['currency', 'contribution_source',
-        'contact_id', 'total_amount', 'payment_instrument_id',
-        'is_test', 'tax_amount', 'contribution_recur_id', 'financial_type_id',
-      ],
+      'return' => ['id'],
       'contribution_recur_id' => $this->currentRecurContributionID,
       'options' => ['limit' => 1, 'sort' => 'id DESC'],
     ])['values'][0];
@@ -752,15 +749,15 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
    */
   protected function recordPaymentPlanFirstContribution() {
     $params = [
-      'currency' => $this->lastContribution['currency'],
-      'source' => $this->lastContribution['contribution_source'],
-      'contact_id' => $this->lastContribution['contact_id'],
+      'currency' => $this->currentRecurringContribution['currency'],
+      'source' => 'Offline Autorenewal: ' . date('Y-m-d H:i:s'),
+      'contact_id' => $this->currentRecurringContribution['contact_id'],
       'net_amount' => $this->totalAmount,
       'total_amount' => $this->totalAmount,
       'receive_date' => $this->paymentPlanStartDate,
-      'payment_instrument_id' => $this->lastContribution['payment_instrument_id'],
-      'financial_type_id' => $this->lastContribution['financial_type_id'],
-      'is_test' => $this->lastContribution['is_test'],
+      'payment_instrument_id' => $this->currentRecurringContribution['payment_instrument_id'],
+      'financial_type_id' => $this->currentRecurringContribution['financial_type_id'],
+      'is_test' => $this->currentRecurringContribution['is_test'],
       'contribution_status_id' => $this->contributionPendingStatusValue,
       'is_pay_later' => TRUE,
       'skipLineItem' => 1,

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentPlan.php
@@ -305,6 +305,7 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
       'sequential' => 1,
       'return' => ['contact_id', 'soft_credit_type_id'],
       'contribution_id' => $contribution['id'],
+      'options' => ['limit' => 1],
     ]);
     if (!empty($softContribution['values'][0])) {
       $softContribution = $softContribution['values'][0];
@@ -770,18 +771,10 @@ abstract class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentPlan {
     }
 
     if (!empty($this->lastContribution['soft_credit'])) {
-      $params['soft_credit'] = $this->lastContribution['soft_credit'];
+      $params['soft_credit'][1] = $this->lastContribution['soft_credit'];
     }
 
     $contribution = CRM_Contribute_BAO_Contribution::create($params);
-
-    $contributionSoftParams = CRM_Utils_Array::value('soft_credit', $params);
-    if (!empty($contributionSoftParams)) {
-      $contributionSoftParams['contribution_id'] = $contribution->id;
-      $contributionSoftParams['currency'] = $contribution->currency;
-      $contributionSoftParams['amount'] = $contribution->total_amount;
-      CRM_Contribute_BAO_ContributionSoft::add($contributionSoftParams);
-    }
 
     CRM_MembershipExtras_Service_CustomFieldsCopier::copy(
       $this->lastContribution['id'],

--- a/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsHandler.php
@@ -90,6 +90,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
       'sequential' => 1,
       'return' => ['contact_id', 'soft_credit_type_id'],
       'contribution_id' => $contribution['id'],
+      'options' => ['limit' => 1],
     ]);
     if (!empty($softContribution['values'][0])) {
       $softContribution = $softContribution['values'][0];
@@ -164,14 +165,6 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
 
     $contribution = CRM_Contribute_BAO_Contribution::create($params);
 
-    $contributionSoftParams = CRM_Utils_Array::value('soft_credit', $params);
-    if (!empty($contributionSoftParams)) {
-      $contributionSoftParams['contribution_id'] = $contribution->id;
-      $contributionSoftParams['currency'] = $contribution->currency;
-      $contributionSoftParams['amount'] = $contribution->total_amount;
-      CRM_Contribute_BAO_ContributionSoft::add($contributionSoftParams);
-    }
-
     $membershipPayments = civicrm_api3('MembershipPayment', 'get', [
       'return' => 'membership_id',
       'contribution_id' => $this->lastContribution['id'],
@@ -224,7 +217,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsHandler {
     }
 
     if (!empty($this->lastContribution['soft_credit'])) {
-      $params['soft_credit'] = $this->lastContribution['soft_credit'];
+      $params['soft_credit'][1] = $this->lastContribution['soft_credit'];
     }
 
     return $params;


### PR DESCRIPTION
## Overview

Changing how contributions are created after autorenewal, so they use data from the recurring contribution instead of the previous term last contribution. The specific fields we are now copying from the payment plan instead of the last term contribution are:

- currency
- contact_id
- payment_instrument_id
- financial_type_id
- is_test

The reason behind this, is that sometimes contributions might be changed manually by users, or sometimes a contribution might be paid let's say with "credit card" payment method , where the original payment plan was paid by "direct debit" payment method. Thus the recurring contribution is more accurate place to get such information, instead of using the last contribution which is subject to manual changes.

The only things we still copy from the previous contribution are :
- The soft contribution data
- The custom fields

given that such kind of data doesn't exist on the recurring contribution.


As part of this change, I also changed the "Source" field so it is set to "Offline Autorenewal: <Renewal Time>" instead of copying the old source, given that in cases such as using an importer, it doesn't make sense to keep copying the source over and over, also having the source set to contain "Autorenewal" should help in the future to identify renewal issues in case they happen.

## Before
Last Contribution data are used to create the new contributions after offline autorenewal.


- Here are the recurring contribution financial type and payment instrument: 

![image](https://user-images.githubusercontent.com/6275540/190446777-1994840f-16ed-4a98-a5df-3bfcf1101fd3.png)

- Here  I changed the last contribution financial type and payment instrument: 
![2022-09-15 18_35_14-cacsa csaacs _ cc139](https://user-images.githubusercontent.com/6275540/190446869-e3d98687-3dce-42dc-a689-05ab33a452d6.png)

- Here is one of the contributions that got created after renewal:
![2022-09-15 18_39_48-cacsa csaacs _ cc139](https://user-images.githubusercontent.com/6275540/190447378-b1d5e479-1285-4556-bdc1-e5e56542f31a.png)

we can see that the data from the last contributing got used.

## After
Recurring contribution data are used to create the new contributions after offline autorenewal.

- Here are the recurring contribution financial type and payment instrument: 

![image](https://user-images.githubusercontent.com/6275540/190447986-8e05a0a1-a559-4a93-9d33-d51d89941fb5.png)


- Here  I changed the last contribution financial type and payment instrument: 

![2022-09-15 18_44_42-asasas dsadsa$ _ cc139](https://user-images.githubusercontent.com/6275540/190448395-53f3ef00-6e0f-42e3-a4f7-e6950c03d3f3.png)


- Here is one of the contributions that got created after renewal:

![2022-09-15 18_45_57-asasas dsadsa$ _ cc139](https://user-images.githubusercontent.com/6275540/190448641-c2c9a3cb-a488-4c28-abc0-edff0bb6128b.png)


we can see that we now use the data from the recurring contribution instead, also the "source" field is set to  "Offline Autorenewal: <Renewal Time>" instead of being copied from the previous contribution.


## Update 1

An issue with soft contributions creation and renewal is also discovered, where when you try to create a payment plan with soft contribution, or try to renew a payment plan that already has a soft contribution throw the following error:

```
Sep 20 09:29:27  [error] $Fatal Error Details = Array
(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => exceptionHandler
        )

    [code] => -1
    [message] => DB Error: unknown error
    [mode] => 16
    [debug_info] => INSERT INTO `civicrm_contribution_soft` (`currency` ) VALUES ('GBP' )  [nativecode=1364 ** Field 'contribution_id' doesn't have a default value]
    [type] => DB_Error
    [user_info] => INSERT INTO `civicrm_contribution_soft` (`currency` ) VALUES ('GBP' )  [nativecode=1364 ** Field 'contribution_id' doesn't have a default value]
    [to_string] => [db_error: message="DB Error: unknown error" code=-1 mode=callback callback=CRM_Core_Error::exceptionHandler prefix="" info="INSERT INTO `civicrm_contribution_soft` (`currency` ) VALUES ('GBP' )  [nativecode=1364 ** Field 'contribution_id' doesn't have a default value]"]
)
```

which probably was never caught before because we rarely use Soft Contributions with Payment plans, given it it is something that our clients use and no one raised an issue about it before.

The cause of this error is that CiviCMR expects soft contributions to be in form of "array of arrays" https://github.com/civicrm/civicrm-core/blob/5.39.1/CRM/Contribute/BAO/ContributionSoft.php#L67-L68 given that it is possible to have more than one soft contribution, I fixed this by ensuring that `soft_credit` parameter used in the Contribution API is an array of arrays, but given that in Membership context, you cannot have more than one soft contribution, this array of arrays will only contain one array in it.

I also removed the code that tries to add the Soft Contribution using `CRM_Contribute_BAO_ContributionSoft::add()` method:

```
    $contributionSoftParams = CRM_Utils_Array::value('soft_credit', $params);
    if (!empty($contributionSoftParams)) {
      $contributionSoftParams['contribution_id'] = $contribution->id;
      $contributionSoftParams['currency'] = $contribution->currency;
      $contributionSoftParams['amount'] = $contribution->total_amount;
      CRM_Contribute_BAO_ContributionSoft::add($contributionSoftParams);
    }
```
given that passing `soft_credit` paramter to the Contribution API is enough to create the needed soft contributions.