### PR TITLE
CIWEMB-347: Support for payment cancellation workflow for external (non offline) payment processors

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/Cancel.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/Cancel.php
@@ -13,11 +13,22 @@ class CRM_MembershipExtras_Form_RecurringContribution_Cancel extends CRM_Core_Fo
   private $id;
 
   /**
-   * ID of contact from where contributions is being cancellsd.
+   * The recurring contribution to be cancelled data.
+   * @var array
+   */
+  private $recurContribution;
+
+  /**
+   * ID of contact from where contributions is being cancelled.
    *
    * @var int
    */
   private $contactID;
+
+  /**
+   * @var bool
+   */
+  private $isOfflinePaymentProcessor;
 
   /**
    * @inheritdoc
@@ -25,6 +36,17 @@ class CRM_MembershipExtras_Form_RecurringContribution_Cancel extends CRM_Core_Fo
   public function preProcess() {
     $this->id = CRM_Utils_Request::retrieve('crid', 'Positive', $this);
     $this->contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
+
+    $this->recurContribution = \Civi\Api4\ContributionRecur::get()
+      ->addSelect('payment_processor_id', 'payment_processor_id:name', 'custom.*')
+      ->addWhere('id', '=', $this->id)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+
+    // These two payment processors are special case given they are both are not external payment processors.
+    $isOfflinePaymentProcessor = in_array($this->recurContribution['payment_processor_id:name'], ['Offline Recurring Contribution', 'Direct Debit']);
+    $this->assign('isOfflinePaymentProcessor', $isOfflinePaymentProcessor);
   }
 
   /**
@@ -68,15 +90,45 @@ class CRM_MembershipExtras_Form_RecurringContribution_Cancel extends CRM_Core_Fo
   public function postProcess() {
     $submittedValues = $this->controller->exportValues($this->_name);
 
-    if ($submittedValues['cancel_memberships']) {
-      $this->cancelMemberships();
+    if (!$this->isOfflinePaymentProcessor) {
+      $isProcessedExternallySuccessfully = $this->invokePreRecurContributionCancellationHook();
+      if ($isProcessedExternallySuccessfully === FALSE) {
+        CRM_Core_Session::setStatus(ts('An error occurred while trying to cancel this recurring contribution.'), ts('Cancellation Failed'), 'error');
+        return;
+      }
     }
 
-    if ($submittedValues['cancel_pending_installments']) {
-      $this->cancelPendingInstallments();
-    }
+    $transaction = new CRM_Core_Transaction();
+    try {
+      if ($submittedValues['cancel_memberships']) {
+        $this->cancelMemberships();
+      }
 
-    $this->cancelRecurringContribution();
+      if ($submittedValues['cancel_pending_installments']) {
+        $this->cancelPendingInstallments();
+      }
+
+      $this->cancelRecurringContribution();
+
+      $transaction->commit();
+    }
+    catch (Exception $e) {
+      $transaction->rollback();
+      CRM_Core_Session::setStatus(ts('An error occurred while trying to cancel this recurring contribution: ') . ':' . $e->getMessage(), ts('Cancellation Failed'), 'error');
+    }
+  }
+
+  private function invokePreRecurContributionCancellationHook() {
+    $nullObject = CRM_Utils_Hook::$_nullObject;
+    $isProcessedExternallySuccessfully = FALSE;
+    CRM_Utils_Hook::singleton()->invoke(
+      ['recurContribution', 'isProcessedExternallySuccessfully'],
+      $this->recurContribution, $isProcessedExternallySuccessfully,
+      $nullObject, $nullObject, $nullObject, $nullObject,
+      'membershipextras_preRecurContributionCancellation'
+    );
+
+    return $isProcessedExternallySuccessfully;
   }
 
   /**

--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -72,13 +72,14 @@ class CRM_MembershipExtras_Hook_Links_RecurringContribution {
    */
   public function alterLinks() {
     foreach ($this->links as &$actionLink) {
-      if ($actionLink['name'] == 'Cancel' && $this->isSupportedPaymentPlan()) {
+      $isSupportedPaymentPlan = $this->isSupportedPaymentPlan();
+      if ($actionLink['name'] == 'Cancel' && $isSupportedPaymentPlan) {
         unset($actionLink['ref']);
         $actionLink['url'] = 'civicrm/recurring-contribution/cancel';
         $actionLink['qs'] = 'reset=1&crid=%%crid%%&cid=%%cid%%&context=contribution';
       }
 
-      if ($actionLink['name'] == 'Edit' && $this->isSupportedPaymentPlan()) {
+      if ($actionLink['name'] == 'Edit' && $isSupportedPaymentPlan) {
         $this->mask |= CRM_Core_Action::UPDATE;
       }
     }

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/Cancel.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/Cancel.tpl
@@ -1,8 +1,14 @@
 <div class="crm-block crm-form-block crm-payment-plan-cancel-form-block">
   <div class="messages status no-popup">
+   {if $isOfflinePaymentProcessor}
     <div class="crm-i fa-info-circle"></div>
     WARNING - This action sets the CiviCRM recurring contribution status to cancelled, but does NOT send a cancellation request to the payment processor. You will need to ensure that this recurring payment (subscription) is cancelled by the payment processor.
   </div>
+   {else}
+  <div class="crm-i fa-info-circle"></div>
+  WARNING: Cancelling the payment plan will also cancel any future payments that have not yet been submitted from being taken by the payment processor. Note, that any payments which have already been submitted will continue to process.
+  </div>
+   {/if}
   <p>
     <strong> Are you sure you want to mark this recurring contribution as cancelled? </strong>
   </p>
@@ -23,7 +29,7 @@
         <td>
           {$form.cancel_memberships.html}
         </td>
-      </tr>      
+      </tr>
     </tbody>
   </table>
   <div class="crm-submit-buttons">

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/Cancel.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/Cancel.tpl
@@ -12,6 +12,7 @@
   <p>
     <strong> Are you sure you want to mark this recurring contribution as cancelled? </strong>
   </p>
+  {if $isMembershipextrasPaymentPlan}
   <table class="form-layout-compressed">
     <tbody>
       <tr>
@@ -32,6 +33,7 @@
       </tr>
     </tbody>
   </table>
+  {/if}
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>


### PR DESCRIPTION
## Overview


With the work in this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/462 we now support payment processor extensions to opt in for Membershipextras support, extensions like GoCardless (and Stripe in the future) are examples of such payment processors that will opt for Membershipextras support.

At the moment when the user tries to cancel a recurring contribution, where the recurring contribution uses a payment processor that opted for Membershipextras support, the following screen will appear:

![2](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/835d914d-afac-4c73-8f4f-e4739aff95f2)

which as you can see allow users to decide if they also want to cancel any linked pending instalment (contribution) and/or linked memberships. But with payment processors like GoCardless, it would be important to sync the cancelation on CiviCRM with GoCardless (a one way sync, from Civi to GoCardless for now).

To allow that, I've updated the current form above so:

1- If we are cancelling a recurring contribution that is linked to any payment processor other than `Offline Recurring Contribution` or `Direct Debit` (the one added by Manual Direct debit extension), which are both offline type of payment processors, then a a slightly different warning message will appear to indicate that external payments and mandate will also be cancelled by this action:

![3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/15347ac9-3423-437a-b9b2-a34d4a8b82fc)


2- And then I invoke a hook with the following signature : 

```
function hook_membershipextras_preRecurContributionCancellation($recurContribution, $isMembershipextrasPaymentPlan, $isProcessedExternallySuccessfully) {

}
```

extensions like GoCardless should implement this extension so it can call GoCardless API to cancel the relevant mandate and payments, the parameters passed in the above hook are:

 - `$recurContribution`: The recurring contribution to be cancelled, contains the following data: 

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/9a7bf897-3f30-43c3-9433-ac5edd522122)

- ` $isMembershipextrasPaymentPlan`: Will be True if the recurring contribution is a one created by Membershipextras (using the Membership form or Webforms), and will be False if created using other methods, such as using CiviCRM Contribution Pages, More on this below.
- `$isProcessedExternallySuccessfully`: By default set to False, it is the payment processor that implements this hook responsibility to either keep this value as False if it failed to cancel things on payment processor platform, or to set it to True if it was able to. Membershipextras will read the value of this variable and either show an error message if the value of this field is False, or if it is value is True then it will cancel the recurring contribution and any linked pending instalment or membership if the user chose to cancel them.

It also the responsibility of the payment processor extension to check if the payment processor of the recurring contribution `$recurContribution['payment_processor_id:name']` (or `$recurContribution['payment_processor_id']`) matches the payment processor of the extension itself, e.g:

```
function gocardless_membershipextras_preRecurContributionCancellation($recurContribution, $isMembershipextrasPaymentPlan, $isProcessedExternallySuccessfully) {

if (!$recurContribution['payment_processor_id:name'] == CRM_GoCardless_Helper_PaymentProcessorConstant::PAYMENT_PROCESSOR_NAME) {
// the payment processor of the recurring contribution we want to cancel is not GoCardless, so don't do anything.
return;
}

// do things here
}
```

to prevent multiple payment processor extensions from trying to process the same recurring contribution.



We also had to differentiate between two other kinds of recurring contributions, ones that are created by Membershipextras, and others that are created by different means such as Contribution Pages, the latter does not make use of any Membershipextras features, and if it is uses a payment processor such as GoCardless, then the subscription will be mostly managed on GoCardless platform itself, thus we are hiding options like "Cancel Pending Contributions" and "Cancel Memberships" for such type of recurring contributions:

![2023-08-04 19_43_25-bbadsdasasd@adad com _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/6cd3ba7b-0580-497d-94fd-1204feb42145)

Extensions that implement this hook can tell the difference between the two by looking at ` $isMembershipextrasPaymentPlan` value that is passed by the hook and then they can decide what kind of action they want to make. The way in which I set the value of this field to either True or False is by looking into the recurring contribution `is_active` field which we added long ago in this PR (https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/355), if this field value is NULL then it is a recurring contribution that is not created by Membershipextras, given Membershipextra  recurring contributions should have this value either set to True or False.



