### PR TITLE
CIWEMB-214: Create API to generate the payment plan schedule based on payment scheme

### DIFF
--- a/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGenerator.php
+++ b/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGenerator.php
@@ -1,0 +1,163 @@
+<?php
+
+class CRM_MembershipExtras_Service_PaymentScheme_PaymentPlanScheduleGenerator {
+
+  private $contributionRecurId;
+
+  private $scheduleGenerationRawData;
+
+  public function __construct($contributionRecurId) {
+    $this->contributionRecurId = $contributionRecurId;
+  }
+
+  /**
+   * Generates a payment schedule for payment
+   * scheme recurring contributions.
+   *
+   * @return array
+   *   With the following values:
+   *   'name' => In "'PP' + contact id + recurring contribution id" format.
+   *   'currency' => the currency of the payment schedule, same as the recurring contribution currency.
+   *   'total_amount' => the same of all instalment amounts.
+   *   'instalments' => an array of array,where each sub-array contains 'charge_date'
+   *     and 'amount', the 'amount' is coming from the recurring contribution amount, where
+   *     the 'charge_date' is calculated based on "base_time, time_to_add" format. The
+   *    "base_time" can be:
+   *      A- a token in case it is surrounded by {},  for now we will only support 1 token which is {next_period_start_date}
+   *         ,which is the max end date among all the memberships that are part of the payment plan + 1 day.
+   *      B- Or anything that DateTime constructor accepts.
+   *    And "time_to_add" is any string that DateTime::modify() accepts, which will be added
+   *     to or subtracted from the "base_time"
+   * @throws CRM_Extension_Exception
+   */
+  public function generateSchedule() {
+    $this->scheduleGenerationRawData = $this->getScheduleGenerationRawData();
+    if (empty($this->scheduleGenerationRawData)) {
+      return [];
+    }
+
+    $instalmentsSchedule = $this->generateInstalmentsSchedule();
+    $totalAmount = $this->calculateTotalAmount($instalmentsSchedule);
+
+    $outputParams = [
+      'name' => 'PP' . '-' . $this->scheduleGenerationRawData['contact_id'] . '-' . $this->scheduleGenerationRawData['contribution_recur_id'],
+      'currency' => $this->scheduleGenerationRawData['currency'],
+      'instalments' => $instalmentsSchedule,
+      'total_amount' => $totalAmount,
+    ];
+
+    return $outputParams;
+  }
+
+  /**
+   * Gets all the data needed to generate
+   * the payment schedule.
+   *
+   * @return array
+   */
+  private function getScheduleGenerationRawData() {
+    $query = '
+      SELECT
+      cr.id as contribution_recur_id, cr.contact_id, cr.currency, cr.amount as instalment_amount, ps.parameters as payment_scheme_parameters
+      FROM civicrm_contribution_recur cr
+      INNER JOIN civicrm_value_payment_plan_extra_attributes ppea ON cr.id = ppea.entity_id
+      INNER JOIN membershipextras_payment_scheme ps ON ppea.payment_scheme_id = ps.id
+      WHERE cr.id = %1
+      LIMIT 1
+    ';
+    $result = CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->contributionRecurId, 'Integer'],
+    ]);
+
+    if (!$result->fetch()) {
+      throw new CRM_Extension_Exception('The recurring contribution used does not exists, or is not linked to a payment scheme.');
+    }
+
+    $result = $result->toArray();
+
+    $result['max_membership_end_date'] = $this->getMaxMembershipEndDate();
+
+    return $result;
+  }
+
+  /**
+   * Gets the max end date of all memberships that
+   * are part of the payment plan, and adds one day to it
+   * which is the time of next membership renewal start
+   * date.
+   *
+   * @return mixed|null
+   */
+  private function getMaxMembershipEndDate() {
+    $query = '
+      SELECT
+      max(m.end_date) as max_membership_end_date
+      FROM civicrm_contribution_recur cr
+      INNER JOIN civicrm_contribution c ON cr.id = c.contribution_recur_id
+      INNER JOIN civicrm_membership_payment cm ON c.id = cm.contribution_id
+      INNER JOIN civicrm_membership m ON cm.membership_id = m.id
+      WHERE cr.id = %1
+      LIMIT 1
+    ';
+    $result = CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->contributionRecurId, 'Integer'],
+    ]);
+
+    if (!$result->fetch()) {
+      return NULL;
+    }
+
+    $result = $result->toArray();
+    return $result['max_membership_end_date'];
+  }
+
+  /**
+   * Generates the 'instalments' part of
+   * instalments schedule.
+   *
+   * @return array|NULL
+   */
+  private function generateInstalmentsSchedule() {
+    $paymentSchemeParameters = $this->scheduleGenerationRawData['payment_scheme_parameters'];
+    $decodedPaymentSchemeParameters = json_decode($paymentSchemeParameters, TRUE);
+    if (empty($decodedPaymentSchemeParameters)) {
+      return NULL;
+    }
+
+    $result = [];
+    $instalmentsConfigs = $decodedPaymentSchemeParameters['instalments'];
+    foreach ($instalmentsConfigs as $instalmentConfigs) {
+      $instalmentChargeDateConfig = explode(',', $instalmentConfigs['charge_date']);
+      $baseTime = $instalmentChargeDateConfig[0];
+      $timeToAdd = $instalmentChargeDateConfig[1] ?? '+0';
+      $result[] = [
+        'charge_date' => $this->calculateInstalmentChargeDate($baseTime, $timeToAdd),
+        'amount' => $this->scheduleGenerationRawData['instalment_amount'],
+      ];
+    }
+
+    return $result;
+  }
+
+  private function calculateInstalmentChargeDate($baseTime = 'now', $timeToAdd = '') {
+    if (stripos($baseTime, '{next_period_start_date}') !== FALSE) {
+      $membershipEndDate = $this->scheduleGenerationRawData['max_membership_end_date'];
+      $baseChargeDate = new DateTime($membershipEndDate);
+      $baseChargeDate->modify('+1 day');
+      $baseChargeDate = $baseChargeDate->format('Y-m-d');
+    }
+    else {
+      $baseChargeDate = $baseTime;
+    }
+
+    $chargeDate = new DateTime($baseChargeDate);
+    $chargeDate->modify($timeToAdd);
+    return $chargeDate->format('Y-m-d');
+  }
+
+  private function calculateTotalAmount($instalmentsSchedule) {
+    $instalmentAmounts = array_column($instalmentsSchedule, 'amount');
+    return array_sum($instalmentAmounts);
+  }
+
+}

--- a/Civi/Api4/Action/PaymentScheme/GetPaymentSchemeSchedule.php
+++ b/Civi/Api4/Action/PaymentScheme/GetPaymentSchemeSchedule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Civi\Api4\Action\PaymentScheme;
+
+use Civi\Api4\Generic\Result;
+use CRM_MembershipExtras_Service_PaymentScheme_PaymentPlanScheduleGenerator as PaymentPlanScheduleGenerator;
+
+/**
+ *
+ * @see \Civi\Api4\Generic\AbstractAction
+ *
+ * @package Civi\Api4\Action\PaymentScheme
+ */
+class GetPaymentSchemeSchedule extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * @var int
+   * @required
+   */
+  protected $contributionRecurId;
+
+  /**
+   * @inheritDoc
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  public function _run(Result $result) {
+    $paymentPlanScheduleGenerator = new PaymentPlanScheduleGenerator($this->contributionRecurId);
+    $result[] = $paymentPlanScheduleGenerator->generateSchedule();
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @return array
+   */
+  public static function fields() {
+    return [
+      ['name' => 'contributionRecurId', 'data_type' => 'Integer'],
+    ];
+  }
+
+}

--- a/tests/phpunit/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGeneratorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGeneratorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use CRM_MembershipExtras_Service_PaymentScheme_PaymentPlanScheduleGenerator as PaymentPlanScheduleGenerator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Entity_PaymentPlanMembershipOrder as PaymentPlanMembershipOrder;
+use CRM_MembershipExtras_Test_Fabricator_PaymentPlanOrder as PaymentPlanOrderFabricator;
+
+/**
+ * Class CRM_MembershipExtras_Service_PaymentPlanScheduleGeneratorTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Service_PaymentPlanScheduleGeneratorTest extends BaseHeadlessTest {
+
+  private $testRollingMembershipType;
+
+  private $testRollingMembershipTypePriceFieldValue;
+
+  private $paymentScheme;
+
+  private $paymentPlanOrder;
+
+  public function setUp() {
+    $this->createTestRollingMembershipType();
+    $this->createPaymentPlanOrder();
+    $this->createPaymentSchemeAndLinkToPaymentPlanOrder();
+  }
+
+  private function createTestRollingMembershipType() {
+    $this->testRollingMembershipType = MembershipTypeFabricator::fabricate(
+      [
+        'name' => 'Test Rolling Membership',
+        'period_type' => 'rolling',
+        'minimum_fee' => 120,
+        'duration_interval' => 1,
+        'duration_unit' => 'year',
+      ]);
+
+    $this->testRollingMembershipTypePriceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $this->testRollingMembershipType['id'],
+      'options' => ['limit' => 1],
+    ])['values'][0];
+  }
+
+  private function createPaymentPlanOrder() {
+    $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d');
+    $paymentPlanMembershipOrder->membershipEndDate = date('Y-m-d', strtotime('+1 year'));
+    $paymentPlanMembershipOrder->paymentPlanFrequency = 'Yearly';
+    $paymentPlanMembershipOrder->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $this->testRollingMembershipTypePriceFieldValue['price_field_id'],
+      'price_field_value_id' => $this->testRollingMembershipTypePriceFieldValue['id'],
+      'label' => $this->testRollingMembershipType['name'],
+      'qty' => 1,
+      'unit_price' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'line_total' => $this->testRollingMembershipTypePriceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+    ];
+    $this->paymentPlanOrder = PaymentPlanOrderFabricator::fabricate($paymentPlanMembershipOrder);
+  }
+
+  private function createPaymentSchemeAndLinkToPaymentPlanOrder() {
+    $params = [
+      'name' => 'Test scheme',
+      'admin_title' => 'Admin title',
+      'admin_description' => 'Admin description',
+      'public_title' => 'Public value',
+      'public_description' => 'Public description',
+      'permission' => 'public',
+      'enabled' => TRUE,
+      'parameters' => '{"instalments_count": 2,"instalments": [{"charge_date": "{next_period_start_date}, + 1 month"},{"charge_date": "{next_period_start_date}, + 2 months"}]}',
+      'payment_processor' => 1,
+    ];
+    $this->paymentScheme = CRM_MembershipExtras_BAO_PaymentScheme::create($params);
+
+    \Civi\Api4\ContributionRecur::update()
+      ->addValue('id', $this->paymentPlanOrder['id'])
+      ->addValue('payment_plan_extra_attributes.payment_scheme_id', $this->paymentScheme->id)
+      ->execute();
+  }
+
+  public function testUsingInvalidRecurringContributionIdThrowsAnError() {
+    $this->expectException(CRM_Extension_Exception::class);
+
+    $paymentPlanScheduleGenerator = new PaymentPlanScheduleGenerator(100000000000);
+    $paymentPlanScheduleGenerator->generateSchedule();
+  }
+
+  public function testUsingRecurringContributionWithNoLinkedPaymentSchemeThrowsAnError() {
+    $this->expectException(CRM_Extension_Exception::class);
+
+    $results = \Civi\Api4\ContributionRecur::create()
+      ->addValue('contact_id', 1)
+      ->addValue('amount', 100)
+      ->addValue('is_test', FALSE)
+      ->addValue('auto_renew', TRUE)
+      ->execute()
+      ->getArrayCopy();
+
+    $paymentPlanScheduleGenerator = new PaymentPlanScheduleGenerator($results[0]['id']);
+    $paymentPlanScheduleGenerator->generateSchedule();
+  }
+
+  public function testGenerateScheduleReturnsCorrectScheduleFormat() {
+    $paymentPlanScheduleGenerator = new PaymentPlanScheduleGenerator($this->paymentPlanOrder['id']);
+    $paymentPlanSchedule = $paymentPlanScheduleGenerator->generateSchedule();
+
+    $this->assertArrayHasKey('name', $paymentPlanSchedule);
+    $this->assertArrayHasKey('currency', $paymentPlanSchedule);
+    $this->assertArrayHasKey('instalments', $paymentPlanSchedule);
+    $this->assertArrayHasKey('total_amount', $paymentPlanSchedule);
+    $this->assertTrue(is_array($paymentPlanSchedule['instalments']));
+    $this->assertTrue(is_array($paymentPlanSchedule['instalments'][0]));
+  }
+
+  public function testTotalAmountIsTheSumOfAllInstalmentAmounts() {
+    $paymentPlanScheduleGenerator = new PaymentPlanScheduleGenerator($this->paymentPlanOrder['id']);
+    $paymentPlanSchedule = $paymentPlanScheduleGenerator->generateSchedule();
+
+    $this->assertEquals(240, $paymentPlanSchedule['total_amount']);
+  }
+
+  /**
+   * @dataProvider providerTest
+   */
+  public function testInstalmentsScheduleGeneratedCorrectlyFromPaymentSchemeParameters($expectedInstalmentsSchedule, $newSchemeParams) {
+    $params = [
+      'id' => $this->paymentScheme->id,
+      'parameters' => $newSchemeParams,
+    ];
+    $this->paymentScheme = CRM_MembershipExtras_BAO_PaymentScheme::create($params);
+
+    $paymentPlanScheduleGenerator = new PaymentPlanScheduleGenerator($this->paymentPlanOrder['id']);
+    $paymentPlanSchedule = $paymentPlanScheduleGenerator->generateSchedule();
+
+    $this->assertEquals($expectedInstalmentsSchedule, $paymentPlanSchedule['instalments']);
+  }
+
+  public function providerTest() {
+    return [
+      [
+        // with membership token
+        [['charge_date' => date('Y-m-d', strtotime('+1 year +1 day +1 month')), 'amount' => 120], ['charge_date' => date('Y-m-d', strtotime('+1 year +1 day +2 month')), 'amount' => 120]],
+        '{"instalments_count": 2,"instalments": [{"charge_date": "{next_period_start_date}, + 1 month"},{"charge_date": "{next_period_start_date}, + 2 months"}]}',
+      ],
+      [
+        // with hardcoded date
+        [['charge_date' => date('Y-m-d', strtotime('2021-01-01 +1 month')), 'amount' => 120], ['charge_date' => date('Y-m-d', strtotime('2021-01-01 +6 month')), 'amount' => 120]],
+        '{"instalments_count": 2,"instalments": [{"charge_date": "2021-01-01, + 1 month"},{"charge_date": "2021-01-01, + 6 months"}]}',
+      ],
+      [
+        // with relative date and no added time
+        [['charge_date' => date('Y-m-d', strtotime('10 March')), 'amount' => 120], ['charge_date' => date('Y-m-d', strtotime('13 June')), 'amount' => 120]],
+        '{"instalments_count": 2,"instalments": [{"charge_date": "10 March"},{"charge_date": "13 June"}]}',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Overview

Creating new API v4 action `PaymentScheme`.`GetPaymentSchemeSchedule`, that generates the instalments schedule for a recurring contribution (payment plan) that is linked to a payment scheme, using the payment scheme instalments configurations.

This API will be used by payment processor extensions like GoCardless and Stripe to help creating `Payment Schedule` on such payment processors.

## Before

~

## After

- New API  v4 action `PaymentScheme`.`GetPaymentSchemeSchedule` is now avaiable.
- That takes `contributionRecurId` as an input.
- And expect such recurring contribution to have a payment scheme to be linked to it (it throws an error if no payment scheme is linked to the input recurring contribution), where the payment scheme parameters field is expected to be configured by the admin in the following JSON format:

```
{
	"instalments_count": 12,
	"instalments": [
	  {"charge_date": "base_time, time_to_add"},
	  {"charge_date": "base_time, time_to_add"},
	  //..rest of instalments
	]
}
```


where the `charge_date` has two variables separated by a comma, these two variables are:

1- `base_time`: Which can be either:

A- a token in case it is surrounded by {},  for now we only support 1  token which is `{next_period_start_date`} , which is the max membership end date among all the payment plan memberships + 1 day.
B- Or a specific hardcoded date (such as `2022-05-11`).
C- Or a relative date that is accepted by PHP DateTime constructor, see [PHP: Supported Date and Time Formats - Manual](https://www.php.net/manual/en/datetime.formats.php). (such as: `10 January`, which will be translated to 10 Of Januaryof the current year`).


2- `time_to_add`: Which can anything that is accepted by DateTime::modify() function, see [PHP: Supported Date and Time Formats - Manual](https://www.php.net/manual/en/datetime.formats.php). (such as '+2 months).

The `time_to_add` variable as well as comma can be both ignored if there is no extra time to be added.

Example:

```
{
	"instalments_count": 12,
	"instalments": [
	  {"charge_date": "{next_period_start_date}, + 7 days"},
	  {"charge_date": "{next_period_start_date}, + 1 month"},
          {"charge_date": "2022-01-11, + 1 month"},
          {"charge_date": "15 March"},
	  //..rest of instalments
	]
}
```

- And then API will return will generate an instalments schedule based on the recurring contribution data, as well as the linked payment scheme configuration, the format of the response looks as the following:


```
{
    "name" => "PP-contact_id-recur_contribution_id", // e.g PP-115-20
    "currency" => "The recurring contribution currency", // e.g "GBP"
    "total_amount" => "the sum of all instalments amounts in the instalments list below", // e.g "120"
	"instalments" => {
	  {
	    "charge_date" => "2019-08-20", // which is calculated for each instalment according to the format mentioned above, and based on the linked payment scheme configuration.
	    "amount" => "10", // the total amount divided by number of instalments,  which is taken from the recurring contribution amount field directly
	  },
          {
	    "charge_date" => "2019-09-03",
	    "amount" => "10",
	  },
	  //..rest of instalments
	}
}
```



