### PR TITLE
CIWEMB-249: Add setting to allow configuring supported payment processors

### DIFF
--- a/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
+++ b/CRM/MembershipExtras/Service/ManualPaymentProcessors.php
@@ -42,27 +42,4 @@ class CRM_MembershipExtras_Service_ManualPaymentProcessors {
     return $manualPaymentProcessorsList;
   }
 
-  /**
-   * Builds an array mapping manual payment processor id's to processor name.
-   *
-   * @return array
-   */
-  public static function getIDNameMap() {
-    $offlineRecPaymentProcessors = civicrm_api3('PaymentProcessor', 'get', [
-      'sequential' => 1,
-      'class_name' => 'Payment_Manual',
-      'options' => ['limit' => 0],
-    ]);
-
-    $recPaymentProcessors = [];
-    if (!empty($offlineRecPaymentProcessors['values'])) {
-      foreach ($offlineRecPaymentProcessors['values'] as $paymentProcessor) {
-        $testOrLive = $paymentProcessor['is_test'] ? 'Test - ': 'Live - ';
-        $recPaymentProcessors[$paymentProcessor['id']] = $testOrLive . $paymentProcessor['name'];
-      }
-    }
-
-    return $recPaymentProcessors;
-  }
-
 }

--- a/CRM/MembershipExtras/Setup/Configure/SetDefaultSupportedPaymentProcessor.php
+++ b/CRM/MembershipExtras/Setup/Configure/SetDefaultSupportedPaymentProcessor.php
@@ -1,0 +1,32 @@
+<?php
+
+use CRM_MembershipExtras_Setup_Configure_ConfigurerInterface as ConfigurerInterface;
+
+/**
+ * Sets the 'Offline Recurring Contribution' payment
+ * processor as supported payment processor.
+ */
+class CRM_MembershipExtras_Setup_Configure_SetDefaultSupportedPaymentProcessor implements ConfigurerInterface {
+
+  public function apply() {
+    try {
+      $paymentProcessors = \Civi\Api4\PaymentProcessor::get()
+        ->addSelect('id')
+        ->addWhere('name', '=', 'Offline Recurring Contribution')
+        ->addWhere('is_test', 'IN', [FALSE, TRUE])
+        ->execute()
+        ->getArrayCopy();
+      if (empty($paymentProcessors)) {
+        return;
+      }
+
+      $paymentProcessorIds = array_column($paymentProcessors, 'id');
+      civicrm_api3('setting', 'create', [
+        'membershipextras_paymentplan_supported_payment_processors' => $paymentProcessorIds,
+      ]);
+    }
+    catch (Exception $exception) {
+    }
+  }
+
+}

--- a/CRM/MembershipExtras/Upgrader.php
+++ b/CRM/MembershipExtras/Upgrader.php
@@ -23,6 +23,7 @@ class CRM_MembershipExtras_Upgrader extends CRM_MembershipExtras_Upgrader_Base {
     // steps that configure existing entities or alter settings.
     $configurationSteps = [
       new CRM_MembershipExtras_Setup_Configure_SetManualPaymentProcessorAsDefaultProcessor(),
+      new CRM_MembershipExtras_Setup_Configure_SetDefaultSupportedPaymentProcessor(),
       new CRM_MembershipExtras_Setup_Configure_DisableContributionCancelActionsExtension(),
     ];
     foreach ($configurationSteps as $step) {

--- a/CRM/MembershipExtras/Upgrader/Steps/Step0012.php
+++ b/CRM/MembershipExtras/Upgrader/Steps/Step0012.php
@@ -1,0 +1,18 @@
+<?php
+
+class CRM_MembershipExtras_Upgrader_Steps_Step0012 {
+
+  /**
+   *
+   * @return void
+   */
+  public function apply() {
+    $this->SetDefaultSupportedPaymentProcessor();
+  }
+
+  private function SetDefaultSupportedPaymentProcessor() {
+    $configureSupportedProcessor = new CRM_MembershipExtras_Setup_Configure_SetDefaultSupportedPaymentProcessor();
+    $configureSupportedProcessor->apply();
+  }
+
+}

--- a/info.xml
+++ b/info.xml
@@ -20,14 +20,16 @@
   </comments>
   <civix>
     <namespace>CRM/MembershipExtras</namespace>
+    <format>22.05.2</format>
   </civix>
   <classloader>
-    <psr4 prefix="Civi\" path="Civi" />
+    <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <urls>
     <url desc="Documentation">https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/master/readme.md</url>
   </urls>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
   </mixins>
 </extension>

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -15,6 +15,27 @@ return [
     'default' => FALSE,
     'is_required' => FALSE,
   ],
+  'membershipextras_paymentplan_supported_payment_processors' => [
+    'name' => 'membershipextras_paymentplan_supported_payment_processors',
+    'group_name' => 'MembershipExtras: Payment Plan',
+    'group' => 'membershipextras_paymentplan',
+    'type' => 'Integer',
+    'quick_form_type' => 'Element',
+    'add' => '4.7',
+    'pseudoconstant' => [
+      'name' => 'paymentProcessor',
+    ],
+    'title' => 'Supported Payment Processors',
+    'html_type' => 'select',
+    'is_required' => FALSE,
+    'extra_attributes' => [
+      'class' => 'crm-select2',
+      'multiple' => 'multiple',
+      'placeholder' => ts('- select -'),
+    ],
+    'description' => '',
+    'help_text' => 'Select the payment processors that can be used with payment plans',
+  ],
   'membershipextras_paymentplan_default_processor' => [
     'name' => 'membershipextras_paymentplan_default_processor',
     'group_name' => 'MembershipExtras: Payment Plan',

--- a/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
+++ b/templates/CRM/MembershipExtras/Form/PaymentPlanSettings.hlp
@@ -1,6 +1,11 @@
 {htxt id="membershipextras_paymentplan_default_processor-title"}
 {ts}Offline payment processor for back office{/ts}
 {/htxt}
+
+{htxt id="membershipextras_paymentplan_supported_payment_processors"}
+{ts}Select the payment processors that can be used with payment plans.{/ts}
+{/htxt}
+
 {htxt id="membershipextras_paymentplan_default_processor"}
 {ts}Select the payment processor that should be used when creating payment plans
   via CiviCRM admin interface such as new/ renew membership.{/ts}
@@ -26,7 +31,7 @@
 {ts}Custom groups to be excluded when auto-renew{/ts}
 {/htxt}
 {htxt id="membershipextras_customgroups_to_exclude_for_autorenew"}
-{ts}Information in selected custom groups will not be copied over to any new installments 
+{ts}Information in selected custom groups will not be copied over to any new installments
  of an existing payment plan when it auto-renews.{/ts}
 {/htxt}
 
@@ -34,6 +39,6 @@
 {ts}Update start date on renewal{/ts}
 {/htxt}
 {htxt id="membershipextras_paymentplan_update_start_date_renewal"}
-{ts}If the field is selected, on membership auto-renewed, 
+{ts}If the field is selected, on membership auto-renewed,
 the start date of the membership period is set as the end date of the last period + 1 day, so the start date increases each period{/ts}
 {/htxt}


### PR DESCRIPTION
## Overview

Membershipextras only supports payment processors that implement the `Payment_Manual` class, but given we now want it to work with GoCardless as well, and in the future we will probably add Stripe support too, this approach has to change. Here we we  create new setting under  `/civicrm/admin/payment_plan_settings` called "Supported Payment Processors", that stores the payment processors that Membershipextras support.

There is another ticket to change Membershipextras codebase to use this new setting, so the work to do that is not part of this PR.

## Before

Membershipextras extension only work with Payment Processors that:

- Have their `class_name` field = `Payment_Manual`
- Or for Payment Plans with empty payment_processor_id field (which are considered "Pay Later").



## After

Nothing change regarding how Membershipextras work yet, only new setting is added under "Payment Plan settings" page,  called "Supported Payment Processors" , which stores all the payment processors that Membershipextras supports:

![2023-04-06 18_07_44-Payment Plan Settings _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/230432456-9f9c0ef4-2f1f-439d-aef8-3ed77aab24eb.png)

An installer and an upgrader are added as well to add "Offline Recurring Contribution" Payment processor (that is defined by Membershipextras)to the this new setting.

![2023-04-06 18_08_12-Payment Plan Settings _ compuclientv2ssp](https://user-images.githubusercontent.com/6275540/230432693-ab0e8165-b58c-4cd5-ad7d-de86c46c7986.png)

And any extension that wants to opt in to get Membershipextras support, can just add similar installer and upgrader to do so.

In future PR, this new setting will be used instead of what is mentioned in the "Before" section to determine if the payment processor is supported by Membershipextras or not.


## Other notes

-  I also updated "Offline payment processor for back office" setting field, so it now shows all the avaiable payment procssors in the system, instead of only the ones that have their `class_name` field = `Payment_Manual`.
- I also added the settings mixin to the info file, because without it the setting page will just be empty, the new Civix versions relies on the mixin to load the settings defined in the settings folder.