### PR TITLE
CIWEMB-372: Allow CiviCRM Admin to access Payment Schemes

### DIFF
--- a/xml/Menu/membershipextras.xml
+++ b/xml/Menu/membershipextras.xml
@@ -88,12 +88,12 @@
     <path>civicrm/member/admin/payment-scheme</path>
     <page_callback>CRM_MembershipExtras_Form_PaymentScheme</page_callback>
     <title>Payment Scheme</title>
-    <access_arguments>administer MembershipExtras</access_arguments>
+    <access_arguments>administer CiviCRM;administer MembershipExtras</access_arguments>
   </item>
   <item>
     <path>civicrm/member/admin/payment-schemes</path>
     <page_callback>CRM_MembershipExtras_Page_PaymentScheme</page_callback>
     <title>Payments Schemes</title>
-    <access_arguments>administer MembershipExtras</access_arguments>
+    <access_arguments>administer CiviCRM;administer MembershipExtras</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR allows users with the CiviCRM Admin roles to access "Payment Schemes"
## Before
Authenticated users with the "CiviCRM Admin" role cannot access the "Payment Schemes" page

![Screenshot from 2023-07-17 21-26-42](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/74309109/26f50a83-df16-4147-95d0-581954cca04e)

## After
Authenticated users with the "CiviCRM Admin" role can access the "Payment Schemes" page

[CIWEMB-372-after.webm](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/74309109/4a3ae3c4-6108-4e10-91cd-02313a1f83c1)


## Technical Details
I've altered the "Payment Schemes"  menu item to allow users with the permission "administer CiviCRM" to access the related page: 
```diff
-    <access_arguments>administer MembershipExtras</access_arguments>
+    <access_arguments>administer CiviCRM;administer MembershipExtras</access_arguments>
```
These menu items were created as part of the PRs [#452](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/452/commits/d5a95ccb425be524267560c1306394d98f35954c) and [#453](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/453/commits/404e93e8e73b60ee765ac1716549005db6d16561).