### PR TITLE
CIWEMB-267: Allow adding payment plan line item when there are no pending instalments

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.php
@@ -1,0 +1,191 @@
+<?php
+
+class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsDonationLineItem extends CRM_Core_Form {
+
+  private $recurringContribution;
+
+  private $lineItemParams;
+
+  private $calculatedAmounts;
+
+  private $submittedValues;
+
+  /**
+   * @inheritdoc
+   */
+  public function preProcess() {
+    $recurringContributionID = CRM_Utils_Request::retrieve('contribution_recur_id', 'Positive', $this);
+    $this->recurringContribution = $this->getRecurringContribution($recurringContributionID);
+    $this->lineItemParams = CRM_Utils_Request::retrieve('line_item', 'Text', $this);
+  }
+
+  private function getRecurringContribution($id) {
+    return civicrm_api3('ContributionRecur', 'getsingle', [
+      'id' => $id,
+    ]);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Add Line Item Confirmation'));
+
+    $this->add('checkbox', 'noinstalmentline_send_confirmation_email', ts('Send confirmation email?'));
+
+    $this->addButtons([
+      [
+        'type' => 'submit',
+        'name' => ts('Apply'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+        'isDefault' => FALSE,
+      ],
+    ]);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function postProcess() {
+    $this->submittedValues = $this->exportValues();
+
+    $transaction = new CRM_Core_Transaction();
+    try {
+      $this->processPostRequest();
+      $transaction->commit();
+    }
+    catch (Exception $e) {
+      $transaction->rollback();
+      $this->showErrorNotification($e);
+    }
+  }
+
+  private function processPostRequest() {
+    $this->calculateAmounts();
+    $contribution = $this->createOneOffPayment();
+    $this->createRecurringLineItem();
+    $this->sendConfirmationEmail($contribution['id']);
+    $this->showOnSuccessNotifications();
+  }
+
+  private function calculateAmounts() {
+    $amountExcTax = CRM_MembershipExtras_Service_MoneyUtilities::roundToPrecision($this->lineItemParams['amount'], 2);
+    $amounts = civicrm_api3('ContributionRecurLineItem', 'calculatetaxamount', [
+      'amount_exc_tax' => $amountExcTax,
+      'financial_type_id' => $this->lineItemParams['financial_type_id'],
+    ]);
+
+    $this->calculatedAmounts = [
+      'amount_exc_tax' => $amountExcTax,
+      'amount_inc_tax' => $amounts['total_amount'],
+      'tax_amount' => $amounts['tax_amount'],
+    ];
+  }
+
+  private function createOneOffPayment() {
+    $contribution = civicrm_api3('Contribution', 'create', [
+      'financial_type_id' => $this->lineItemParams['financial_type_id'],
+      'receive_date' => $this->lineItemParams['start_date'],
+      'total_amount' => $this->calculatedAmounts['amount_inc_tax'],
+      'fee_amount' => 0,
+      'net_amount' => $this->calculatedAmounts['amount_inc_tax'],
+      'tax_amount' => $this->calculatedAmounts['tax_amount'],
+      'contact_id' => $this->recurringContribution['contact_id'],
+      'contribution_status_id' => 'Pending',
+      'currency' => $this->recurringContribution['currency'],
+      'payment_instrument_id' => $this->recurringContribution['payment_instrument_id'],
+      'source' => 'Manage Instalments form - One off payment',
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'is_pay_later' => TRUE,
+    ]);
+
+    return array_shift($contribution['values']);
+  }
+
+  private function createRecurringLineItem() {
+    $priceFieldValue = $this->getDefaultPriceFieldValueForContributions();
+
+    $lineItemParams = [
+      'sequential' => 1,
+      'entity_table' => 'civicrm_contribution_recur',
+      'entity_id' => $this->recurringContribution['id'],
+      'price_field_id' => $priceFieldValue ? $priceFieldValue['price_field_id'] : NULL,
+      'price_field_value_id' => $priceFieldValue ? $priceFieldValue['price_field_value_id'] : NULL,
+      'label' => $this->lineItemParams['item'],
+      'financial_type_id' => $this->lineItemParams['financial_type_id'],
+      'qty' => 1,
+      'unit_price' => $this->calculatedAmounts['amount_exc_tax'],
+      'line_total' => $this->calculatedAmounts['amount_exc_tax'],
+      'tax_amount' => $this->calculatedAmounts['tax_amount'],
+    ];
+    $lineItem = civicrm_api3('LineItem', 'create', $lineItemParams);
+
+    $recurringSubscriptionLineParams = [
+      'contribution_recur_id' => $this->recurringContribution['id'],
+      'line_item_id' => $lineItem['id'],
+      'start_date' => $this->lineItemParams['start_date'],
+      'auto_renew' => $this->lineItemParams['auto_renew'],
+    ];
+    CRM_MembershipExtras_BAO_ContributionRecurLineItem::create($recurringSubscriptionLineParams);
+  }
+
+  private function getDefaultPriceFieldValueForContributions() {
+    $priceField = civicrm_api3('PriceField', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => 'contribution_amount',
+      'price_set_id' => 'default_contribution_amount',
+      'options' => ['limit' => 1],
+    ]);
+    if (empty($priceField['id'])) {
+      return NULL;
+    }
+
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'price_field_id' => $priceField['id'],
+      'options' => ['limit' => 1],
+    ]);
+    if (empty($priceFieldValue['id'])) {
+      return NULL;
+    }
+
+    return ['price_field_id' => $priceField['id'], 'price_field_value_id' => $priceFieldValue['id']];
+  }
+
+  /**
+   * Sends the confirmation email if such option is selected.
+   *
+   * @param int $contributionId
+   * @return void
+   */
+  private function sendConfirmationEmail($contributionId) {
+    if (!empty($this->submittedValues['noinstalmentline_send_confirmation_email'])) {
+      civicrm_api3('Contribution', 'sendconfirmation', [
+        'id' => $contributionId,
+      ]);
+    }
+  }
+
+  private function showOnSuccessNotifications() {
+    CRM_Core_Session::setStatus(
+      ts('The line item has been added.'),
+      ts('Adding line item'),
+      'success'
+    );
+  }
+
+  private function showErrorNotification(Exception $e) {
+    CRM_Core_Session::setStatus(
+      ts('An error occurred while trying to add the line item') . ':' . $e->getMessage(),
+      ts('Error Adding Line item'),
+      'error'
+    );
+  }
+
+}

--- a/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
@@ -153,7 +153,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembership
       'unit_price' => 0,
       'line_total' => 0,
       'price_field_value_id' => $priceFieldValue['id'],
-      'financial_type_id' => $priceFieldValue['financial_type_id'],
+      'financial_type_id' => $this->membershipType->financial_type_id,
     ];
     $data['line_item'] = $lineItemParams = array_merge($lineItemParams, $this->getOneOffPaymentLineItemParams());
     $lineItem = civicrm_api3('LineItem', 'create', $lineItemParams);
@@ -251,7 +251,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembership
       'contribution_status_id' => 'Pending',
       'currency' => $this->recurringContribution['currency'],
       'payment_instrument_id' => $this->recurringContribution['payment_instrument_id'],
-      'source' => 'Manage Instalments form',
+      'source' => 'Manage Instalments form - One off payment',
       'contribution_recur_id' => $this->recurringContribution['id'],
       'is_pay_later' => TRUE,
     ]);

--- a/api/v3/ContributionRecurLineItem.php
+++ b/api/v3/ContributionRecurLineItem.php
@@ -75,11 +75,11 @@ function civicrm_api3_contribution_recur_line_item_calculatetaxamount($params) {
   if (!empty($taxRates[$financialTypeId])) {
     $taxRate = $taxRates[$financialTypeId];
     $taxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($amountExcTax, $taxRate);
-    $taxAmount = CRM_MembershipExtras_Service_MoneyUtilities::roundToCurrencyPrecision($taxAmount['tax_amount']);
+    $taxAmount = CRM_MembershipExtras_Service_MoneyUtilities::roundToPrecision($taxAmount['tax_amount'], 2);
   }
 
   $totalAmount = $amountExcTax + $taxAmount;
-  $totalAmount = CRM_MembershipExtras_Service_MoneyUtilities::roundToCurrencyPrecision($totalAmount);
+  $totalAmount = CRM_MembershipExtras_Service_MoneyUtilities::roundToPrecision($totalAmount, 2);
 
   return ['total_amount' => $totalAmount, 'tax_amount' => $taxAmount];
 }

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.tpl
@@ -1,0 +1,18 @@
+<p class="help">
+  {ts}As there are no future instalments in this period, you can create a single one off future payment.{/ts}
+</p>
+
+<div class="crm-section">
+  <table id="payment_details_form_container" class="form-layout-compressed">
+    <tbody>
+    <tr>
+      <td>{$form.noinstalmentline_send_confirmation_email.label}</td>
+      <td>{$form.noinstalmentline_send_confirmation_email.html}</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+<div id="AddNoInstalmentsDonationLineItemFormButtons" class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/tests/phpunit/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItemTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItemTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsDonationLineItem as AddNoInstalmentsDonationLineItemForm;
+use CRM_MembershipExtras_Test_Fabricator_Contact as ContactFabricator;
+use CRM_MembershipExtras_Test_Fabricator_RecurringContribution as RecurringContributionFabricator;
+
+/**
+ * Class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsDonationLineItemTest
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsDonationLineItemTest extends BaseHeadlessTest {
+
+  use CRM_MembershipExtras_Test_Helper_FinancialAccountTrait;
+
+  private $testContact;
+
+  private $testRecurringContribution;
+
+  public function setUp(): void {
+    $this->mockSalesTaxFinancialAccount(10, 'Member Dues');
+
+    $this->testContact = ContactFabricator::fabricate();
+
+    $this->testRecurringContribution = RecurringContributionFabricator::fabricate([
+      'sequential' => 1,
+      'contact_id' => $this->testContact['id'],
+      'amount' => 0,
+      'frequency_unit' => 'month',
+      'frequency_interval' => 1,
+      'installments' => 12,
+      'contribution_status_id' => 'Pending',
+      'is_test' => 0,
+      'auto_renew' => 1,
+      'cycle_day' => 1,
+      'payment_processor_id' => 'Offline Recurring Contribution',
+      'financial_type_id' => 'Member Dues',
+      'payment_instrument_id' => 'EFT',
+      'start_date' => '2023-01-01',
+    ]);
+  }
+
+  public function testAddDonationLineItemWithOneOffPayment(): void {
+    $_REQUEST['contribution_recur_id'] = $this->testRecurringContribution['id'];
+    $_REQUEST['line_item'] = [
+      'start_date' => '2023-03-01',
+      'auto_renew' => 1,
+      'item' => 'Test Line 1',
+      'amount' => 25,
+      'financial_type_id' => 2,
+    ];
+
+    $formValues = [
+      'noinstalmentline_send_confirmation_email' => 0,
+    ];
+    $this->submitForm($formValues);
+
+    $this->validateRecurContributionLineData();
+    $this->validateContribution();
+  }
+
+  private function submitForm($formValues) {
+    $form = new AddNoInstalmentsDonationLineItemForm();
+    $form->controller = new CRM_Core_Controller_Simple('CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembershipLineItem', '');
+    $form->_submitValues = $formValues;
+
+    $form->buildForm();
+    $form->loadValues($formValues);
+    $form->validate();
+
+    $form->postProcess();
+
+    return $form;
+  }
+
+  private function validateRecurContributionLineData() {
+    $recurLineItem = civicrm_api3('ContributionRecurLineItem', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $this->testRecurringContribution['id'],
+    ])['values'][0];
+
+    $lineItem = \Civi\Api4\LineItem::get()
+      ->addWhere('id', '=', $recurLineItem['line_item_id'])
+      ->execute()[0];
+
+    $actualParams = [
+      'start_date' => date('Y-m-d', strtotime($recurLineItem['start_date'])) ,
+      'entity_table' => $lineItem['entity_table'],
+      'unit_price' => $lineItem['unit_price'],
+      'line_total' => $lineItem['line_total'],
+      'tax_amount' => $lineItem['tax_amount'],
+    ];
+
+    $expectedParams = [
+      'start_date' => $_REQUEST['line_item']['start_date'],
+      'entity_table' => 'civicrm_contribution_recur',
+      'unit_price' => 25,
+      'line_total' => 25,
+      'tax_amount' => 2.5,
+    ];
+
+    $this->assertEquals($expectedParams, $actualParams);
+  }
+
+  private function validateContribution() {
+    $contribution = \Civi\Api4\Contribution::get()
+      ->addWhere('contact_id', '=', $this->testContact['id'])
+      ->execute();
+    $contribution = $contribution[0];
+    $actualParams = [
+      'total_amount' => $contribution['total_amount'],
+      'tax_amount' => $contribution['tax_amount'],
+      'contribution_recur_id' => $contribution['contribution_recur_id'],
+    ];
+
+    $expectedParams = [
+      'total_amount' => 27.5,
+      'tax_amount' => 2.5,
+      'contribution_recur_id' => $this->testRecurringContribution['id'],
+    ];
+
+    $this->assertEquals($expectedParams, $actualParams);
+  }
+
+}

--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -61,6 +61,12 @@
     <access_arguments>edit contributions,edit memberships</access_arguments>
   </item>
   <item>
+    <path>civicrm/recurring-contribution/add-noinstalments-donation-lineitem</path>
+    <page_callback>CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsDonationLineItem</page_callback>
+    <title>Add Donation Line Item</title>
+    <access_arguments>edit contributions,edit memberships</access_arguments>
+  </item>
+  <item>
     <path>civicrm/contribution/duplicate-contribution</path>
     <page_callback>CRM_MembershipExtras_Form_Contribution_Action_Duplicate</page_callback>
     <title>Cancel Recurring Contribution</title>


### PR DESCRIPTION
## Overview

Making the manage instalments screen more flexible, where the user can now add a line item, even when all the instalments within the payment plan are completed (paid).

This PR is the continuation to the work here: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/470
, where that PR is about adding membership line items, and this one is about adding standard non membership line items.

## Before

Currently, the ability to add new (non membership) line item is not supported in Membershipextras when all the the instalments (contribution)  within the payment plan are completed (paid), and an error toast message is shown when the user tries to do so.


## After

Instead of showing the error toast message, we now show a confirmation message, allowing the user to create on off payment:


![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/74c20943-fa54-4f20-9278-ffa3f8802a44)


And as you can see, it is different from the on when trying to add membership line item, because for non membership line items:

1- It unlike membership line items where a membership record will be created, it doesn't make much sense to add a non membership line item without creating a on-off payment.
2- Given there is no pro-rata for non membership line items, it does not make sense to show the same fields we show when selecting "on-off payment" option for membership line items, given all the values we need will be entered at the first screen.

With this option, the following happens:

1- New  subscription line item will be created on the payment plan, which the user can see inside the manage instalments screen, the amount of that line item is the amount the user entered where the tax amount will be set based on the selected financial type, and it will automatically renew with the rest of the payment plan (unless the user ticks the auto renew checkbox off when adding the line item). 
2- New pending Contribution, the contribution total amount will = The amount the user entered + the sales tax if the selected financial type has sales tax on it, this contribution will be linked to the payment plan  (the recurring contribution).


![ezgif-5-d556d8faf3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/9caa48f7-505b-49fd-9d0e-fcbf93f138bf)


## Technical Details

In the other linked PR, I already updated the  `js/CurrentPeriodLineItemHandler.js`, so instead of showing a validation error toast message when adding a line item to a completed payment plan,  it now uses `CRM.loadForm` to either load the form at the following path:

```
civicrm/recurring-contribution/add-noinstalments-membership-lineitem
```

which I implemented in the other PR.



or this path

```
civicrm/recurring-contribution/add-noinstalments-donation-lineitem
```

for non membership line item. In this PR I implemented this 2nd path. The rest of the PR is just a standard quick form implementation, that takes the user input and creates the entities mention in the "after" section.


