### PR TITLE
CIWEMB-439: Respect civicrm default date format when showing future payment schedule

### DIFF
--- a/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
@@ -32,7 +32,12 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
   private function getFuturePaymentSchemeScheduleIfExist($recurId) {
     try {
       $paymentPlanScheduleGenerator = new CRM_MembershipExtras_Service_PaymentScheme_PaymentPlanScheduleGenerator($recurId);
-      return $paymentPlanScheduleGenerator->generateSchedule();
+      $paymentsSchedule = $paymentPlanScheduleGenerator->generateSchedule();
+      array_walk($paymentsSchedule['instalments'], function (&$value) {
+        $value['charge_date'] = CRM_Utils_Date::customFormat($value['charge_date']);
+      });
+
+      return $paymentsSchedule;
     }
     catch (CRM_Extension_Exception $e) {
       return NULL;


### PR DESCRIPTION
## Before

The "Future payment schedule" in the recurring contibution shows dates in "Y-m-d" format.

![2023-08-02 12_23_21-daad dada _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/a9b06a65-54b1-41d3-adbc-095a2b4f2eae)


## After

These dates now show in CiviCRM complete date format: 

![2023-08-02 12_22_57-daad dada _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d252a740-cfe8-43f5-950e-25867393479d)


![2023-08-02 12_23_47-Settings - Date _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/f034dae5-0455-4ab9-be9b-12d7485e8683)
