### PR TITLE
CIWEMB-269: Simplify switching payment plan membership from one type to another - One off Payment

### DIFF
--- a/CRM/MembershipExtras/BAO/ContributionRecurLineItem.php
+++ b/CRM/MembershipExtras/BAO/ContributionRecurLineItem.php
@@ -24,4 +24,28 @@ class CRM_MembershipExtras_BAO_ContributionRecurLineItem extends CRM_MembershipE
     return $instance;
   }
 
+  /**
+   * Gets the payment plan period end date,
+   * which is the maximum end date among all
+   * membership recurring line items.
+   *
+   * @param int $recurContributionId
+   * @return string
+   */
+  public static function getPeriodEndDate($recurContributionId) {
+    $query = "
+      SELECT MAX(m.end_date) FROM civicrm_membership m
+      INNER JOIN civicrm_line_item li ON m.id = li.entity_id and li.entity_table = 'civicrm_membership'
+      INNER JOIN membershipextras_subscription_line msl ON li.id = msl.line_item_id
+      WHERE msl.contribution_recur_id = %1
+        AND msl.is_removed = FALSE
+        AND msl.auto_renew = 1
+        AND msl.end_date IS NULL;
+    ";
+
+    return CRM_Core_DAO::singleValueQuery($query, [
+      1 => [$recurContributionId, 'Integer'],
+    ]);
+  }
+
 }

--- a/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.php
@@ -21,9 +21,11 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
    * @inheritdoc
    */
   public function setDefaultValues() {
+    $tomorrowsDate = date('Y-m-d', strtotime('+1 day'));
     return [
       'payment_type' => MembershipTypeSwitcher::PAYMENT_TYPE_UPDATE_PENDING_INSTALMENTS,
-      'switch_date' => date('Y-m-d', strtotime('+1 day')),
+      'switch_date' => $tomorrowsDate,
+      'scheduled_charge_date' => $tomorrowsDate,
     ];
   }
 
@@ -33,7 +35,9 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Upgrade Membership Type'));
 
-    $this->assign('current_membership_type_name', $this->getCurrentMembershipTypeName());
+    $currentMembershipType = $this->getCurrentMembershipType();
+    $this->assign('current_membership_type_name', $currentMembershipType['name']);
+    $this->assign('current_membership_type_id', $currentMembershipType['id']);
 
     $this->addEntityRef('new_membership_type', ts('New Membership Type'), [
       'entity' => 'membership_type',
@@ -47,6 +51,8 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
       MembershipTypeSwitcher::PAYMENT_TYPE_UPDATE_PENDING_INSTALMENTS => ts('Charge the member at the new membership type rate for any future unpaid instalments.'),
       MembershipTypeSwitcher::PAYMENT_TYPE_ONE_OFF_PAYMENT => ts('Charge them a one off fee for this change.'),
     ], [], '<br>');
+
+    $this->addOneOffFeeFields();
 
     $this->addButtons([
       [
@@ -62,11 +68,35 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
     ]);
   }
 
-  private function getCurrentMembershipTypeName() {
-    return civicrm_api3('LineItem', 'getvalue', [
-      'return' => 'label',
-      'id' => $this->lineItemID,
+  private function getCurrentMembershipType() {
+    $query = "
+      SELECT mt.id, mt.name FROM civicrm_line_item li
+      INNER JOIN civicrm_membership cm ON li.entity_id = cm.id AND li.entity_table = 'civicrm_membership'
+      INNER JOIN civicrm_membership_type mt ON cm.membership_type_id = mt.id
+      WHERE li.id = %1
+    ";
+    $result = CRM_Core_DAO::executeQuery($query, [
+      1 => [$this->lineItemID, 'Integer'],
     ]);
+
+    if (!$result->fetch()) {
+      throw new CRM_Core_Exception(ts('Cannot find the membership type of the selected line item.'));
+    }
+
+    return $result->toArray();
+  }
+
+  private function addOneOffFeeFields() {
+    $this->add('datepicker', 'scheduled_charge_date', ts('Scheduled Charge Date'), [], TRUE, ['time' => FALSE]);
+
+    $this->addMoney('amount_exc_tax', ts('Amount exc Tax'), TRUE, [], FALSE);
+
+    $financialTypes = CRM_Financial_BAO_FinancialType::getAvailableFinancialTypes();
+    $this->add('select', 'switchmembership_financial_type_id', ts('Financial Type'), $financialTypes, TRUE);
+
+    $this->addMoney('amount_inc_tax', ts('Amount inc Tax'), FALSE, ['readonly' => TRUE], FALSE);
+
+    $this->add('checkbox', 'switchmembership_send_confirmation_email', ts('Send confirmation email?'));
   }
 
   /**
@@ -74,8 +104,10 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
    */
   public function postProcess() {
     $submittedValues = $this->exportValues();
+    $oneOffFeeParams = $this->getOneOffFeeParams($submittedValues);
+
     try {
-      $membershipTypeSwitcher = new MembershipTypeSwitcher($this->lineItemID, $submittedValues['new_membership_type'], $submittedValues['switch_date'], $submittedValues['payment_type']);
+      $membershipTypeSwitcher = new MembershipTypeSwitcher($this->lineItemID, $submittedValues['new_membership_type'], $submittedValues['switch_date'], $submittedValues['payment_type'], $oneOffFeeParams);
       $membershipTypeSwitcher->switchType();
 
       CRM_Core_Session::setStatus(
@@ -91,6 +123,21 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
         'error'
       );
     }
+  }
+
+  private function getOneOffFeeParams($submittedValues) {
+    if ($submittedValues['payment_type'] == MembershipTypeSwitcher::PAYMENT_TYPE_UPDATE_PENDING_INSTALMENTS) {
+      return NULL;
+    }
+
+    $sendConfirmation = CRM_Utils_Array::value('switchmembership_send_confirmation_email', $submittedValues, 0);
+    return [
+      'scheduled_charge_date' => $submittedValues['scheduled_charge_date'],
+      'amount_exc_tax' => $submittedValues['amount_exc_tax'],
+      'amount_inc_tax' => $submittedValues['amount_inc_tax'],
+      'financial_type_id' => $submittedValues['switchmembership_financial_type_id'],
+      'send_confirmation_email' => $sendConfirmation,
+    ];
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipLineProRataCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipLineProRataCalculator.php
@@ -1,0 +1,56 @@
+<?php
+
+use CRM_MembershipExtras_BAO_ContributionRecurLineItem as ContributionRecurLineItem;
+
+class CRM_MembershipExtras_Service_MembershipLineProRataCalculator {
+
+  /**
+   * Calculates the pro-rata amounts for a given membership type
+   * within a payment plan within a specified period of time.
+   * The period end date will be used as "To Date" if it is not
+   * supplied, where the input membership type financial type id
+   * will be used if no financial type is supplied.
+   *
+   * @param int $recurContributionId
+   * @param int $membershipTypeId
+   * @param string $fromDate
+   * @param string $toDate
+   * @param int $financialTypeId
+   *
+   * @return array
+   */
+  public static function calculateAmounts($recurContributionId, $membershipTypeId, $fromDate, $toDate = NULL, $financialTypeId = NULL) {
+    if (empty($toDate)) {
+      $toDate = ContributionRecurLineItem::getPeriodEndDate($recurContributionId);
+    }
+
+    $membershipType = CRM_Member_BAO_MembershipType::findById($membershipTypeId);
+    if (empty($financialTypeId)) {
+      $financialTypeId = $membershipType->financial_type_id;
+    }
+
+    $membershipTypeDatesCalculator = new CRM_MembershipExtras_Service_MembershipTypeDatesCalculator();
+    $membershipDurationCalculator = new CRM_MembershipExtras_Service_MembershipTypeDurationCalculator($membershipType, $membershipTypeDatesCalculator);
+    $membershipStartDate = new DateTime($fromDate);
+    $membershipEndDate = new DateTime($toDate);
+    $prorataDaysCount = $membershipDurationCalculator->calculateDaysBasedOnDates($membershipStartDate, $membershipEndDate);
+
+    $membershipTypeDurationInDays = $membershipDurationCalculator->calculateOriginalInDays();
+    $proratedAmount = ($membershipType->minimum_fee / $membershipTypeDurationInDays) * $prorataDaysCount;
+    $proratedAmount = CRM_MembershipExtras_Service_MoneyUtilities::roundToPrecision($proratedAmount, 2);
+
+    $amounts = civicrm_api3('ContributionRecurLineItem', 'calculatetaxamount', [
+      'amount_exc_tax' => $proratedAmount,
+      'financial_type_id' => $financialTypeId,
+    ]);
+
+    return [
+      'amount_exc_tax' => $proratedAmount,
+      'amount_inc_tax' => $amounts['total_amount'],
+      'tax_amount' => $amounts['tax_amount'],
+      'prorata_days_count' => $prorataDaysCount,
+      'used_financial_type_id' => $financialTypeId,
+    ];
+  }
+
+}

--- a/api/v3/ContributionRecurLineItem.php
+++ b/api/v3/ContributionRecurLineItem.php
@@ -83,3 +83,45 @@ function civicrm_api3_contribution_recur_line_item_calculatetaxamount($params) {
 
   return ['total_amount' => $totalAmount, 'tax_amount' => $taxAmount];
 }
+
+function _civicrm_api3_contribution_recur_line_item_calcmembershipprorata_spec(&$spec) {
+  $spec['recur_contribution_id'] = [
+    'title' => ts('Recurring Contribution Id'),
+    'api.required' => TRUE,
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
+  $spec['membership_type_id'] = [
+    'title' => ts('Membership Type Id'),
+    'api.required' => TRUE,
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+
+  $spec['from_date'] = [
+    'title' => ts('From Date'),
+    'api.required' => TRUE,
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $spec['to_date'] = [
+    'title' => ts('To Date'),
+    'api.required' => FALSE,
+    'type' => CRM_Utils_Type::T_DATE,
+  ];
+
+  $spec['financial_type_id'] = [
+    'title' => ts('Financial Type Id'),
+    'api.required' => FALSE,
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+}
+
+/**
+ * @param $params
+ * @return array
+ */
+function civicrm_api3_contribution_recur_line_item_calcmembershipprorata($params) {
+  $params['to_date'] = CRM_Utils_Array::value('to_date', $params);
+  $params['financial_type_id'] = CRM_Utils_Array::value('financial_type_id', $params);
+  return CRM_MembershipExtras_Service_MembershipLineProRataCalculator::calculateAmounts($params['recur_contribution_id'], $params['membership_type_id'], $params['from_date'], $params['to_date'], $params['financial_type_id']);
+}

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.tpl
@@ -1,3 +1,88 @@
+<script type="text/javascript">
+    {literal}
+    CRM.$(function () {
+      var currentMembershipTypeId = {/literal}{$current_membership_type_id}{literal};
+      CRM.$('#payment_details_form_container').css('display', 'none');
+
+      CRM.$('input[type=radio][name=payment_type]').change(function() {
+        if (this.value == 1) {
+          CRM.$('#payment_details_form_container').css('display', 'none');
+        }
+        else if (this.value == 2) {
+          CRM.$('#payment_details_form_container').css('display', 'inline');
+        }
+      });
+
+      CRM.$('#new_membership_type').change(function() {
+        var newMembershipTypeId = CRM.$(this).val();
+        var fromDate = CRM.$('input[name=switch_date]').val();
+        updateAmountFields(newMembershipTypeId, fromDate);
+      });
+
+      CRM.$('#switch_date').change(function() {
+        var fromDate = CRM.$(this).val();
+        var newMembershipTypeId = CRM.$('input[name=new_membership_type]').val();
+        updateAmountFields(newMembershipTypeId, fromDate);
+      });
+
+      function updateAmountFields(newMembershipTypeId, fromDate) {
+        CRM.$('button[data-identifier="_qf_SwitchMembershipType_submit"]').prop('disabled',true);
+
+        var recurContributionId = CRM.$('#recurringContributionID').val();
+        CRM.api3('ContributionRecurLineItem', 'calcmembershipprorata', {
+          'recur_contribution_id': recurContributionId,
+          'membership_type_id' : currentMembershipTypeId,
+          'from_date' : fromDate,
+        }).done(function (currentTypeResult) {
+          CRM.api3('ContributionRecurLineItem', 'calcmembershipprorata', {
+            'recur_contribution_id': recurContributionId,
+            'membership_type_id' : newMembershipTypeId,
+            'from_date' : fromDate,
+          }).done(function (newTypeResult) {
+            var amountExcTax = 0;
+            var amountIncTax = 0;
+            if (newTypeResult.amount_inc_tax > currentTypeResult.amount_inc_tax) {
+              amountExcTax = (newTypeResult.amount_exc_tax - currentTypeResult.amount_exc_tax).toFixed(2);
+              amountIncTax = (newTypeResult.amount_inc_tax - currentTypeResult.amount_inc_tax).toFixed(2);
+            }
+
+            CRM.$('input[name=amount_exc_tax]').val(amountExcTax);
+            CRM.$('input[name=amount_inc_tax]').val(amountIncTax);
+            CRM.$('#switchmembership_financial_type_id ').val(newTypeResult.used_financial_type_id).change();
+            CRM.$('button[data-identifier="_qf_SwitchMembershipType_submit"]').prop('disabled',false);
+          });
+        });
+      }
+
+      CRM.$('input[name=amount_exc_tax]').keyup(function() {
+        amountExcTax = CRM.$(this).val();
+        financialTypeId = CRM.$('select[name=switchmembership_financial_type_id]').val();
+
+        updateAmountIncTaxField(amountExcTax, financialTypeId);
+      });
+
+      CRM.$('select[name=switchmembership_financial_type_id]').on('change', function() {
+        financialTypeId = CRM.$(this).val();
+        amountExcTax = CRM.$('input[name=amount_exc_tax]').val();
+
+        updateAmountIncTaxField(amountExcTax, financialTypeId);
+      });
+
+      function updateAmountIncTaxField(amountExcTax, financialTypeId) {
+        CRM.$('button[data-identifier="_qf_SwitchMembershipType_submit"]').prop('disabled',true);
+
+        CRM.api3('ContributionRecurLineItem', 'calculatetaxamount', {
+          'amount_exc_tax': amountExcTax,
+          'financial_type_id': financialTypeId
+        }).done(function (response) {
+          CRM.$('input[name=amount_inc_tax]').val(response.total_amount);
+          CRM.$('button[data-identifier="_qf_SwitchMembershipType_submit"]').prop('disabled',false);
+        });
+      }
+    });
+    {/literal}
+</script>
+
 <p class="help">
     {ts}Here you can switch membership type for a member and arrange an additional fee if required.{/ts}<br>
     {ts}Note that if you would like the switch to take place at the end of the current period this should be done from the "Next period" tab rather than on this screen.{/ts}
@@ -34,6 +119,37 @@
       <td>{$form.payment_type.html}</td>
       <td></td>
       <td></td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="crm-section">
+  <table id="payment_details_form_container" class="form-layout-compressed">
+    <tbody>
+    <tr>
+      <td>{$form.scheduled_charge_date.label}</td>
+      <td>{$form.scheduled_charge_date.html}</td>
+    </tr>
+    <tr>
+      <td>{$form.amount_exc_tax.label}</td>
+      <td>{$form.amount_exc_tax.html}</td>
+    </tr>
+      <tr>
+        <td></td>
+        <td><span class="description">{ts}This amount defaults to the pro-rata increased cost of the new membership type for the rest of the period, but you maybe enter any amount.{/ts}</span></td>
+      </tr>
+    <tr>
+      <td>{$form.switchmembership_financial_type_id.label}</td>
+      <td>{$form.switchmembership_financial_type_id.html}</td>
+    </tr>
+    <tr>
+      <td>{$form.amount_inc_tax.label}</td>
+      <td>{$form.amount_inc_tax.html}</td>
+    </tr>
+    <tr>
+      <td>{$form.switchmembership_send_confirmation_email.label}</td>
+      <td>{$form.switchmembership_send_confirmation_email.html}</td>
     </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Overview

In this PR I am implementing the 2nd option "One Off Payment" in the membership switching form that is implemented here:
https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/476

## Before

The "Charge them a one off fee for this change" on the "Switch Membership" form does nothing.

## After

When clicking on the mentioned option, a list of extra fields will appear to the user to allow them to enter the details for the "one off payment":

![11111](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/166d0489-8997-4ef6-ad56-e388fe230dd3)

These fields are:

- `Scheduled Charge Date`: The default value is same as the "Switch Date" which is "Today Date + 1 day", but can be changed by the user and will be used as the new contribution date (receive_date).


- `Amount exc Tax`: Will be calculated automatically based on the following:
A: The current membership line type.
B: The new membership type that we want to switch to.
C: The selected "Switch Date"

The formal is: [The pro-rata amount for the new membership type starting from the switch date to the end of the period, minus The pro-rata amount for the current membership type starting from the switch date to the nd of the period]

in case the current membership amount is higher than the new membership amount, then we default the value to 0, though we might change this once we implement the credit note.

The `Amount exc Tax` despite being calculated automatically if either the "Switch Date" or the "New Membership Type" change, its value can still be overridden manually by the user.

- Financial Type: Will be set automaticly based on the selected "New Membership Type", but can be overridden manually by the user. 

- `Amount inc Tax`: Just a display field and cannot be altered, it is basically the total amount including tax, the tax is calculated using the selected "Financial Type"  in case the Financial Type has a tax account linked to it.

- `Send confirmation email?`:  Allows sending a confirmation email about the newly created contribution.

Here is a demo showing how the mentioned fields interact with each others:

![ezgif-5-3ede72b8bb](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/7726fafe-5883-4229-9126-75a4b57f7ed6)

## Example

Here we are switching one membership from one type to another:
![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/91917516-d63b-4d34-89b8-cfe8f637b850)


Here is the change reflected on the manage instalments screen where the old membership line is removed, and the new membership type is added and auto-renewable:

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/261c5d29-158d-4485-b0d5-cefe214250dd)


Here is the newly created membership with start date = the switch date and end date = the period end date:

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/263a78fe-3fbe-4f44-9037-0e3d82ebab52)

and here is the newly created contribution, the  other contributions are not touched:

![2023-06-23 01_41_51-RO1 RO1 _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/8130d646-3e5e-4007-815e-2003a97cbcc2)





