### PR TITLE
CIWEMB-260: Prevent membership creation form multi submission

### DIFF
--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -12,6 +12,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
       initializeMembershipForm();
       hideOfflineAutorenewField();
       toggleNumOfTermsField();
+      preventMultiFormSubmission();
     });
 
     /**
@@ -57,7 +58,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
     function hideOfflineAutorenewField() {
       const autoRenewSelector = '.custom-group-offline_autorenew_option';
 
-      waitForElement($, '#customData', 
+      waitForElement($, '#customData',
         element => isPaymentPlanTabActive()
           ? $(autoRenewSelector).show()
           : $(autoRenewSelector).hide()
@@ -419,7 +420,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
       $('#num_terms').val(1);
       $('#num_terms').prop("readonly", isPaymentPlanTabActive());
 
-      waitForElement($, 'input[name=contribution_type_toggle]', 
+      waitForElement($, 'input[name=contribution_type_toggle]',
         element => {
           $('#num_terms').val(1);
           $('#num_terms').prop("readonly", isPaymentPlanTabActive());
@@ -429,10 +430,10 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
 
     /**
      * Triggers callback when element attribute changes.
-     * 
-     * @param {object} $ 
-     * @param {string} elementPath 
-     * @param {object} callBack 
+     *
+     * @param {object} $
+     * @param {string} elementPath
+     * @param {object} callBack
      */
     function waitForElement($, elementPath, callBack) {
       (new MutationObserver(function(mutations) {
@@ -440,7 +441,21 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
       })).observe(document.querySelector(elementPath), {
         attributes: true
       });
-    };
+    }
+
+    /**
+     * Prevents submitting the membership form multiple times.
+     *
+     * The two selectors used are for handling both
+     * opening the membership form a modal or in
+     * a new tab, given the submit buttons markup are
+     * different in each case.
+     */
+    function preventMultiFormSubmission() {
+      $('form').submit(function() {
+        $(".ui-dialog-buttonset button, .crm-submit-buttons button").prop('disabled',true);
+      });
+    }
   });
 
 }


### PR DESCRIPTION
## Before

The same instance of the membership creation form can be submitted multiple times if the user clicks on the submit button more than once, which results in creating multiple memberships and contributions.:

![dsasdasadsad](https://user-images.githubusercontent.com/6275540/235211353-b658da3d-0990-4c69-bc4d-85514dffc6d7.gif)

here you can see how the "Save" button is still available during the form submission:

![2023-04-28 18_12_54-dsasdasadsad gif ‎- Photos](https://user-images.githubusercontent.com/6275540/235211519-6bbaab28-b266-4bfc-8f53-3617c9c90af9.png)




## After

The same instance of the membership creation form can be submitted only once, which is achieved by disabling the form buttons after the user clicks on "Save":

![32323232](https://user-images.githubusercontent.com/6275540/235210703-321255c6-4dd2-4913-b6aa-368202983f71.gif)

here you can see how the "Save" button and the form buttons in general are now disabled during the form submission:

![2023-04-28 18_09_33-32323232 gif ‎- Photos](https://user-images.githubusercontent.com/6275540/235210666-6be349e1-0e92-4945-acd3-4d414b67a353.png)


## Technical Details


I am using two differenet selectors for the form buttons which are:

`.ui-dialog-buttonset button`
and
`.crm-submit-buttons button`

the first is the selector that get used when opening the membership creation form through the a modal, when the 2nd is when it is opened in new tab or from "Memberships >> New Membership", given the form buttons markup is different in each case.