### PR TITLE
CIWEMB-433: Prevent extending payment plan memberships when using Payment create API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.3.0-php8.0
+    container: compucorp/civicrm-buildkit:1.3.1-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions

--- a/CRM/MembershipExtras/Hook/Config/APIWrapper/PaymentAPI.php
+++ b/CRM/MembershipExtras/Hook/Config/APIWrapper/PaymentAPI.php
@@ -1,0 +1,25 @@
+<?php
+
+use CRM_MembershipExtras_ExtensionUtil as ExtensionUti;
+
+class CRM_MembershipExtras_Hook_Config_APIWrapper_PaymentAPI {
+
+  /**
+   * Callback precedes Payment.Create API call.
+   *
+   * If the Payment.create API is getting called, then we set `paymentApiCalled`
+   * to True, which we use later in Membership Pre Edit hook to prevent extending
+   * the membership end date.
+   *
+   * See: https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/#migrating-away-from-this-hook
+   */
+  public static function preApiCall($event) {
+    $apiRequestSig = $event->getApiRequestSig();
+    if (!in_array($apiRequestSig, ['3.payment.create', '4.payment.create'])) {
+      return;
+    }
+
+    Civi::$statics[ExtensionUti::LONG_NAME]['paymentApiCalled'] = TRUE;
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -11,6 +11,8 @@ use CRM_MembershipExtras_ExtensionUtil as E;
  */
 function membershipextras_civicrm_config(&$config) {
   _membershipextras_civix_civicrm_config($config);
+
+  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_MembershipExtras_Hook_Config_APIWrapper_PaymentAPI', 'preApiCall']);
 }
 
 /**

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
@@ -118,7 +118,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id'], $paymentType);
     $hook->preProcess();
 
-    $this->assertTrue(!isset($membership['end_date']));
+    $this->assertFalse(array_key_exists('end_date', $membershipParams));
   }
 
   public function testPreventExtendingPaymentPlanMembershipOnRecordingPayment() {
@@ -138,13 +138,13 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $paymentType = 'owed';
 
     $tmpGlobals = [];
-    $tmpGlobals['_REQUEST']['entryURL'] = 'action=add&id=' . $contributions[0]['id'];
+    $tmpGlobals['_REQUEST']['entryURL'] = '?action=add&id=' . $contributions[0]['id'];
     CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
 
     $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL, $paymentType);
     $hook->preProcess();
 
-    $this->assertTrue(!isset($membership['end_date']));
+    $this->assertFalse(array_key_exists('end_date', $membershipParams));
     CRM_Utils_GlobalStack::singleton()->pop();
   }
 
@@ -164,7 +164,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $paymentType = 'owed';
 
     $tmpGlobals = [];
-    $tmpGlobals['_REQUEST']['q'] = 'civicrm/contribute/search';
+    $tmpGlobals['_GET']['q'] = 'civicrm/contribute/search';
     $tmpGlobals['_REQUEST']['_qf_Status_next'] = 'Update Pending Status';
     $tmpGlobals['_REQUEST']['contribution_status_id'] = '1';
     CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
@@ -172,7 +172,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL, $paymentType);
     $hook->preProcess();
 
-    $this->assertTrue(!isset($membership['end_date']));
+    $this->assertFalse(array_key_exists('end_date', $membershipParams));
     CRM_Utils_GlobalStack::singleton()->pop();
   }
 

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculatorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculatorTest.php
@@ -5,6 +5,7 @@ use CRM_MembershipExtras_Service_MembershipTypeDatesCalculator as MembershipType
 use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator as FixedPeriodCalculator;
 use CRM_MembershipExtras_Test_Fabricator_MembershipType as MembershipTypeFabricator;
 use CRM_MembershipExtras_Service_MembershipInstalmentTaxAmountCalculator as MembershipInstalmentTaxAmountCalculator;
+use CRM_MembershipExtras_Service_MoneyUtilities as MoneyUtil;
 
 /**
  * Class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculatorTest
@@ -39,9 +40,9 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
     $calculator = new FixedPeriodCalculator([$membershipType]);
     $calculator->setStartDate($startDate);
     $calculator->calculate();
-    $this->assertEquals($expectedAmount, $calculator->getAmount());
-    $this->assertEquals($expectedTaxAmount, $calculator->getTaxAmount());
-    $this->assertEquals($expectedTotalAmount, $calculator->getTotalAmount());
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedAmount, 2), MoneyUtil::roundToPrecision($calculator->getAmount(), 2));
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedTaxAmount, 2), MoneyUtil::roundToPrecision($calculator->getTaxAmount(), 2));
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedTotalAmount, 2), MoneyUtil::roundToPrecision($calculator->getTotalAmount(), 2));
     $this->assertNotEmpty($calculator->getLineItems());
     $this->assertEquals($diffInMonths, $calculator->getProRatedNumber());
     $this->assertEquals(FixedPeriodCalculator::BY_MONTHS, $calculator->getProRatedUnit());
@@ -66,9 +67,9 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
     $calculator = new FixedPeriodCalculator([$membershipType]);
     $calculator->setStartDate($startDate);
     $calculator->calculate();
-    $this->assertEquals($expectedAmount, $calculator->getAmount());
-    $this->assertEquals($expectedTaxAmount, $calculator->getTaxAmount());
-    $this->assertEquals($expectedTotalAmount, $calculator->getTotalAmount());
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedAmount, 2), MoneyUtil::roundToPrecision($calculator->getAmount(), 2));
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedTaxAmount, 2), MoneyUtil::roundToPrecision($calculator->getTaxAmount(), 2));
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedTotalAmount, 2), MoneyUtil::roundToPrecision($calculator->getTotalAmount(), 2));
     $this->assertNotEmpty($calculator->getLineItems());
     $this->assertEquals($diffInDays, $calculator->getProRatedNumber());
     $this->assertEquals(FixedPeriodCalculator::BY_DAYS, $calculator->getProRatedUnit());
@@ -79,12 +80,6 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
     $membershipType = $this->fabricateMembeshipType(['name' => 'xyz']);
     $this->mockSettings($membershipType->id, ['membership_type_annual_pro_rata_calculation' => FixedPeriodCalculator::BY_DAYS, 'membership_type_annual_pro_rata_skip' => ['M' => 6, 'd' => 2]]);
 
-    $membershipTypeDurationCalculator = new MembershipTypeDurationCalculator($membershipType, new MembershipTypeDatesCalculator());
-    $membershipTypeDurationInDays = $membershipTypeDurationCalculator->calculateOriginalInDays();
-    $diffInDays = $membershipTypeDurationCalculator->calculateDaysBasedOnDates($startDate);
-    $expectedAmount = ($membershipType->minimum_fee / $membershipTypeDurationInDays) * $diffInDays;
-    $expectedTaxAmount = $this->getTaxAmount($membershipType, $expectedAmount);
-    $expectedTotalAmount = $expectedAmount + $expectedTaxAmount;
     $calculator = new FixedPeriodCalculator([$membershipType]);
     $calculator->setStartDate($startDate);
     $calculator->calculate();
@@ -98,12 +93,6 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
     $membershipType = $this->fabricateMembeshipType(['name' => 'xyz']);
     $this->mockSettings($membershipType->id, ['membership_type_annual_pro_rata_calculation' => FixedPeriodCalculator::BY_DAYS, 'membership_type_annual_pro_rata_skip' => ['M' => 6, 'd' => 2]]);
 
-    $membershipTypeDurationCalculator = new MembershipTypeDurationCalculator($membershipType, new MembershipTypeDatesCalculator());
-    $membershipTypeDurationInDays = $membershipTypeDurationCalculator->calculateOriginalInDays();
-    $diffInDays = $membershipTypeDurationCalculator->calculateDaysBasedOnDates($startDate);
-    $expectedAmount = ($membershipType->minimum_fee / $membershipTypeDurationInDays) * $diffInDays;
-    $expectedTaxAmount = $this->getTaxAmount($membershipType, $expectedAmount);
-    $expectedTotalAmount = $expectedAmount + $expectedTaxAmount;
     $calculator = new FixedPeriodCalculator([$membershipType]);
     $calculator->setStartDate($startDate);
     $calculator->calculate();
@@ -126,9 +115,10 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
     $calculator = new FixedPeriodCalculator([$membershipType]);
     $calculator->setStartDate($startDate);
     $calculator->calculate();
-    $this->assertEquals($expectedAmount, $calculator->getAmount());
-    $this->assertEquals($expectedTaxAmount, $calculator->getTaxAmount());
-    $this->assertEquals($expectedTotalAmount, $calculator->getTotalAmount());
+
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedAmount, 2), MoneyUtil::roundToPrecision($calculator->getAmount(), 2));
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedTaxAmount, 2), MoneyUtil::roundToPrecision($calculator->getTaxAmount(), 2));
+    $this->assertEquals(MoneyUtil::roundToPrecision($expectedTotalAmount, 2), MoneyUtil::roundToPrecision($calculator->getTotalAmount(), 2));
   }
 
   protected function fabricateMembeshipType($params = []) {


### PR DESCRIPTION
## Before

The motivation for this PR is that when using the new SSP 'Switch to Direct Debit' button and choosing to pay any outstanding invoice with GoCardless, it results in extending the membership end date:


![CIWEMB-433](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d205115b-f5e6-42d8-9e5c-9540c891a455)


but I found that the problem is actually not limited to this option, but can also happen whenever the Payment.create API is used to pay for any pending contribution that is linked to a membership.


## After

Using the Payment.create API on any pending invoice (contribution) that is linked to a payment plan membership does not result in extending the membership end date, this also includes using the SSP "Switch to Direct Debit" button and then selecting "Pay outstanding invoices" option.

## Technical Details

 GoCardless uses the Payment.create API when using the "Pay outstanding invoices" option after switching the payment plan to direct debit
https://github.com/compucorp/io.compuco.gocardless/blob/6775f7bcaed76f8771d89ec728a6f554c20d3b52/Civi/GoCardless/Service/OneOffPaymentService.php#L153-L168

Now the reason is Payment.create results in extending the membership is that the Payment.create API is designed to update any attached entity that is linked to the payment whether its a membership, participants  ..etc , and given the default Core behavior is to extend the membership when a pending contribution linked to a membership is paid, the Payment.create just follows that.

We previously in Membershipextras added some logic to prevent such behavior for payment plan memberships, given in Membershipextras we might have more than one contribution linked to one membership, for example when paying for a membership using "Monthly" payment plan schedule, 12 pending contributions will be created so keeping the core behavior will result in extending the membership for 12 terms each time one of these pending contributions gets paid (completed), though this logic and before this PR did not work with Payment.create API given we added some conditions on this logic to limit its effect to only  the places we are interested in (such as using the "Record Payment" option on the contribution or using Bulk contribution update), in this PR I extended this logic to include the Payment.create API as well by simply using the API wrappers to set certain flag in the session whenever the Payment.create API is used, and if this Payment.create call results in calling Membership pre Edit hook, then we can tell for sure that this Payment is trying to extend the membership, so we just unset the Membership end date to prevent that.



Additionally I:
-  found out that some of the tests for inside `tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php` are logically wrong (even though they pass), mainly because there were calling this assertion `$this->assertTrue(!isset($membership['end_date']));` on non existing variable `$membership` and that is why these tests always passed, I've updated these assertions to use the correct variable, which ended up showing some more issues that I also fixed.

- Fixed some rounding issues in FixedPeriodTypeCalculator tests (not related to the work here).
