### PR TITLE
CIWEMB-258: Make manage instalments form full screen by default

### DIFF
--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -1,6 +1,8 @@
 <div id="periodsContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
   <script type="text/javascript">
     {literal}
+    CRM.$('.crm-dialog-titlebar-resize:visible').click();
+
     var selectedTab = CRM.$('#periodsContainer').closest('.ui-dialog-content').data('selectedTab') || 'current';
     CRM.$(function($) {
       $('#tab_current').click(function () {


### PR DESCRIPTION
## Overview

This is how the "Manage instalments" form usually look like:

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d530ad1a-c27c-481b-82cf-30e4ef39ab0f)

But on small screens and specially when trying to add Membership line item with long name, the form UI will become less friendly:

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/829094f4-3b9a-4f07-8639-817e7c206093)

This PR improves that by making the manage instalments modal full screen by default. 

## Before

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d78b9e04-17a9-41a8-80af-d55175f5332e)


## After

The "Manage instalments" screen open in full screen mode by default:
![dasdasdas](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/879033b4-f8ec-4886-876e-3e229de9218c)

## Technical Details

I couldn't find an easy way within Civi to make the modal full screen by default, given it is added using the `hook_civicrm_links` and managed by Civi, and non of the hook options seems to allow the possibility of achieving that.  So my solution was an within the modal page template itself, to add a JS code that simulates the click event on the modal "Toggle full screen" button:

![2023-06-08 16_57_32-gfsfd dfssd _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/9593f2a0-6d28-427e-bce0-c159b18a8985)

by using this selector `.crm-dialog-titlebar-resize`, and to prevent it from getting triggered for modals that hidden and only force the resize on the modal the user opened, I added `:visible`  to the above selector.
