### PR TITLE
CIWEMB-135: Add payment processor field to payment scheme form

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentScheme.php
+++ b/CRM/MembershipExtras/Form/PaymentScheme.php
@@ -46,6 +46,7 @@ class CRM_MembershipExtras_Form_PaymentScheme extends CRM_Core_Form {
       TRUE
     );
     $this->add('checkbox', 'enabled', E::ts('Enabled'), NULL, FALSE);
+    $this->addPaymentProcessorField();
     $this->add('textarea', 'parameters', E::ts('Parameters'), NULL, TRUE);
 
     $this->addButtons([
@@ -123,6 +124,33 @@ class CRM_MembershipExtras_Form_PaymentScheme extends CRM_Core_Form {
       }
     }
     return $elementNames;
+  }
+
+  private function addPaymentProcessorField() {
+    $gocardlessProcessorType = civicrm_api3('PaymentProcessorType', 'get', [
+      'return' => ["id"],
+      'name' => "GoCardless",
+    ]);
+
+    if ($gocardlessProcessorType['count'] != 0) {
+      $gocardlessPaymentProcessors = civicrm_api3('PaymentProcessor', 'get', [
+        'sequential' => 1,
+        'is_active' => 1,
+        'is_test' => 0,
+        'payment_processor_type_id' => $gocardlessProcessorType['id'],
+      ]);
+    }
+
+    $paymentProcessors = [];
+    if (!empty($gocardlessPaymentProcessors['values'])) {
+      foreach ($gocardlessPaymentProcessors['values'] as $gocardlessPaymentProcessors) {
+        $paymentProcessors[$gocardlessPaymentProcessors['id']] = $gocardlessPaymentProcessors['name'];
+      }
+    }
+    $select = ['' => ts('- select -')] + $paymentProcessors;
+
+    $this->add('select', 'payment_processor', E::ts('Payment Processor'), $select, TRUE);
+
   }
 
 }


### PR DESCRIPTION
## Overview
Add payment processor dropdown menu field where it shows only the payment processor whose type is `GoCardless` to payment scheme form

## Before
![Screenshot 2023-02-27 174208](https://user-images.githubusercontent.com/115652455/221598432-c5ee7883-4473-44ae-a31a-e284557fe461.jpg)


## After
![Screenshot 2023-02-27 190521](https://user-images.githubusercontent.com/115652455/221615937-741c3dc3-cb75-42c5-a002-b2d2bcd1f5b8.jpg)


