### PR TITLE
CIWEMB-222: Only process hooks on membership payment

### DIFF
--- a/CRM/MembershipExtras/Helper/RecurringContributionHelper.php
+++ b/CRM/MembershipExtras/Helper/RecurringContributionHelper.php
@@ -1,0 +1,21 @@
+<?php
+
+class CRM_MembershipExtras_Helper_RecurringContributionHelper {
+
+  /**
+   * Checks if recurring contribution links to any membership.
+   */
+  public static function isRecurringContributionLinkToMembership($recurringContributionID) {
+    $membershipCount = \Civi\Api4\Membership::get()
+      ->selectRowCount()
+      ->addWhere('contribution_recur_id', '=', $recurringContributionID)
+      ->execute();
+
+    if ($membershipCount->rowCount == 0) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
@@ -38,6 +38,10 @@ class CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate implements CRM
   private function setMembershipTypeColourStyle($page) {
     $inactiveMembers = $page->get_template_vars('inActiveMembers');
     $activeMembers = $page->get_template_vars('activeMembers');
+    if (!$inactiveMembers || !$activeMembers) {
+      return;
+    }
+
     $allMemberships = array_merge($inactiveMembers, $activeMembers);
     $css = '';
     $membershipTypeColourSettings = Civi::settings()->get(MembershipTypeSettings::COLOUR_SETTINGS_KEY);

--- a/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Post/ContributionRecur.php
@@ -1,5 +1,6 @@
 <?php
 use CRM_MembershipExtras_Service_SupportedPaymentProcessors as SupportedPaymentProcessors;
+use CRM_MembershipExtras_Helper_RecurringContributionHelper as RecurringContributionHelper;
 
 /**
  * Implements post-process hooks on ContributionRecur entity.
@@ -27,9 +28,15 @@ class CRM_MembershipExtras_Hook_Post_ContributionRecur {
    */
   public function postProcess() {
     $isSupportedPaymentPlan = SupportedPaymentProcessors::isSupportedPaymentProcessor($this->contributionRecurBAO->payment_processor_id);
-    if ($isSupportedPaymentPlan) {
-      $this->updateLineItemEndDates();
+    if (!$isSupportedPaymentPlan) {
+      return;
     }
+
+    if (!RecurringContributionHelper::isRecurringContributionLinkToMembership($this->contributionRecurBAO->id)) {
+      return;
+    }
+
+    $this->updateLineItemEndDates();
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
+++ b/CRM/MembershipExtras/Hook/Post/EntityFinancialTrxn.php
@@ -2,6 +2,7 @@
 
 use CRM_MembershipExtras_Service_SupportedPaymentProcessors as SupportedPaymentProcessors;
 use CRM_MembershipExtras_Service_PaymentPlanStatusCalculator as PaymentPlanStatusCalculator;
+use CRM_MembershipExtras_Helper_RecurringContributionHelper as RecurringContributionHelper;
 
 class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
 
@@ -38,8 +39,16 @@ class CRM_MembershipExtras_Hook_Post_EntityFinancialTrxn {
     }
 
     $this->setRecurContribution();
+    if (empty($this->recurContribution)) {
+      return;
+    }
+
     $isSupportedPaymentPlanTransaction = SupportedPaymentProcessors::isSupportedPaymentProcessor($this->recurContribution['payment_processor_id']);
-    if (empty($this->recurContribution) || !$isSupportedPaymentPlanTransaction) {
+    if (!$isSupportedPaymentPlanTransaction) {
+      return;
+    }
+
+    if (!RecurringContributionHelper::isRecurringContributionLinkToMembership($this->recurContribution['id'])) {
       return;
     }
 

--- a/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
+++ b/CRM/MembershipExtras/Hook/Pre/ContributionRecur.php
@@ -2,6 +2,7 @@
 
 use CRM_MembershipExtras_Service_SupportedPaymentProcessors as SupportedPaymentProcessors;
 use CRM_MembershipExtras_Service_PaymentPlanStatusCalculator as PaymentPlanStatusCalculator;
+use CRM_MembershipExtras_Helper_RecurringContributionHelper as RecurringContributionHelper;
 
 /**
  * Implements pre hook on ContributionRecur entity.
@@ -66,18 +67,18 @@ class CRM_MembershipExtras_Hook_Pre_ContributionRecur {
    * contribution.
    */
   public function preProcess() {
-    if ($this->operation == 'create') {
+    $isPaymentPlanPayment = CRM_MembershipExtras_Helper_InstalmentSchedule::isPaymentPlanPayment();
+    if ($this->operation == 'create' && $isPaymentPlanPayment) {
       $this->calculateCycleDay();
     }
 
     $paymentProcessorID = CRM_Utils_Array::value('payment_processor_id', $this->recurringContribution, 0);
     $isSupportedPaymentPlan = SupportedPaymentProcessors::isSupportedPaymentProcessor($paymentProcessorID);
-
     if ($isSupportedPaymentPlan) {
       $this->preventUpdatingNextScheduledContributionDate();
     }
 
-    if ($this->operation == 'edit' && $isSupportedPaymentPlan) {
+    if ($this->operation == 'edit' && $isSupportedPaymentPlan && RecurringContributionHelper::isRecurringContributionLinkToMembership($this->recurringContribution['id'])) {
       $this->rectifyPaymentPlanStatus();
     }
   }


### PR DESCRIPTION
## Overview

Since this https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/462, Membership Extras allows other Payment Processor to support Membership Extras via hook. 

Some payment processors like GoCardless support recurring contribution (donation subscription) that do not require membership functionality. 

This PR adds additional check if the recurring contribution links to any membership, in addition to check if processor is supported Membership Extras before executing hooks. 

## Before

Pre and post hooks always run on ContributionRecur and EntityFinancialTrxn objects, so contribution status was not recorded correctly. 

## After

Pre and post hooks for ContributionRecur and EntityFinancialTrxn objects, only run if the recurring contribution links to a membership.

