### PR TITLE
CIWEMB-510: Refresh the contribution and the membership tabs when closing the manage instalments form

### DIFF
--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -1,10 +1,18 @@
 <div id="periodsContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
   <script type="text/javascript">
     {literal}
+    // expand the manage instalments modal to take the whole screen.
     CRM.$('.crm-dialog-titlebar-resize:visible').click();
 
     var selectedTab = CRM.$('#periodsContainer').closest('.ui-dialog-content').data('selectedTab') || 'current';
     CRM.$(function($) {
+      // refresh the contribution and the membership tabs when closing the
+      // manage instalments form.
+      $('.ui-dialog-titlebar-close[title|="Close"]').click(function (e) {
+        CRM.tabHeader.resetTab('#tab_contribute');
+        CRM.tabHeader.resetTab('#tab_member');
+      });
+
       $('#tab_current').click(function () {
         window.CompucorpMembershipExtras_selectedTab = 'current';
       });


### PR DESCRIPTION

## Before

When doing some actions on the manage  instalments form, such as switching the membership type, the user will have to refresh the whole contact page manually to able to see the update contribution(s) and membership(s):

![before](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/65b64458-6d6d-46d6-a62a-6cb515ec5a91)

## After

The Memberships and the Contributions tabs are now refreshed automatically when the user closes the manage instalments form:

![after](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/231e15cd-fff2-4316-8921-c40d8d6e6bde)

