### PR TITLE
CIWEMB-100: Add page to list payment schemes

### DIFF
--- a/CRM/MembershipExtras/BAO/PaymentScheme.php
+++ b/CRM/MembershipExtras/BAO/PaymentScheme.php
@@ -4,7 +4,7 @@ use CRM_MembershipExtras_ExtensionUtil as E;
 class CRM_MembershipExtras_BAO_PaymentScheme extends CRM_MembershipExtras_DAO_PaymentScheme {
 
   /**
-   * Create a new PaymentScheme based on array-data
+   * Creates a new PaymentScheme based on array-data.
    *
    * @param array $params key-value pairs
    *
@@ -22,6 +22,23 @@ class CRM_MembershipExtras_BAO_PaymentScheme extends CRM_MembershipExtras_DAO_Pa
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
+  }
+
+  /**
+   * Gets all Payment schemes order by ID in descending order.
+   *
+   * @return array
+   */
+  public static function getAll() {
+    $bao = new self();
+    $bao->orderBy('id DESC');
+    $bao->find();
+    $schemes = [];
+    while ($bao->fetch()) {
+      $schemes[] = $bao->toArray();
+    }
+
+    return $schemes;
   }
 
 }

--- a/CRM/MembershipExtras/Page/PaymentScheme.php
+++ b/CRM/MembershipExtras/Page/PaymentScheme.php
@@ -1,0 +1,15 @@
+<?php
+use CRM_MembershipExtras_ExtensionUtil as E;
+
+class CRM_MembershipExtras_Page_PaymentScheme extends CRM_Core_Page {
+
+  public $useLivePageJS = TRUE;
+
+  public function run() {
+    CRM_Utils_System::setTitle(E::ts('Payment Schemes'));
+    $schemes = CRM_MembershipExtras_BAO_PaymentScheme::getAll();
+    $this->assign('rows', $schemes);
+    parent::run();
+  }
+
+}

--- a/templates/CRM/MembershipExtras/Page/PaymentScheme.tpl
+++ b/templates/CRM/MembershipExtras/Page/PaymentScheme.tpl
@@ -1,0 +1,49 @@
+<div class="crm-content-block crm-block">
+    {if $rows}
+      <div class="action-link">
+          {crmButton p="civicrm/member/admin/payment-scheme" q='action=add&reset=1' class="new-option" icon="plus-circle"}{ts}Add Payment Scheme{/ts}{/crmButton}
+          {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
+      </div>
+      {strip}
+        <table cellpadding="0" cellspacing="0" border="0"  class="selector row-highlight">
+          <tr class="columnheader">
+            <th></th>
+            <th>{ts}Name{/ts}</th>
+            <th>{ts}Admin Title{/ts}</th>
+            <th>{ts}Public Title{/ts}</th>
+            <th>{ts}Admin Description{/ts}</th>
+            <th>{ts}Public Description{/ts}</th>
+            <th>{ts}Permission{/ts}</th>
+            <th>{ts}Enabled?{/ts}</th>
+            <th></th>
+          </tr>
+            {foreach from=$rows item=row}
+              <tr id="scheme-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}{if NOT $row.enabled} disabled{/if}">
+                <td></td>
+                <td class="crm-admin-member-payment-scheme-name">{$row.name}</td>
+                <td class="crm-admin-member-payment-scheme-admin-title">{$row.admin_title}</td>
+                <td class="crm-admin-member-payment-scheme-public-title">{$row.public_title}</td>
+                <td class="crm-admin-member-payment-scheme-admin-description">{$row.admin_description}</td>
+                <td class="crm-admin-member-payment-scheme-public-description">{$row.public_description}</td>
+                <td class="crm-admin-member-payment-scheme-permission">{$row.permission}</td>
+                <td class="crm-admin-member-payment-scheme-permission-enabled" id="row_{$row.id}_status">{if $row.enabled eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
+                <td>
+                  <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=update&reset=1"}" class="action-item crm-hover-button" title="{ts}View and Edit Payment Scheme{/ts}">{ts}Edit{/ts}</a>
+                  <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=delete&reset=1"}" class="action-item crm-hover-button small-popup" title="Delete Paymet Scheme">Delete</a>
+                </td>
+              </tr>
+            {/foreach}
+        </table>
+      {/strip}
+
+    {else}
+      <div class="messages status no-popup">
+        <img src="{$config->resourceBase}i/Inform.gif" alt="{ts}status{/ts}"/>{ts}No payment schemes found.{/ts}
+      </div>
+      <div class="action-link">
+          {crmButton p="civicrm/member/admin/payment-scheme" q='action=add&reset=1' class="new-option" icon="plus-circle"}{ts}Add Payment Scheme{/ts}{/crmButton}
+          {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
+      </div>
+   {/if}
+
+</div>

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -4,11 +4,13 @@ use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
 abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
-  HeadlessInterface, TransactionalInterface {
+    HeadlessInterface,
+    TransactionalInterface {
 
   public function setUpHeadless() {
     return \Civi\Test::headless()
       ->installMe(__DIR__)
       ->apply();
   }
+
 }

--- a/tests/phpunit/CRM/MembershipExtras/BAO/PaymentSchemeTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/BAO/PaymentSchemeTest.php
@@ -26,4 +26,25 @@ class CRM_MembershipExtras_BAO_PaymentSchemeTest extends BaseHeadlessTest {
     $this->assertEquals('Test scheme', $scheme->name);
   }
 
+  public function testGetAll() {
+    $param = [
+      'admin_title' => 'Admin title',
+      'admin_description' => 'Admin description',
+      'public_title' => 'Public value',
+      'public_description' => 'Public description',
+      'permission' => 'public',
+      'enabled' => TRUE,
+      'parameters' => '{"name":"John", "age":30, "car":null}',
+    ];
+
+    for ($i = 0; $i < 5; $i++) {
+      $param['name'] = random_bytes(5);
+      CRM_MembershipExtras_BAO_PaymentScheme::create($param);
+    }
+
+    $schemes = CRM_MembershipExtras_BAO_PaymentScheme::getAll();
+    $this->assertEquals(5, count($schemes));
+    $this->assertEqusls(5, $schemes[0]);
+  }
+
 }

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -72,4 +72,10 @@
     <title>Payment Scheme</title>
     <access_arguments>administer MembershipExtras</access_arguments>
   </item>
+  <item>
+    <path>civicrm/member/admin/payment-schemes</path>
+    <page_callback>CRM_MembershipExtras_Page_PaymentScheme</page_callback>
+    <title>Payments Schemes</title>
+    <access_arguments>administer MembershipExtras</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview

This PR adds a page that display list of payment scheme.  The payment scheme will display by ID in descending order.  

The list page also supports CiviCRM pop-up form when adding or editing the payment scheme. 

## Before

The page does not exist. 

## After
[screencast-dev.localhost_8020-2023.02.10-14_07_10.webm](https://user-images.githubusercontent.com/208713/218135067-c3357bb0-88d5-491f-89a1-7dc2cd075b5c.webm)

