### PR TITLE
CIWEMB-438: Introduce {next_period_year} payment scheme token to allow better configurations

### DIFF
--- a/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGenerator.php
+++ b/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGenerator.php
@@ -146,6 +146,12 @@ class CRM_MembershipExtras_Service_PaymentScheme_PaymentPlanScheduleGenerator {
       $baseChargeDate->modify('+1 day');
       $baseChargeDate = $baseChargeDate->format('Y-m-d');
     }
+    elseif (stripos($baseTime, '{next_period_year}') !== FALSE) {
+      $membershipEndDate = new DateTime($this->scheduleGenerationRawData['max_membership_end_date']);
+      $membershipEndDateYear = $membershipEndDate->format('Y');
+
+      $baseChargeDate = str_replace('{next_period_year}', $membershipEndDateYear, $baseTime);
+    }
     else {
       $baseChargeDate = $baseTime;
     }

--- a/tests/phpunit/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGeneratorTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/PaymentScheme/PaymentPlanScheduleGeneratorTest.php
@@ -140,6 +140,8 @@ class CRM_MembershipExtras_Service_PaymentPlanScheduleGeneratorTest extends Base
   }
 
   public function providerTest() {
+    $nextPeriodYear = date('Y', strtotime('+1 year'));
+
     return [
       [
         // with membership token
@@ -155,6 +157,11 @@ class CRM_MembershipExtras_Service_PaymentPlanScheduleGeneratorTest extends Base
         // with relative date and no added time
         [['charge_date' => date('Y-m-d', strtotime('10 March')), 'amount' => 120], ['charge_date' => date('Y-m-d', strtotime('13 June')), 'amount' => 120]],
         '{"instalments_count": 2,"instalments": [{"charge_date": "10 March"},{"charge_date": "13 June"}]}',
+      ],
+      [
+        // with "next period year" token
+        [['charge_date' => date('Y-m-d', strtotime("1 December {$nextPeriodYear}")), 'amount' => 120], ['charge_date' => date('Y-m-d', strtotime("1 December {$nextPeriodYear} +1 month")), 'amount' => 120]],
+        '{"instalments_count": 2,"instalments": [{"charge_date": "1 December {next_period_year}"},{"charge_date": "1 December {next_period_year}, + 1 month"}]}',
       ],
     ];
   }


### PR DESCRIPTION
## Before

If for example you have a  payment scheme with the following configuration:

`{"instalments_count": 2,"instalments": [{"charge_date": "1 December"},{"charge_date": "1 December, + 1 month"}]}`

And then you:

1- Create an annual membership with the start date = 2nd August 2022, end date = 1st August 2023. 

![1_before](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/f863cad9-5215-4253-b3f2-582947c69bab)


2- Switch the recurring contribution (payment plan) to use Direct Debit with the above payment scheme.
3- Visit  the recurring contribution view page and you will see the following in the “Future payment scheme Instalments”:

![2_before](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/36b5fda5-790e-43f4-9b9a-30529f94906a)

which is all correct given the payment scheme configurations.

4- Run the autorenewal scheduled job (assuming today's date is >= 1st August 2023 or you are using autorenewal in advance setting to renew in advance), two contributions with the dates shown in the “Future payment scheme Instalments” will be created, and the membership end date will get extended by one year to become "1 August 2024", which is correct so far, 


5- Now view the recurring contribution page again, and you will still find the same dates in step 3 instead of showing the new future payment scheme instalment dates which should be:

- 2024-12-01
- 2025-01-01


This happen because as explained in this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/463
we allow the base_time in the  payment scheme to be configured in certain way, which in summary:

1- Using a token, and for now we only support one token which is the period end date: `{next_period_start_date}`.
2- Using a hardcoded date.
3- Using relative date such as the one used in the example above "1 December".

and while of course we can add time (like +1 year, +2 months ..etc) to the base_time, it is still hard to find a configuration given its current capabilities that shows the correct date in the example above.


## After

I decided to introduce new token called `{next_period_year}`, this token is similar to the `{next_period_start_date}` token but instead of being replaced by the next period start date, it only gets replaced by the year part of the next period start date, for example if the next period end date is: 2024-12-31, then:

- `{next_period_start_date}` : will be replaced by `2025-12-31`
- where `{next_period_year}` will be by `2025`

this allows this token to be used with relative dates such as `1 December` (e.g `1 December `{next_period_year}`),  so the payment scheme configuration mentioned above can be replaced with this:

`{"instalments_count": 2,"instalments": [{"charge_date": "1 December {next_period_year}"},{"charge_date": "1 December {next_period_year}, + 1 month"}]}`

which will utilize the year in which the membership will expire (end) (or the period end date in case there are more than one membership) instead of the "Current year", which results in an accurate payment scheme schedule:

![2023-08-01 18_45_24-adsasd dasads _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d16d5a00-b81e-4d17-9bd1-daa627470a3d)

![2023-08-01 18_45_39-adsasd dasads _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/ef31c8c2-2695-4202-bc70-dc1591a64fef)




