### PR TITLE
CIWEMB-102: Allow deleting a payment scheme. 

### DIFF
--- a/CRM/MembershipExtras/BAO/PaymentScheme.php
+++ b/CRM/MembershipExtras/BAO/PaymentScheme.php
@@ -41,4 +41,27 @@ class CRM_MembershipExtras_BAO_PaymentScheme extends CRM_MembershipExtras_DAO_Pa
     return $schemes;
   }
 
+  /**
+   * Deletes payment scheme by ID.
+   *
+   * @throws CRM_Core_Exception
+   *   Function throws error if payment scheme ID
+   *   is linked to any recurring contribution.
+   */
+  public static function deleteByID($id) {
+    $contributionRecursCount = \Civi\Api4\ContributionRecur::get()
+      ->selectRowCount()
+      ->addWhere('payment_plan_extra_attributes.payment_scheme_id', '=', $id)
+      ->execute()->count();
+
+    if ($contributionRecursCount > 0) {
+      throw new CRM_Core_Exception('You are not able to delete this payment scheme as it’s linked with one or more recurring contributions.');
+    }
+
+    $param = [
+      'id' => $id,
+    ];
+    CRM_MembershipExtras_BAO_PaymentScheme::deleteRecord($param);
+  }
+
 }

--- a/templates/CRM/MembershipExtras/Form/PaymentScheme.tpl
+++ b/templates/CRM/MembershipExtras/Form/PaymentScheme.tpl
@@ -2,20 +2,27 @@
   <div class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
-  <table class="form-layout-compressed">
-    <tbody>
-    {foreach from=$elementNames item=elementName}
-    <tr>
-      <td class="label">
-        <label>{$form.$elementName.label}</label>
-      </td>
-      <td>
-          {$form.$elementName.html}
-      </td>
-    </tr>
-    {/foreach}
-    </tbody>
-  </table>
+    {if $action eq 8}
+      <div class="messages status no-popup">
+          {icon icon="fa-info-circle"}{/icon}
+          {ts}WARNING: This will permanently delete the payment scheme, this action cannot be undone. Do you want to continue?{/ts}
+      </div>
+    {else}
+      <table class="form-layout-compressed">
+        <tbody>
+        {foreach from=$elementNames item=elementName}
+        <tr>
+          <td class="label">
+            <label>{$form.$elementName.label}</label>
+          </td>
+          <td>
+              {$form.$elementName.html}
+          </td>
+        </tr>
+        {/foreach}
+        </tbody>
+      </table>
+    {/if}
   <div class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>

--- a/templates/CRM/MembershipExtras/Page/PaymentScheme.tpl
+++ b/templates/CRM/MembershipExtras/Page/PaymentScheme.tpl
@@ -31,7 +31,7 @@
                 <td class="crm-admin-member-payment-scheme-permission-enabled" id="row_{$row.id}_status">{if $row.enabled eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>
                   <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=update&reset=1"}" class="action-item crm-hover-button" title="{ts}View and Edit Payment Scheme{/ts}">{ts}Edit{/ts}</a>
-                  <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=delete&reset=1"}" class="action-item crm-hover-button small-popup" title="Delete Paymet Scheme">Delete</a>
+                  <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=delete&reset=1"}" class="action-item crm-hover-button small-popup" title="Delete Payment Scheme">Delete</a>
                 </td>
               </tr>
             {/foreach}


### PR DESCRIPTION
## Overview

This PR adds the ability to delete a payment scheme that has not been linked to any recurring contribution. 

## Before

Delete link did not work. 

## After

_Screencast shows a payment scheme cannot be deleted if it has been linked to a recurring contribution(s). The error toast message will display if the payment scheme cannot be deleted._ 

[screencast to delete payment scheme.webm](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/208713/27ac3a21-8944-44ff-a3be-97b0f3234ad9)

_Screencast shows payment scheme was deleted successfully._ 

[screencast-compucorp.atlassian.net-2023.06.06-14_31_21.webm](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/208713/27770b1e-665e-4352-b82a-57e1802c68da)

## Technical Details

In this PR, I updated the existing class `CRM_MembershipExtras_Form_PaymentScheme ` in process deletion in delete and add the logic to validate if payment scheme is linked to any recurring contribution by using ContributionRecur API v4 to check. 

```
 \Civi\Api4\ContributionRecur::get()
      ->selectRowCount()
      ->addWhere('payment_plan_extra_attributes.payment_scheme_id', '=', $this->id)
      ->execute()->count();
```

In the smarty [template](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/472/files#diff-b98da6eab66fb5b44f3960032ec43005a95a0f03232ed1bc0e4eeebd66982af0R5), I also added the condition to display delete warning message by checking if the action equals to 8 which aligns with constant in[ Civi Action class ](https://github.com/compucorp/civicrm-core/blob/5.51.3-patches/CRM/Core/Action.php#L33)