### PR TITLE
CIWEMEB-100: Add menu payment scheme menu

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -93,6 +93,16 @@ function membershipextras_civicrm_navigationMenu(&$menu) {
     'separator' => 2,
   ];
   _membershipextras_civix_insert_navigation_menu($menu, 'Administer/CiviMember', $automatedMembershipUpgradeRulesMenuItem);
+
+  $paymentSchemeMenuItem = [
+    'name' => 'membership_payment_scheme',
+    'label' => ts('Payment Schemes'),
+    'url' => 'civicrm/member/admin/payment-schemes?reset=1',
+    'permission' => 'administer CiviCRM,administer MembershipExtras',
+    'operator' => 'OR',
+    'separator' => NULL,
+  ];
+  _membershipextras_civix_insert_navigation_menu($menu, 'Administer/CiviContribute', $paymentSchemeMenuItem);
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR adds menu to list paymet schemes to CiviCRM admin page

## Before

The menu does not exist

## After

Menu added under Administrator -> CiviContribute 

[screencast-dev.localhost_8020-2023.02.22-14_06_43.webm](https://user-images.githubusercontent.com/208713/220644659-9296f4e3-c076-407b-9b7e-ced1ca680ce5.webm)


