### PR TITLE
CIWEMB-213: Add field to link recur contribution with payment scheme

### DIFF
--- a/CRM/MembershipExtras/Setup/Manage/CustomGroup/PaymentPlanExtraAttributes.php
+++ b/CRM/MembershipExtras/Setup/Manage/CustomGroup/PaymentPlanExtraAttributes.php
@@ -21,6 +21,7 @@ class CRM_MembershipExtras_Setup_Manage_CustomGroup_PaymentPlanExtraAttributes e
   public function remove() {
     $customFields = [
       'is_active',
+      'payment_scheme_id',
     ];
     foreach ($customFields as $customFieldName) {
       civicrm_api3('CustomField', 'get', [

--- a/CRM/MembershipExtras/Upgrader/Steps/Step0011.php
+++ b/CRM/MembershipExtras/Upgrader/Steps/Step0011.php
@@ -1,0 +1,35 @@
+<?php
+
+class CRM_MembershipExtras_Upgrader_Steps_Step0011 {
+
+  /**
+   * Adds payment_scheme_id field to
+   * payment_plan_extra_attributes custom group.
+   *
+   * @return void
+   */
+  public function apply() {
+    $ppExtraAttributesCustomGroup = civicrm_api3('CustomGroup', 'get', [
+      'extends' => 'ContributionRecur',
+      'name' => 'payment_plan_extra_attributes',
+    ]);
+
+    if (!$ppExtraAttributesCustomGroup['count']) {
+      return;
+    }
+
+    civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => $ppExtraAttributesCustomGroup['id'],
+      'name' => 'payment_scheme_id',
+      'label' => 'Payment Scheme',
+      'data_type' => 'Int',
+      'html_type' => 'Text',
+      'required' => 0,
+      'is_active' => 1,
+      'is_searchable' => 1,
+      'column_name' => 'payment_scheme_id',
+      'is_view' => 1,
+    ]);
+  }
+
+}

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -62,5 +62,21 @@
             <column_name>is_active</column_name>
             <custom_group_name>payment_plan_extra_attributes</custom_group_name>
         </CustomField>
+        <CustomField>
+          <name>payment_scheme_id</name>
+          <label>Payment Scheme</label>
+          <data_type>Int</data_type>
+          <html_type>Text</html_type>
+          <is_required>0</is_required>
+          <is_searchable>1</is_searchable>
+          <is_search_range>0</is_search_range>
+          <is_active>1</is_active>
+          <is_view>1</is_view>
+          <text_length>64</text_length>
+          <note_columns>60</note_columns>
+          <note_rows>4</note_rows>
+          <column_name>payment_scheme_id</column_name>
+          <custom_group_name>payment_plan_extra_attributes</custom_group_name>
+        </CustomField>
     </CustomFields>
 </CustomData>


### PR DESCRIPTION
## Overview
Adding `payment_scheme_id` custom field to "Payment Plan extra attributes" custom group, so we can use it to link a recurring contribution to a payment scheme.

## Technical Details

The initial plan was to create new entity with the following:

- 3 fields (id, contribution_recur_id, payment_scheme_id) 
- With API v3 and API v4 support to be able to do all the CRUD operations on this entity.

But I found that we already have a custom group called "Payment Plan extra attributes"  on the payment plan, so I found that it is easier and probably better to just add new field to it instead of creating new entity.

Also in general having API v3 support is not that important, and that we can just use API v4, which allows us to update or retrieve the value of this field using its name (unlike V3 that requires the custom field id, which results in more complicated queries), thus saving us from creating new API:

![2023-03-17 19_45_23-CiviCRM APIv4 (ContributionRecur__update) _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/226019047-dc8a2335-c4c7-4fa4-88fc-40935b9cebe1.png)
