### PR TITLE
CIWEMB-377: Don't allow changing the payment processor

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentScheme.php
+++ b/CRM/MembershipExtras/Form/PaymentScheme.php
@@ -163,9 +163,15 @@ class CRM_MembershipExtras_Form_PaymentScheme extends CRM_Core_Form {
         $paymentProcessors[$gocardlessPaymentProcessors['id']] = $gocardlessPaymentProcessors['name'];
       }
     }
-    $select = ['' => ts('- select -')] + $paymentProcessors;
 
-    $this->add('select', 'payment_processor', ts('Payment Processor'), $select, TRUE);
+    $select = ['' => ts('- select -')] + $paymentProcessors;
+    $required = TRUE;
+    $attributes = [];
+    if ($this->_action == CRM_Core_Action::UPDATE) {
+      $attributes = ['disabled' => TRUE];
+      $required = FALSE;
+    }
+    $this->add('select', 'payment_processor', ts('Payment Processor'), $select, $required, $attributes);
   }
 
   private function isDeleteContext() {


### PR DESCRIPTION
## Overview
This PR updates the edit payment scheme form to not allow users to change the payment processor for a scheme.

## Before
The user can edit the payment processor.
## After
The user cannot edit the payment processor.

[CIWEMB-377-after.webm](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/74309109/a6ade4e9-2a24-426e-9bb2-46bff46b66bc)

## Technical Details
If the user is editing a payment scheme then we make the payment processor field disabled and not required.