### PR TITLE
CIWEMB-476: Usability improvements to the "manage instalments" forms

### DIFF
--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddDonationLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddDonationLineItem.tpl
@@ -1,6 +1,10 @@
 <script type="text/javascript">
   {literal}
   CRM.$(function () {
+    CRM.$('form').submit(function() {
+      CRM.$(".ui-dialog-buttonset button, .crm-submit-buttons button").prop('disabled',true);
+    });
+
     CRM.$('#adjust_first_amount').click(function() {
       if(this.checked) {
         CRM.$('#amount_container').css('display', 'inline');

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.tpl
@@ -1,6 +1,10 @@
 <script type="text/javascript">
   {literal}
   CRM.$(function () {
+    CRM.$('form').submit(function() {
+      CRM.$(".ui-dialog-buttonset button, .crm-submit-buttons button").prop('disabled',true);
+    });
+
     CRM.$('#adjust_first_amount').click(function() {
       if(this.checked) {
         CRM.$('#amount_container').css('display', 'inline');

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.tpl
@@ -2,6 +2,16 @@
   {ts}As there are no future instalments in this period, you can create a single one off future payment.{/ts}
 </p>
 
+<script type="text/javascript">
+{literal}
+  CRM.$(function () {
+    CRM.$('form').submit(function() {
+      CRM.$(".ui-dialog-buttonset button, .crm-submit-buttons button").prop('disabled',true);
+    });
+  });
+{/literal}
+</script>
+
 <div class="crm-section">
   <table id="payment_details_form_container" class="form-layout-compressed">
     <tbody>

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.tpl
@@ -1,6 +1,10 @@
 <script type="text/javascript">
   {literal}
   CRM.$(function () {
+    CRM.$('form').submit(function() {
+      CRM.$(".ui-dialog-buttonset button, .crm-submit-buttons button").prop('disabled',true);
+    });
+
     CRM.$('#payment_details_form_container').css('display', 'none');
 
     var amountExcTax = CRM.$('input[name=amount_exc_tax]').val();

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.tpl
@@ -5,7 +5,10 @@
       CRM.$(".ui-dialog-buttonset button, .crm-submit-buttons button").prop('disabled',true);
     });
 
-    CRM.$('#payment_details_form_container').css('display', 'none');
+    var checkedVal = CRM.$('input[type=radio][name=payment_type]:checked').val()
+    if (checkedVal != 2) {
+      CRM.$('#payment_details_form_container').css('display', 'none');
+    }
 
     var amountExcTax = CRM.$('input[name=amount_exc_tax]').val();
     var financialTypeId = CRM.$('select[name=noinstalmentline_financial_type_id]').val();

--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.tpl
@@ -2,7 +2,11 @@
     {literal}
     CRM.$(function () {
       var currentMembershipTypeId = {/literal}{$current_membership_type_id}{literal};
-      CRM.$('#payment_details_form_container').css('display', 'none');
+
+      var checkedVal = CRM.$('input[type=radio][name=payment_type]:checked').val()
+      if (checkedVal != 2) {
+        CRM.$('#payment_details_form_container').css('display', 'none');
+      }
 
       CRM.$('input[type=radio][name=payment_type]').change(function() {
         if (this.value == 1) {


### PR DESCRIPTION
## Before

# Issue 1

When trying to add a line item through the manage instalments screen, and after clicking "Apply", the "Apply" button will remain enabled until the form is fully submitted, which might lead to users clicking on it twice or more by mistake, which may result in multiple submissions. 

![1before](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/c0966603-3cc6-40ff-add5-ba9aae915d5f)


# Issue 2

When trying to add a line item through the manage instalments screen or if you are using the "Switch membership type" option, and if you select a "one-off payment" option and entered a non numeric value, then the payment form will disappear and nothing will happen:

![2before](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/b63c2948-1c73-4ceb-b8a6-f42e7a68efa9)


## After

# Issue 1

The "Apply" button will be disabled after the user clicks on, and so preventing multi submissions:
![1after](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/f0573ab4-91be-4ab1-95ee-d198d1c6f0a8)


# Issue 2

Entering non numeric value in the amount field will show the validation error properly. 
![2after](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/5bca094d-a439-48c0-a121-7416a2c7fd1a)
