### PR TITLE
CIWEMB-359: Hide 'Cancel Auto-Renewal' membership action

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -372,6 +372,13 @@ function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$
       ];
     }
   }
+
+  // hide memberships 'Cancel Auto-renewal` action.
+  if (in_array($op, ['membership.tab.row', 'membership.selector.row']) && $objectName == 'Membership') {
+    $cancelAutorenewalActionName = ts('Cancel Auto-renewal');
+    $cancelAutoRenewActionIndex = array_search($cancelAutorenewalActionName, array_column($links, 'name'));
+    unset($links[$cancelAutoRenewActionIndex]);
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview

CiviCRM core has this  'Cancel Auto-Renewal' action that shows up for any membership linked to a recurring contribution (basically if the contribution_recur_id field on the membership is set), this option is not useful for Membershipextras given we have our own mechanism to control if the membership should autorenewal or not, which is using the manage instalments form, so here we are hiding this action



## Before

The 'Cancel Auto-Renewal' action appears in both membership tab on the contact page, and on the memberships search form:

![2023-06-08 13_09_13-gfsfd dfssd _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/bddbbdd5-eedb-4e78-aa36-7a66a12dd056)

![2023-06-08 13_09_38-Find Memberships _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/b66cfd58-4b16-42c4-8db7-fd077960ab0f)




## After

The 'Cancel Auto-Renewal' is not hidden in both pages:


![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/76480c1d-325e-4fdc-81b4-829c5f96b02b)

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/fd7561b4-4ef8-489a-914f-b8f180a5b992)
