### PR TITLE
CIWEMB-488: Make the manage instalments form usable if the user cancels membership switching

### DIFF
--- a/js/CurrentPeriodLineItemHandler.js
+++ b/js/CurrentPeriodLineItemHandler.js
@@ -596,7 +596,11 @@ CRM.RecurringContribution.CurrentPeriodLineItemHandler = (function($) {
 
     CRM.loadForm(formUrl, {
       dialog: {width: 1040, height: 0}
-    }).on('crmFormSuccess', function () {
+    })
+      .on('crmBeforeLoad', function () {
+        that.currentTab.unblock();
+      })
+      .on('crmFormSuccess', function () {
       createActivity('Update Payment Plan Current Period', 'update_payment_plan_current_period');
       CRM.refreshParent('#periodsContainer');
     });


### PR DESCRIPTION
## Before

If you are on the membership switching form, and then decided to close the form (modal) without changing anything, the manage instalment screen will be stuck showing a loading screen:
![before](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/0c4671cb-f5c1-4431-92d6-6e470ecb3007)


## After

Closing the membership switching no longer blocks the manage instalments screen:
![after](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/81b80293-eff3-4081-b870-01c2c9982084)

