### PR TITLE
CIWEMB-389: Reword the frequency column under membership view page for payment scheme recurring contributions

### DIFF
--- a/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
@@ -22,7 +22,11 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionTab implements CRM_Membershi
    * @return void
    */
   private function improveFrequencyColumnWordingForPaymentSchemeRecurringContributions() {
-    $rowTypes = ['activeRecurRows', 'inactiveRecurRows'];
+    // `activeRecurRows` and `inactiveRecurRows` are the template variable names that
+    // contain the list of recurring contributions on the recurring contribution tab.
+    // while `recurRows` contains the list of recurring contributions on the membership
+    // view page under the recurring contribution section.
+    $rowTypes = ['activeRecurRows', 'inactiveRecurRows', 'recurRows'];
     foreach ($rowTypes as $rowType) {
       $tplVarName = $rowType . 'PaymentSchemeField';
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -316,7 +316,7 @@ function membershipextras_civicrm_pageRun($page) {
     $recurViewPage->handle($page);
   }
 
-  if ($page instanceof CRM_Contribute_Page_Tab) {
+  if ($page instanceof CRM_Contribute_Page_Tab || $page instanceof CRM_Member_Page_RecurringContributions) {
     $hook = new CRM_MembershipExtras_Hook_PageRun_ContributionTab();
     $hook->handle($page);
   }

--- a/templates/CRM/Member/Page/RecurringContributions.extra.tpl
+++ b/templates/CRM/Member/Page/RecurringContributions.extra.tpl
@@ -1,0 +1,15 @@
+<script type="text/javascript">
+var recurRowsPaymentSchemeField= {$recurRowsPaymentSchemeField};
+
+{literal}
+(function($) {
+  // we look for the columns with the word "Every" which is hardcoded inside the
+  // frequency column under the recurring contribution list page.
+  $('#membership-recurring-contributions table tr td:contains("Every")').each(function(index, el) {
+    if (recurRowsPaymentSchemeField[index]) {
+      $(el).text('~ Payment Scheme ~');
+    }
+  });
+})(CRM.$);
+{/literal}
+</script>


### PR DESCRIPTION
## Overview

A follow up for this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/492, where there I update the frequency column for recurring contributions that are linked to payment scheme under the recurring contributions tab, here I update the frequency column for such recurring contribution under the membership view as well.

## Before

![2023-09-04 17_08_49-fssasa sasad _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/8b2fc0b7-43e3-4c22-abef-ca508ca17764)


## After



![2023-09-04 17_08_16-fssasa sasad _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/0eb16734-d885-447d-80fc-53814d778575)