### PR TITLE
MAE-887: Update testing workflow to PHP 8 container and fix failing tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.39.1 --cms-ver 7.78 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.39.1
+          version: 5.51.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
@@ -36,8 +36,8 @@ class CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate implements CRM
    * @param CRM_Core_Page $page
    */
   private function setMembershipTypeColourStyle($page) {
-    $inactiveMembers = $page->get_template_vars('inActiveMembers');
-    $activeMembers = $page->get_template_vars('activeMembers');
+    $inactiveMembers = $page->get_template_vars('inActiveMembers') ?? [];
+    $activeMembers = $page->get_template_vars('activeMembers') ?? [];
     $allMemberships = array_merge($inactiveMembers, $activeMembers);
     $css = '';
     $membershipTypeColourSettings = Civi::settings()->get(MembershipTypeSettings::COLOUR_SETTINGS_KEY);

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
@@ -29,12 +29,6 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest 
    */
   private $membership;
 
-  public function setUp() {
-    //We mocked membership ID as the membership ID is always when
-    //Contribution pre_process hook is called.
-    MembershipPaymentPlanProcessor::$membership_id = $this->membership['id'];;
-  }
-
   /**
    * Tests pro rated price set contribution line item on calucation by month for fixed period membership type.
    *
@@ -156,11 +150,12 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest 
     $contact = ContactFabricator::fabricate();
     $membershipType = $this->mockMembershipType($membershipPeriodType, $membershipTypeDuration, $membershipTypeSetting);
     $this->membership = $this->mockMembership($contact['id'], $membershipType['id'], date('Y-m-d'));
+    MembershipPaymentPlanProcessor::$membership_id = $this->membership['id'];
     $contribution = $this->mockContribution($this->membership, $membershipType);
 
     if (is_null($priceSet)) {
       $this->priceSet = $this->mockPriceSet();
-      $priceField = $this->mockPriceField($this->priceSet['id'], 'price field for price set ' . $priceSet['id']);
+      $priceField = $this->mockPriceField($this->priceSet['id'], 'price field for price set ' . $this->priceSet['id']);
     }
     else {
       $priceField = $this->mockPriceField($priceSet['id']);


### PR DESCRIPTION
## Overview

As part of our plan to move to PHP 8.0, we are updating the unit-tests container to use the PHP 8 version of it. With this PHP update, we are also updating Drupal to version 7.79 and CiviCRM to version 5.51.3.

Doing that resulted in many failing tests, large part of them were fixed after applying this patch to our CiviCRM core:
https://github.com/compucorp/civicrm-core/pull/91

The other issues are fixed in this commit: 
https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/443/commits/04c625b11ee8de30f52fda352647662e9e6c96cf

which was caused by `MembershipPaymentPlanProcessor/LineItemTest.php` test trying to access non existent array elements (it used to throw a notice in PHP 7.4, but a warning in PHP8+, which what caused the tests to fail).


## Other fixed issues

While looking around on my local PHP 8 site, I  found that the membership creation form does not load, and the following error is thrown:

```
php_2      | Sep 27 09:37:18 php ccphp83_localhost:3977-drupal: 1664267838|172.30.0.1|http://ccphp83.localhost:3977|php|http://ccphp83.localhost:3977/civicrm/contact/view/membership?reset=1&action=add&cid=4&context=membership&snippet=json|http://ccphp83.localhost:3977/civicrm/contact/view?reset=1&cid=4&selectedChild=member|1||TypeError: array_merge(): Argument #1 must be of type array, null given in array_merge() (line 41 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php).
```
which seems to happen because both `inActiveMembers` and `activeMembers` template variables might equal NULL, but in PHP8 you can no longer do an array_merge on NULL values and a fatal error is throw as the one we see above, I fixed it by making the default value for these variables set to empty array `[]` if their values are NULL.

