### PR TITLE
CIWEMB-438: Show future payment schedule for active payment plans only

### DIFF
--- a/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
@@ -31,6 +31,10 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
 
   private function getFuturePaymentSchemeScheduleIfExist($recurId) {
     try {
+      if (!$this->isActivePaymentPlan($recurId)) {
+        return NULL;
+      }
+
       $paymentPlanScheduleGenerator = new CRM_MembershipExtras_Service_PaymentScheme_PaymentPlanScheduleGenerator($recurId);
       $paymentsSchedule = $paymentPlanScheduleGenerator->generateSchedule();
       array_walk($paymentsSchedule['instalments'], function (&$value) {
@@ -42,6 +46,14 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
     catch (CRM_Extension_Exception $e) {
       return NULL;
     }
+  }
+
+  private function isActivePaymentPlan($recurId) {
+    return \Civi\Api4\ContributionRecur::get()
+      ->addSelect('payment_plan_extra_attributes.is_active')
+      ->addWhere('id', '=', $recurId)
+      ->execute()
+      ->column('payment_plan_extra_attributes.is_active')[0];
   }
 
 }


### PR DESCRIPTION
## Before

"Future payment scheme schedule" shows for both active and non active payment plans, but it make no sense for it to appear on non active payments given they are no longer in use, so there is not "future schedule" for them.

![11111](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/5ddfdc19-b3b8-4ca8-9f04-e4bd4f15397a)



## After

The "Future payment scheme schedule" no longer appears for inactive payment plans:
![dsadsdsadsa](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/82f40ff4-7874-4d03-bc21-b84a5ee8a1f4)

