### PR TITLE
CIWEMB-264: Allow adding membership line item when there are no pending instalments left in the payment plan

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
@@ -1,0 +1,297 @@
+<?php
+
+class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembershipLineItem extends CRM_Core_Form {
+
+  const PAYMENT_TYPE_NO_PAYMENT = 1;
+
+  const PAYMENT_TYPE_ONE_OFF_PAYMENT = 2;
+
+  private $recurringContribution;
+
+  private $membershipType;
+
+  private $lineItemParams;
+
+  private $submittedValues;
+
+  private $prorataDaysCount;
+
+  private $membershipDurationCalculator;
+
+  /**
+   * @inheritdoc
+   */
+  public function preProcess() {
+    $recurringContributionID = CRM_Utils_Request::retrieve('contribution_recur_id', 'Positive', $this);
+    $this->recurringContribution = $this->getRecurringContribution($recurringContributionID);
+    $this->lineItemParams = CRM_Utils_Request::retrieve('line_item', 'Text', $this);
+
+    $this->membershipType = CRM_Member_BAO_MembershipType::findById($this->lineItemParams['membership_type_id']);
+    $membershipTypeDatesCalculator = new CRM_MembershipExtras_Service_MembershipTypeDatesCalculator();
+    $this->membershipDurationCalculator = new CRM_MembershipExtras_Service_MembershipTypeDurationCalculator($this->membershipType, $membershipTypeDatesCalculator);
+    $this->prorataDaysCount = $this->calculateProRataDaysCount();
+  }
+
+  private function getRecurringContribution($id) {
+    return civicrm_api3('ContributionRecur', 'getsingle', [
+      'id' => $id,
+    ]);
+  }
+
+  /**
+   * Calculates the pro data days count,
+   * which is the number of days between
+   * the selected membership start and end
+   * dates.
+   *
+   * @return string
+   */
+  private function calculateProRataDaysCount() {
+    $membershipStartDate = new DateTime($this->lineItemParams['start_date']);
+    $membershipEndDate = new DateTime($this->lineItemParams['end_date']);
+
+    return $this->membershipDurationCalculator->calculateDaysBasedOnDates($membershipStartDate, $membershipEndDate);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Add %1', ['1' => $this->membershipType->name]));
+
+    $this->addRadio('payment_type', '', [
+      self::PAYMENT_TYPE_NO_PAYMENT => ts('No Payment'),
+      self::PAYMENT_TYPE_ONE_OFF_PAYMENT => ts('One off payment'),
+    ]);
+
+    $this->add('datepicker', 'scheduled_charge_date', ts('Scheduled Charge Date'), [], TRUE, ['time' => FALSE]);
+
+    $this->addMoney('amount_exc_tax', ts('Amount exc Tax'), TRUE, [], FALSE);
+
+    $financialTypes = CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes();
+    $this->add('select', 'noinstalmentline_financial_type_id', ts('Financial Type'), $financialTypes, TRUE);
+
+    $this->addMoney('amount_inc_tax', ts('Amount inc Tax'), FALSE, ['readonly' => TRUE], FALSE);
+
+    $this->add('checkbox', 'noinstalmentline_send_confirmation_email', ts('Send confirmation email?'));
+
+    $this->assign('prorataDaysCount', $this->prorataDaysCount);
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => ts('Apply'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+        'isDefault' => FALSE,
+      ],
+    ]);
+  }
+
+  public function setDefaultValues() {
+    return [
+      'payment_type' => self::PAYMENT_TYPE_NO_PAYMENT,
+      'scheduled_charge_date' => date('Y-m-d'),
+      'noinstalmentline_financial_type_id' => $this->membershipType->financial_type_id,
+      'amount_exc_tax' => $this->calculateAmountExcTax(),
+    ];
+  }
+
+  private function calculateAmountExcTax() {
+    $proratedAmount = $this->membershipType->minimum_fee;
+    if ($this->prorataDaysCount > 1) {
+      $membershipTypeDurationInDays = $this->membershipDurationCalculator->calculateOriginalInDays();
+      $proratedAmount = ($this->membershipType->minimum_fee / $membershipTypeDurationInDays) * $this->prorataDaysCount;
+      $proratedAmount = CRM_MembershipExtras_Service_MoneyUtilities::roundToPrecision($proratedAmount, 2);
+    }
+
+    return $proratedAmount;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function postProcess() {
+    $this->submittedValues = $this->exportValues();
+
+    $transaction = new CRM_Core_Transaction();
+    try {
+      $this->processPostRequest();
+      $transaction->commit();
+    }
+    catch (Exception $e) {
+      $transaction->rollback();
+      $this->showErrorNotification($e);
+    }
+  }
+
+  private function processPostRequest() {
+    $createdLineItemData = $this->createRecurringLineItem();
+
+    if ($this->submittedValues['payment_type'] == self::PAYMENT_TYPE_ONE_OFF_PAYMENT) {
+      $contribution = $this->createOneOffPayment($createdLineItemData);
+      $this->sendConfirmationEmail($contribution['id']);
+    }
+
+    $this->showOnSuccessNotifications();
+  }
+
+  private function createRecurringLineItem() {
+    $data['membership'] = $membership = $this->createMembership();
+    $priceFieldValue = $this->getDefaultPriceFieldValueForMembershipType($membership['membership_type_id']);
+
+    $lineItemParams = [
+      'sequential' => 1,
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['id'],
+      'price_field_id' => $priceFieldValue['price_field_id'],
+      'label' => $this->membershipType->name,
+      'qty' => 1,
+      'unit_price' => 0,
+      'line_total' => 0,
+      'price_field_value_id' => $priceFieldValue['id'],
+      'financial_type_id' => $priceFieldValue['financial_type_id'],
+    ];
+    $data['line_item'] = $lineItemParams = array_merge($lineItemParams, $this->getOneOffPaymentLineItemParams());
+    $lineItem = civicrm_api3('LineItem', 'create', $lineItemParams);
+
+    $recurringSubscriptionLineParams = [
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'line_item_id' => $lineItem['id'],
+      'start_date' => $this->lineItemParams['start_date'],
+      'auto_renew' => $this->lineItemParams['auto_renew'],
+    ];
+    CRM_MembershipExtras_BAO_ContributionRecurLineItem::create($recurringSubscriptionLineParams);
+
+    return $data;
+  }
+
+  private function createMembership() {
+    $autoRenew = $this->lineItemParams['auto_renew'];
+    $result = civicrm_api3('Membership', 'create', [
+      'sequential' => 1,
+      'contact_id' => $this->recurringContribution['contact_id'],
+      'membership_type_id' => $this->membershipType->id,
+      'join_date' => $this->lineItemParams['start_date'],
+      'start_date' => $this->lineItemParams['start_date'],
+      'end_date' => $this->calculateEndDateForMembership(),
+      'contribution_recur_id' => $autoRenew ? $this->recurringContribution['id'] : '',
+      'source' => 'Manage Instalments form',
+    ]);
+
+    return array_shift($result['values']);
+  }
+
+  private function calculateEndDateForMembership() {
+    if ($this->membershipType->duration_unit == 'lifetime') {
+      return NULL;
+    }
+
+    return $this->lineItemParams['end_date'];
+  }
+
+  private function getDefaultPriceFieldValueForMembershipType($membershipTypeID) {
+    $result = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'membership_type_id' => $membershipTypeID,
+      'price_field_id.price_set_id.name' => 'default_membership_type_amount',
+    ]);
+
+    if ($result['count'] > 0) {
+      return array_shift($result['values']);
+    }
+
+    return [];
+  }
+
+  /**
+   * Gets the parameters that are required to
+   * create one off payment line item.
+   *
+   * @return array
+   */
+  private function getOneOffPaymentLineItemParams() {
+    if ($this->submittedValues['payment_type'] != self::PAYMENT_TYPE_ONE_OFF_PAYMENT) {
+      return [];
+    }
+
+    $amountExcTax = $this->submittedValues['amount_exc_tax'] ?? 0;
+    $amountIncTax = $this->submittedValues['amount_inc_tax'] ?? 0;
+    $taxAmount = $amountIncTax - $amountExcTax;
+
+    return [
+      'unit_price' => $amountExcTax,
+      'line_total' => $amountExcTax,
+      'tax_amount' => $taxAmount,
+      'financial_type_id' => $this->submittedValues['noinstalmentline_financial_type_id'],
+    ];
+  }
+
+  /**
+   * Creates the one-off payment (contribution) if such option
+   * is selected. It also links it to the created membership.
+   *
+   * @param array $createdLineItemData
+   * @return array
+   */
+  private function createOneOffPayment($createdLineItemData) {
+    $totalIncTax = $this->submittedValues['amount_inc_tax'] ?? 0;
+
+    $contribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => $createdLineItemData['line_item']['financial_type_id'],
+      'receive_date' => $this->submittedValues['scheduled_charge_date'],
+      'total_amount' => $totalIncTax,
+      'fee_amount' => 0,
+      'net_amount' => $totalIncTax,
+      'tax_amount' => $createdLineItemData['line_item']['tax_amount'],
+      'contact_id' => $this->recurringContribution['contact_id'],
+      'contribution_status_id' => 'Pending',
+      'currency' => $this->recurringContribution['currency'],
+      'payment_instrument_id' => $this->recurringContribution['payment_instrument_id'],
+      'source' => 'Manage Instalments form',
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'is_pay_later' => TRUE,
+    ]);
+
+    civicrm_api3('MembershipPayment', 'create', [
+      'membership_id' => $createdLineItemData['membership']['id'],
+      'contribution_id' => $contribution['id'],
+    ]);
+
+    return array_shift($contribution['values']);
+  }
+
+  /**
+   * Sends the confirmation email if such option is selected.
+   *
+   * @param int $contributionId
+   * @return void
+   */
+  private function sendConfirmationEmail($contributionId) {
+    if (!empty($this->submittedValues['noinstalmentline_send_confirmation_email'])) {
+      civicrm_api3('Contribution', 'sendconfirmation', [
+        'id' => $contributionId,
+      ]);
+    }
+  }
+
+  private function showOnSuccessNotifications() {
+    CRM_Core_Session::setStatus(
+      $this->membershipType->name . ' ' . ts('has been added.'),
+      ts('Add') . ' ' . $this->membershipType->name,
+      'success'
+    );
+  }
+
+  private function showErrorNotification(Exception $e) {
+    CRM_Core_Session::setStatus(
+      ts('An error occurred while trying to add') . ' ' . $this->membershipType->name . ':' . $e->getMessage(),
+      ts('Error Adding') . $this->membershipType->name,
+      'error'
+    );
+  }
+
+}

--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -289,7 +289,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
       }
 
       if (that.validateNewMembership()) {
-        that.callNewLineConfirmationForm('civicrm/recurring-contribution/add-membership-lineitem', {
+        that.callNewLineConfirmationForm('membership', {
           reset: 1,
           contribution_recur_id: that.recurringContributionID,
           line_item: {
@@ -385,7 +385,7 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     // Adds line item to recurring contribution and all pending installments.
     CRM.$('#apply_add_donation_btn', this.currentTab).click(function () {
       if (that.validateNewDonation()) {
-        that.callNewLineConfirmationForm('civicrm/recurring-contribution/add-donation-lineitem', {
+        that.callNewLineConfirmationForm('donation', {
           reset: 1,
           contribution_recur_id: that.recurringContributionID,
           line_item: {
@@ -418,10 +418,10 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
    * Shows confimation dialog to add new donation line item if there are
    * sufficient pending installments.
    *
-   * @param path
+   * @param context
    * @param parameters
    */
-  CurrentPeriodLineItemHandler.prototype.callNewLineConfirmationForm = function (path, parameters) {
+  CurrentPeriodLineItemHandler.prototype.callNewLineConfirmationForm = function (context, parameters) {
     var that = this;
     var startDate = parameters.line_item.start_date;
 
@@ -434,20 +434,10 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
     }).done(function (result) {
       that.currentTab.unblock();
 
-      if (result.result < 1) {
-        CRM.alert(
-          'There are no instalments left for this period. Suggest to follow the steps below:' +
-          '<ul>' +
-          '<li>Add the the item to next period instead.</li>' +
-          '<li>(optional) Create the membership or contribution outside the recurring order.</li>' +
-          '</ul>',
-          null,
-          'alert',
-          {expires: NOTIFICATION_EXPIRE_TIME_IN_MS}
-        );
-
-        return;
-      }
+      var isTherePendingFutureInstalments = result.result >= 1;
+      const pathBase = 'civicrm/recurring-contribution/';
+      const pathSuffix = context == 'membership' ? 'membership-lineitem' : 'donation-lineitem';
+      var path = pathBase + (isTherePendingFutureInstalments ? 'add-' : 'add-noinstalments-') + pathSuffix;
 
       var formURL = CRM.url(path, parameters);
       CRM.loadForm(formURL, {

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.tpl
@@ -1,0 +1,93 @@
+<script type="text/javascript">
+  {literal}
+  CRM.$(function () {
+    CRM.$('#payment_details_form_container').css('display', 'none');
+
+    var amountExcTax = CRM.$('input[name=amount_exc_tax]').val();
+    var financialTypeId = CRM.$('select[name=noinstalmentline_financial_type_id]').val();
+    updateAmountIncTaxField(amountExcTax, financialTypeId);
+
+    CRM.$('input[type=radio][name=payment_type]').change(function() {
+      if (this.value == 1) {
+        CRM.$('#payment_details_form_container').css('display', 'none');
+      }
+      else if (this.value == 2) {
+        CRM.$('#payment_details_form_container').css('display', 'inline');
+      }
+    });
+
+    CRM.$('input[name=amount_exc_tax]').keyup(function() {
+      amountExcTax = CRM.$(this).val();
+      financialTypeId = CRM.$('select[name=noinstalmentline_financial_type_id]').val();
+
+      updateAmountIncTaxField(amountExcTax, financialTypeId);
+    });
+
+    CRM.$('select[name=noinstalmentline_financial_type_id]').on('change', function() {
+      financialTypeId = CRM.$(this).val();
+      amountExcTax = CRM.$('input[name=amount_exc_tax]').val();
+
+      updateAmountIncTaxField(amountExcTax, financialTypeId);
+    });
+
+    function updateAmountIncTaxField(amountExcTax, financialTypeId) {
+      CRM.$('button[data-identifier="_qf_AddNoInstalmentsMembershipLineItem_submit"]').prop('disabled',true);
+
+      CRM.api3('ContributionRecurLineItem', 'calculatetaxamount', {
+        'amount_exc_tax': amountExcTax,
+        'financial_type_id': financialTypeId
+      }).done(function (response) {
+        CRM.$('input[name=amount_inc_tax]').val(response.total_amount);
+        CRM.$('button[data-identifier="_qf_AddNoInstalmentsMembershipLineItem_submit"]').prop('disabled',false);
+      });
+    }
+  });
+  {/literal}
+</script>
+
+<p class="help">
+  {ts}As there are no future instalments in this period, you can decide whether to add this line item for no charge or to create a single one off future payment.{/ts}
+</p>
+
+<div class="crm-section">
+  <div>
+      {$form.payment_type.label}
+      {$form.payment_type.html}
+  </div>
+  <br>
+
+  <table id="payment_details_form_container" class="form-layout-compressed">
+    <tbody>
+    <tr>
+      <td>{$form.scheduled_charge_date.label}</td>
+      <td>{$form.scheduled_charge_date.html}</td>
+    </tr>
+    <tr>
+      <td>{$form.amount_exc_tax.label}</td>
+      <td>{$form.amount_exc_tax.html}</td>
+    </tr>
+    {if $prorataDaysCount}
+      <tr>
+        <td></td>
+        <td><span class="description">Pro-rated for {$prorataDaysCount} day(s)</span></td>
+      </tr>
+    {/if}
+    <tr>
+      <td>{$form.noinstalmentline_financial_type_id.label}</td>
+      <td>{$form.noinstalmentline_financial_type_id.html}</td>
+    </tr>
+    <tr>
+      <td>{$form.amount_inc_tax.label}</td>
+      <td>{$form.amount_inc_tax.html}</td>
+    </tr>
+    <tr>
+      <td>{$form.noinstalmentline_send_confirmation_email.label}</td>
+      <td>{$form.noinstalmentline_send_confirmation_email.html}</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+<div id="AddNoInstalmentsMembershipLineItemFormButtons" class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/tests/phpunit/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItemTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItemTest.php
@@ -1,0 +1,196 @@
+<?php
+
+use CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembershipLineItem as AddNoInstalmentsMembershipLineItemForm;
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+
+/**
+ * Class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembershipLineItemTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembershipLineItemTest extends BaseHeadlessTest {
+
+  use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
+
+  private $testContact;
+
+  private $testMembershipType;
+
+  private $testRecurringContribution;
+
+  public function setUp(): void {
+    $this->mockSalesTaxFinancialAccount(10, 'Member Dues');
+
+    $this->testContact = ContactFabricator::fabricate();
+
+    $this->testMembershipType = MembershipTypeFabricator::fabricate([
+      'name' => 'Test Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+      'financial_type_id' => 'Member Dues',
+    ]);
+
+    $this->testRecurringContribution = RecurringContributionFabricator::fabricate([
+      'sequential' => 1,
+      'contact_id' => $this->testContact['id'],
+      'amount' => 0,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'auto_renew' => 1,
+      'cycle_day' => 1,
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'EFT',
+      'start_date' => '2023-01-01',
+    ]);
+  }
+
+  public function testAddMembershipLineItemWithNoPayment(): void {
+    $_REQUEST['contribution_recur_id'] = $this->testRecurringContribution['id'];
+    $_REQUEST['line_item'] = [
+      'start_date' => '2023-03-01',
+      'end_date' => '2023-10-31',
+      'auto_renew' => 1,
+      'membership_type_id' => $this->testMembershipType['id'],
+    ];
+
+    $formValues = [
+      'payment_type' => AddNoInstalmentsMembershipLineItemForm::PAYMENT_TYPE_NO_PAYMENT,
+      'datepicker' => '2023-05-01',
+      'noinstalmentline_financial_type_id' => 2,
+      'amount_exc_tax' => 100,
+      'amount_inc_tax' => 110,
+      'noinstalmentline_send_confirmation_email' => 0,
+    ];
+    $this->submitForm($formValues);
+
+    $this->validateMembershipData();
+    $this->validateRecurContributionLineData(FALSE);
+    $this->validateContribution(FALSE);
+  }
+
+  public function testAddMembershipLineItemWithOneOffPayment(): void {
+    $_REQUEST['contribution_recur_id'] = $this->testRecurringContribution['id'];
+    $_REQUEST['line_item'] = [
+      'start_date' => '2023-03-01',
+      'end_date' => '2023-10-31',
+      'auto_renew' => 1,
+      'membership_type_id' => $this->testMembershipType['id'],
+    ];
+
+    $formValues = [
+      'payment_type' => AddNoInstalmentsMembershipLineItemForm::PAYMENT_TYPE_ONE_OFF_PAYMENT,
+      'datepicker' => '2023-05-01',
+      'noinstalmentline_financial_type_id' => 2,
+      'amount_exc_tax' => 100,
+      'amount_inc_tax' => 110,
+      'noinstalmentline_send_confirmation_email' => 0,
+    ];
+    $this->submitForm($formValues);
+
+    $this->validateMembershipData();
+    $this->validateRecurContributionLineData(TRUE);
+    $this->validateContribution(TRUE);
+  }
+
+  private function submitForm($formValues) {
+    $form = new AddNoInstalmentsMembershipLineItemForm();
+    $form->controller = new CRM_Core_Controller_Simple('CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembershipLineItem', '');
+    $form->_submitValues = $formValues;
+
+    $form->buildForm();
+    $form->loadValues($formValues);
+    $form->validate();
+
+    $form->postProcess();
+
+    return $form;
+  }
+
+  private function validateMembershipData() {
+    $createdMembership = \Civi\Api4\Membership::get()
+      ->addWhere('contact_id', '=', $this->testContact['id'])
+      ->setLimit(1)
+      ->execute()[0];
+    $actualMembershipParams = [
+      'join_date' => $createdMembership['join_date'],
+      'start_date' => $createdMembership['start_date'],
+      'end_date' => $createdMembership['end_date'],
+      'contribution_recur_id' => $createdMembership['contribution_recur_id'],
+      'membership_type_id' => $createdMembership['membership_type_id'],
+    ];
+
+    $expectedMembershipParams = [
+      'join_date' => $_REQUEST['line_item']['start_date'],
+      'start_date' => $_REQUEST['line_item']['start_date'],
+      'end_date' => $_REQUEST['line_item']['end_date'],
+      'contribution_recur_id' => $this->testRecurringContribution['id'],
+      'membership_type_id' => $_REQUEST['line_item']['membership_type_id'],
+    ];
+
+    $this->assertEquals($expectedMembershipParams, $actualMembershipParams);
+  }
+
+  private function validateRecurContributionLineData($withPayment) {
+    $recurLineItem = civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->testRecurringContribution['id'],
+    ])['values'][0];
+
+    $lineItem = \Civi\Api4\LineItem::get()
+      ->addWhere('id', '=', $recurLineItem['line_item_id'])
+      ->execute()[0];
+
+    $actualParams = [
+      'start_date' => date('Y-m-d', strtotime($recurLineItem['start_date'])) ,
+      'entity_table' => $lineItem['entity_table'],
+      'unit_price' => $lineItem['unit_price'],
+      'line_total' => $lineItem['line_total'],
+      'tax_amount' => $lineItem['tax_amount'],
+    ];
+
+    $expectedParams = [
+      'start_date' => $_REQUEST['line_item']['start_date'],
+      'entity_table' => 'civicrm_membership',
+      'unit_price' => $withPayment ? 100 : 0,
+      'line_total' => $withPayment ? 100 : 0,
+      'tax_amount' => $withPayment ? 10 : 0,
+    ];
+
+    $this->assertEquals($expectedParams, $actualParams);
+  }
+
+  private function validateContribution($isOnOffPayment) {
+    $contribution = \Civi\Api4\Contribution::get()
+      ->addWhere('contact_id', '=', $this->testContact['id'])
+      ->execute();
+
+    if (!$isOnOffPayment) {
+      $this->assertEmpty($contribution);
+      return;
+    }
+
+    $contribution = $contribution[0];
+    $actualParams = [
+      'total_amount' => $contribution['total_amount'],
+      'tax_amount' => $contribution['tax_amount'],
+      'contribution_recur_id' => $contribution['contribution_recur_id'],
+    ];
+
+    $expectedParams = [
+      'total_amount' => 110,
+      'tax_amount' => 10,
+      'contribution_recur_id' => $this->testRecurringContribution['id'],
+    ];
+
+    $this->assertEquals($expectedParams, $actualParams);
+  }
+
+}

--- a/tests/phpunit/api/v3/ContributionRecurLineItemTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurLineItemTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Class api_v3_PaymentSchedule_ContributionRecurLineItemTest
+ *
+ * @group headless
+ */
+class api_v3_PaymentSchedule_ContributionRecurLineItemTest extends BaseHeadlessTest {
+
+  use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
+
+  const DONATION_FINANCIAL_TYPE_ID = 1;
+
+  public function testCalculateTaxAndTotalAmountForAFinancialTypeWithoutSalesTax() {
+    $result = civicrm_api3('ContributionRecurLineItem', 'calculatetaxamount', [
+      'amount_exc_tax' => 100.56,
+      'financial_type_id' => self::DONATION_FINANCIAL_TYPE_ID,
+    ]);
+    $this->assertEquals(100.56, $result['total_amount']);
+    $this->assertEquals(0, $result['tax_amount']);
+  }
+
+  public function testCalculateTaxAndTotalAmountForAFinancialTypeWithSalesTax() {
+    $this->mockSalesTaxFinancialAccount(10, 'Donation');
+
+    $result = civicrm_api3('ContributionRecurLineItem', 'calculatetaxamount', [
+      'amount_exc_tax' => 100.56,
+      'financial_type_id' => self::DONATION_FINANCIAL_TYPE_ID,
+    ]);
+    $this->assertEquals(110.62, $result['total_amount']);
+    $this->assertEquals(10.06, $result['tax_amount']);
+  }
+
+}

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -55,6 +55,12 @@
     <access_arguments>edit contributions,edit memberships</access_arguments>
   </item>
   <item>
+    <path>civicrm/recurring-contribution/add-noinstalments-membership-lineitem</path>
+    <page_callback>CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembershipLineItem</page_callback>
+    <title>Add Membership Line Item</title>
+    <access_arguments>edit contributions,edit memberships</access_arguments>
+  </item>
+  <item>
     <path>civicrm/contribution/duplicate-contribution</path>
     <page_callback>CRM_MembershipExtras_Form_Contribution_Action_Duplicate</page_callback>
     <title>Cancel Recurring Contribution</title>


### PR DESCRIPTION
## Overview

Making the manage instalments screen more flexible, where the user can now add a membership line item, even when all the instalments within the payment plan are completed (pain).


## Before

Currently, the ability to add new membership line item (or even a normal line item) is not supported in Membershipextras when all the the instalments (contribution)  within the payment plan are completed (paid), and an error toast message is shown when the user tries to do so.


> (the error toast message appears in the background currently, but that is a separate and known UI problem)

![2023-05-31 17_12_27-vvsdds vsdsdv _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d582a6b1-5e24-48ab-bd87-5843105d7a55)



## After

Instead of showing the error toast message mentioned in the "before" section above, we now present two options to the user, the first is to create the membership without charging the user for it in the current period:

![1111111](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/c362da19-895e-4b63-867d-48771e9279b6)


With this option, the following happen:

1- New Membership with the selected type and dates will be created
2- New  membership subscription line item will be created on the payment plan, which the user can see inside the manage instalments screen, the amount of that line item is 0, and will automatically renew with the rest of the payment plan  (unless the user ticks the auto renew checkbox off when adding the line item). though for the autorenewal to pick the price of the membership correctly at autorenewal , the Membershipextras "**Use latest price when auto renew membership**" setting should be enabled:

![2023-05-31 17_26_41-Payment Plan Settings _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/567edb2e-6586-4519-aa27-516db4997071)



The second option is to create one off payment:

![ezgif-5-ff50eb25c6](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/743257f4-4617-4ebf-8119-1613febd68a8)

With this option, the user will be present with additional fields to control certain values on the payment to be created:

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/015547d9-0ac3-4ab0-aada-3aa97237cb8c)

- `Scheduled Charge Date`: Will be the created contribution `receive_date`, it is today date by default but the user can change it.
- `Amount exc Tax`: The amount of the payment (contribution) excluding the tax, it will be automatically set and pro rated based on the following formula:[(The number of days between the select membership start and end date) * The price of the membership per day based on its membership type length and fee]. The user also change this value if they desire.
- `Financial Type`: The financial type that will be used on the contribution to be created, by default it is the "Financial type" of the membership that is selected, but the user can change it as well, changing it will affect the tax amount given not all financial types are linked to tax account.
- `Amount inc tax`: Read-only field, which is the total amount of the contribution including the tax, this will be automatically calculated, and might change if the user changes the  `Amount exc Tax` or  the `Financial Type`.
- `Send confirmation email?`: If selected, an email will be sent to the contact that we are adding the membership line item for, it is a replica of the CiviCRM sends confirmation emails for contributions, and it will only be sent if the contact has an email, here is an example of such email:

> Given the contribution is linked to a membership, CiviCRM will by default uses "Memberships - Receipt (on-line)" mailing template

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/bc3c2452-e5b8-42ec-924a-f09d697e2bf1)

When the user submit the form, the following will happen:

1- New Membership with the selected type and dates will be created
2- New  membership subscription line item will be created on the payment plan, which the user can see inside the manage instalments screen, the amount of that line item is `Amount exc Tax` and tax amount for the line item will be (Amount inc tax - Amount exc tax), and it will automatically renew with the rest of the payment plan (unless the user ticks the auto renew checkbox off when adding the line item). 
3- New pending Contribution, the contribution total amount will = ((Amount inc tax), and the 'receive_date' will =  the `Scheduled Charge Date`, and it will be linked to the membership (through the MembershipPayment entity) and to the payment plan (through the contribution_recur_id field on the contribution).



## Technical Details

The work in this PR adjusts the code inside  `js/CurrentPeriodLineItemHandler.js`, so instead of showing a validation error toast message when adding a line item to a completed payment plan,  it now uses `CRM.loadForm` to either load the form at the following path:

```
civicrm/recurring-contribution/add-noinstalments-membership-lineitem
```

in case of adding membership line item

or the one at this path:

```
civicrm/recurring-contribution/add-noinstalments-donation-lineitem
```

in case of adding non membership line item.

The rest of the PR implements the form that the user sees when visiting the first path (the one related to adding membership line item), where the 2nd path will be implemented in another PR.  

The form itself is a standard CiviCRM quickform, where the template file of the form contains supporting JS code that is mostly related to updating the "Amount inc tax" field whenever the "Amount exc tax" or the financial type change, and for that calculation new API end point was introduced which is `ContributionRecurLineItem.calculatetaxamount`, that takes the amount and the financial type, and calculated the total amount including tax using such information.


When it comes to the form itself, it operates in two modes, one is when paying without payment `PAYMENT_TYPE_NO_PAYMENT` and the other is when making a one off payment `PAYMENT_TYPE_ONE_OFF_PAYMENT`, both modes are very similar where the main differences are:

1- In "No Payment" mode the subscription line item amount will be 0 where in "One off payment" mode it will contain the submitted value.
2- In "No Payment" no contribution will be created, where in "One off Payment" a contribution will be created, that contribution will also be linked to the membership through the MembershipPayment entity, and to the recurring contribution through the contribution contribution_recur_id field.
3- In "On off payment" an email will be sent if the user select "send confirmation email", this was implemented using the core `Contribution.sendconfirmation` API.

Here is a diagram that shows the entities (in green) that will get created after submitting the form with "No Payment" option:

![2023-05-31 19_52_19-_ Unsaved document - Pencil](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/c9ca148c-a53e-4a1a-8bb8-c15652b4f40c)

And this with "One off payment option":

![2023-05-31 19_51_20-_ Unsaved document - Pencil](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d449d599-9918-4736-ac39-ce21aa1b04f0)


