### PR TITLE
CIWEMB-389: Reword the frequency column for payment scheme recurring contributions

### DIFF
--- a/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
@@ -1,0 +1,61 @@
+<?php
+
+class CRM_MembershipExtras_Hook_PageRun_ContributionTab implements CRM_MembershipExtras_Hook_PageRun_PageRunInterface {
+
+  private $page;
+
+  /**
+   * @param CRM_Core_Page $page
+   */
+  public function handle($page) {
+    $this->page = $page;
+    $this->improveFrequencyColumnWordingForPaymentSchemeRecurringContributions();
+  }
+
+  /**
+   * The values under the frequency column in the
+   * recurring contribution tab are not relevant for
+   * recurring contributions that are linked to payment
+   * schemes, so we alter the wording to indicate that
+   * it uses a payment scheme.
+   *
+   * @return void
+   */
+  private function improveFrequencyColumnWordingForPaymentSchemeRecurringContributions() {
+    $rowTypes = ['activeRecurRows', 'inactiveRecurRows'];
+    foreach ($rowTypes as $rowType) {
+      $tplVarName = $rowType . 'PaymentSchemeField';
+
+      $recurRows = $this->page->get_template_vars($rowType);
+      $recurIds = [];
+      foreach ($recurRows as $recurRow) {
+        $recurIds[] = $recurRow['id'];
+      }
+
+      if (empty($recurIds)) {
+        $this->page->assign($tplVarName, '[]');
+        continue;
+      }
+
+      $recurRowsPaymentSchemeField = $this->getRecurringContributionsPaymentSchemeFieldInSameInputOrder($recurIds);
+      $this->page->assign($tplVarName, json_encode($recurRowsPaymentSchemeField));
+    }
+  }
+
+  private function getRecurringContributionsPaymentSchemeFieldInSameInputOrder($recurIds) {
+    $paymentSchemeValues = \Civi\Api4\ContributionRecur::get()
+      ->addSelect('payment_plan_extra_attributes.payment_scheme_id')
+      ->addWhere('id', 'IN', $recurIds)
+      ->execute()
+      ->indexBy('id')
+      ->getArrayCopy();
+
+    $resultInSameInputOrder = [];
+    foreach ($recurIds as $recurId) {
+      $resultInSameInputOrder[] = $paymentSchemeValues[$recurId]['payment_plan_extra_attributes.payment_scheme_id'];
+    }
+
+    return $resultInSameInputOrder;
+  }
+
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -315,6 +315,11 @@ function membershipextras_civicrm_pageRun($page) {
     $recurViewPage = new CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage();
     $recurViewPage->handle($page);
   }
+
+  if ($page instanceof CRM_Contribute_Page_Tab) {
+    $hook = new CRM_MembershipExtras_Hook_PageRun_ContributionTab();
+    $hook->handle($page);
+  }
 }
 
 /**

--- a/templates/CRM/Contribute/Page/Tab.extra.tpl
+++ b/templates/CRM/Contribute/Page/Tab.extra.tpl
@@ -1,0 +1,22 @@
+<script type="text/javascript">
+var activeRecurRowsPaymentSchemeField= {$activeRecurRowsPaymentSchemeField};
+var inactiveRecurRowsPaymentSchemeField = {$inactiveRecurRowsPaymentSchemeField};
+
+{literal}
+(function($) {
+  // we look for the columns with the word "Every" which is hardcoded inside the
+  // recurring contribution tab frequency column.
+  $('.crm-contact-contribute-recur-active tr td:contains("Every")').each(function(index, el) {
+    if (activeRecurRowsPaymentSchemeField[index]) {
+      $(el).text('~ Payment Scheme ~');
+    }
+  });
+
+  $('.crm-contact-contribute-recur-inactive tr td:contains("Every")').each(function(index, el) {
+    if (inactiveRecurRowsPaymentSchemeField[index]) {
+      $(el).text('~ Payment Scheme ~');
+    }
+  });
+})(CRM.$);
+{/literal}
+</script>


### PR DESCRIPTION
## Before

In this previous PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/473 I improved the recurring contribution view page for recurring contributions that uses payment schemes, so they no longer show unnecessary information such as the "Frequency" and the "Cycle Day", though on the recurring contribution tab the "Frequency" tab still shows the frequency information for such recurring contributions.


![2023-08-08 19_02_21-gfsfd dfssd _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/8913ca73-a61a-40b5-9886-5a0c2a9bf5a1)


## After

For any recurring contribution linked to a payment scheme, I now replace the frequency information with the following: `~ Payment Scheme ~` to indicate that this recurring contribution uses a payment scheme.

![2023-08-08 18_49_33-gfsfd dfssd _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/d3fe219c-b72c-4884-a11f-321818907d80)

![2023-08-08 18_51_28-fdfdsfds fdsfsd _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/f6e94c4c-3639-45e9-99aa-f3deef9c68fe)

![2023-08-08 18_51_51-fdfdsfds fdsfsd _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/333c09b9-076b-4e28-be16-41c1fcfcca51)



## Technical Details


The recurring contribution tab is part of the contribution tab and loads with it, so I: 
1- Implemented the `pageRun` hook on the contribution tab.
2 - And from the existing template variables I fetch the contact's active and inactive recurring contributions (Civi core stores each in one variable).
3 - And then with a single API call for each I fetch the payment scheme id for these recurring contributions (in case there is any) and store them in new template variable.
4 - Then I use the CiviCRM `.extra.tpl` feature to append new template to the contribution tab, this template contains JS code that reads the values from step 3, and then goes through each frequency column (I can tell that by looking if the column contains the word "Every" which is hardcoded inside the recurring contribution tab template in Civi core) , and then I check if that frequency column belongs to a recurring contribution that is linked to a payment scheme, and if so I replace the value of this column with `~ Payment Scheme ~`.
- Hence that I fetch the payment scheme ids for the recurring contributions in the same order CiviCRM core shows them in the recurring contribution tab, so there is no need to index the payment scheme ids by their recurring contribution ids and then check for the id in the JS code.
