### PR TITLE
CIWEMB-475: Update manage instalment screen notification messages

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsDonationLineItem.php
@@ -174,7 +174,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsDonationLi
 
   private function showOnSuccessNotifications() {
     CRM_Core_Session::setStatus(
-      ts('The line item has been added.'),
+      ts('The line item has been added to payment plan and a payment has been created successfully.'),
       ts('Adding line item'),
       'success'
     );
@@ -182,7 +182,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsDonationLi
 
   private function showErrorNotification(Exception $e) {
     CRM_Core_Session::setStatus(
-      ts('An error occurred while trying to add the line item') . ':' . $e->getMessage(),
+      ts('The line item could not be added to the payment plan. Error reason:') . $e->getMessage(),
       ts('Error Adding Line item'),
       'error'
     );

--- a/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
@@ -279,8 +279,13 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembership
   }
 
   private function showOnSuccessNotifications() {
+    $message = 'The membership has been added to payment plan and a payment has been created successfully.';
+    if ($this->submittedValues['payment_type'] == self::PAYMENT_TYPE_NO_PAYMENT) {
+      $message = 'The membership has been added to payment plan but no payment has been created.';
+    }
+
     CRM_Core_Session::setStatus(
-      $this->membershipType->name . ' ' . ts('has been added.'),
+      ts($message),
       ts('Add') . ' ' . $this->membershipType->name,
       'success'
     );
@@ -288,7 +293,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembership
 
   private function showErrorNotification(Exception $e) {
     CRM_Core_Session::setStatus(
-      ts('An error occurred while trying to add') . ' ' . $this->membershipType->name . ':' . $e->getMessage(),
+      ts('The membership could not be added to the payment plan. Error reason:') . $e->getMessage(),
       ts('Error Adding') . $this->membershipType->name,
       'error'
     );


### PR DESCRIPTION
## Overview

This updates the some of the notification messages that appear when we add line items through the manage instalments form, so they match the ones mentioned in our specs document on Confluence, these messages are:

- When adding membership line item and selecting "No Payment" option, then it should show: 
`The membership has been added to payment plan but no payment has been created.`

- When adding membership line item and selecting "On-off Payment" option, then it should show: 
`The membership has been added to payment plan and a payment has been created successfully`

- When adding membership line item and an error occur then  it should:
`The membership could not be added to the payment plan. Error reason: ERROR_REASON_GOES_HERE`

- When adding a non membership line item then it should show:
`The line item has been added to payment plan and a payment has been created successfully.`

- When adding a non membership line item and an error occur then  it should:
`The line item could not be added to the payment plan. Error reason: ERROR_REASON_GOES_HERE`
