### PR TITLE
FOSFA-212: Prevent creating of renewal activity when membership date is not extended

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -50,6 +50,13 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    */
   private static $extendedMemberships = [];
 
+  /**
+   * The membership activity status
+   *
+   * @var string
+   */
+  private $membershipActivityStatus;
+
   public function __construct($id, &$params, $contributionID, $paymentType) {
     $this->id = $id;
     $this->params = &$params;
@@ -154,7 +161,23 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
   public function preventExtendingPaymentPlanMembership() {
     if ($this->isOfflinePaymentPlanMembership()) {
       unset($this->params['end_date']);
+      $this->preventCreatingRenewalActivity();
     }
+  }
+
+  /**
+   * Prevents creating membership renew activity.
+   *
+   * If we are not extending the payment plan membership
+   * we should also prevent CiviCRM from
+   * creating renewal activity.
+   */
+  public function preventCreatingRenewalActivity() {
+    if (isset($this->params['membership_activity_status'])) {
+      $this->membershipActivityStatus = $this->params['membership_activity_status'];
+      unset($this->params['membership_activity_status']);
+    }
+
   }
 
   /**
@@ -319,6 +342,9 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
     }
 
     $this->params['end_date'] = MembershipEndDateCalculator::calculate($this->id);
+    if ($this->membershipActivityStatus) {
+      $this->params['membership_activity_status'] = $this->membershipActivityStatus;
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
In this PR we prevent CiviCRM from creating a new renewal activity when a payment is made for a payment plan membership instalment.

## Before
Renewal activity is created after recording payment for a payment plan membership instalment.
![aasas22](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/85277674/7a1b8e77-0041-4ae8-8c76-176f863ffa13)


## After
Renewal activity is not created after recording payment for a payment plan membership instalment.
![aasasasas](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/85277674/50808e6b-3025-48ed-9713-8d07f2a96398)


## Technical Details
When a membership linked to a pending contribution is completed, it extends the end date of the membership by one term and creates a new renewal activity. However, for memberships paid using an instalment plan, the date should not be extended when any instalment is paid and no renewal activity should be created.

This section of the code already prevents extending the membership end date.
https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/f3b9fee6e345ee9e9991aeb600870d8ae808f8fe/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php#L143-L154

In this PR we also prevent the membership renewal activity from being created if the membership end date is not extended.
https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/b7361ecc70d5383dc320046943bf49add8942bc0/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php#L168-L175
