### PR TITLE
CIWEMB-452: Fix editing payment scheme recurring contributions

### DIFF
--- a/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
@@ -54,6 +54,10 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
    * Validates the subscription form submission
    */
   public function validate() {
+    if (empty($this->recurringContribution['frequency_unit'])) {
+      return;
+    }
+
     $this->validateCycleDay();
     $this->validateNextContributionDate();
   }


### PR DESCRIPTION
## Before

1- Recurring an annual recurring contribution.
2- Use SSP to switch it to use GoCardless Direct debit payment processor.

3- Go to the recurring contribution tab on Civi and try to edit the recurring contribution above.

4- try to click on “Submit” and the form will keep loading indefinitely. 

![dsadasdasa](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/1669d27d-62bc-42ba-9912-a4a900be2c61)



## After
Payment scheme recurring contribution can be edited normally:

![44444](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/f3a38be9-f37c-437c-8f4d-64f9dac33f59)



## Technical Details

We use this API end point in the Automateddirectdebit extension:  https://github.com/compucorp/io.compuco.automateddirectdebit/blob/8e2c6699c8eddaa5021cda9c2ad320a54ba9fbc6/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php#L60 to switch the recurring contribution from annual to the selected payment scheme, and as part of that we set several unnecessary fields to NULL including the `frequency_interval` field: 
https://github.com/compucorp/io.compuco.automateddirectdebit/blob/8e2c6699c8eddaa5021cda9c2ad320a54ba9fbc6/Civi/Api4/Action/AutoDirectDebitPaymentPlan/SwitchToDirectDebitPaymentScheme.php#L75

Here in Membershipextras we have a validation code that validates if the Cycle day is set to a reasonable value when the recurring contribution is being edited, and this code relies on the `frequency_interval` value, but given it is set to NULL after switching the recurring contribution to a payment scheme, the validation code will fails and throw the following error:

```
evlocal-php-2      | Aug  9 14:04:30 php dev_localhost:8020-drupal: 1691586270|172.19.0.1|http://dev.localhost:8020|php|http://dev.localhost:8020/civicrm/contribute/updaterecur?action=update&crid=16&cid=2&context=contribution&snippet=json%7Chttp://dev.localhost:8020/civicrm/contact/view?reset=1&selectedChild=recurring&cid=2%7C1%7C%7CTypeError: CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription::validateNextContributionDateIsNotLeapYear(): Argument #2 ($frequency) must be of type string, null given, called in /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php on line 74 in CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription->validateNextContributionDateIsNotLeapYear() (line 78 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/uk.co.compucorp.membershipextras/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php)
```

Given the Cycle day is not an important field for recurring contributions that are linked to payment schemes anyway, Here I just skip this cycle day validation if the  `frequency_interval`  is not set.