### PR TITLE
CIVIIB-11: Allow only one instance of auto-renewal job to run

### DIFF
--- a/api/v3/OfflineAutoRenewalJob.php
+++ b/api/v3/OfflineAutoRenewalJob.php
@@ -7,10 +7,23 @@
  * @return array
  */
 function civicrm_api3_offline_auto_renewal_job_run($params) {
-  $offlineAutoRenewalJob = new CRM_MembershipExtras_Job_OfflineAutoRenewal();
+  $lock = Civi::lockManager()->acquire('worker.membershipextras.offlineautorenewal');
+  if (!$lock->isAcquired()) {
+    return civicrm_api3_create_error('Could not acquire lock, another Offline Autorenewal process is running');
+  }
+
+  try {
+    $offlineAutoRenewalJob = new CRM_MembershipExtras_Job_OfflineAutoRenewal();
+    $result = $offlineAutoRenewalJob->run();
+    $lock->release();
+  }
+  catch (Exception $error) {
+    $lock->release();
+    throw $error;
+  }
 
   return civicrm_api3_create_success(
-    $offlineAutoRenewalJob->run(),
+    $result,
     $params
   );
 }


### PR DESCRIPTION
## Overview

Here we only allow once instance of the autorenewal job to run at any given time, given the renewal might happen more than one time for the same membership if the autorenewal happen to run multiple times simultaneously.

## Before
Multiple instances of the autorenewal job could run at the same time, which might cause the same membership to be renewed multiple times.

## After
Only once instance of the autorenewal job can run at any given time:

![22222](https://user-images.githubusercontent.com/6275540/196920958-3caa288f-a87e-429f-88f0-99e75cd545a6.gif)

An error saying:

```
Could not acquire lock, another Offline Autorenewal process is running
```

would show in the job logs for any other instance tries to run while there is a one t hat is already running.

## Technical Details

I've used CiviCRM lock manager `Civi::lockManager()` to acquire a lock on the first instance that runs, and that lock is only released when job is done running. 
