### PR TITLE
CIWEMB-491: Replace the membership status calculation error message with more readable content

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddMembershipLineItem.php
@@ -51,7 +51,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
    */
   protected function showOnSuccessNotifications() {
     CRM_Core_Session::setStatus(
-      "{$this->membershipType['name']} has been added to the active order.",
+      "The membership has been added to payment plan successfully.",
       "Add {$this->membershipType['name']}",
       'success'
     );
@@ -69,11 +69,27 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddMembershipLineItem exte
    * @inheritdoc
    */
   protected function showErrorNotification(Exception $e) {
+    $errorMessage = $e->getMessage();
+    $this->replaceExceptionMessagesWithHumanReadableContent($errorMessage);
     CRM_Core_Session::setStatus(
-      "An error ocurred trying to add {$this->membershipType['name']} to the current recurring contribution: " . $e->getMessage(),
+      ts('The membership could not be added to the payment plan. Error reason: ') . $errorMessage,
       "Error Adding {$this->membershipType['name']}",
       'error'
     );
+  }
+
+  /**
+   * Replaces some of the exception messages thrown
+   * when submitting this form with more readable
+   * content.
+   *
+   * @param string $errorMessage
+   * @return void
+   */
+  private function replaceExceptionMessagesWithHumanReadableContent(&$errorMessage) {
+    if (strpos($errorMessage, 'The membership cannot be saved because the status cannot be calculated') !== FALSE) {
+      $errorMessage = 'There is no valid membership status available for the given membership dates.';
+    }
   }
 
   /**

--- a/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/AddNoInstalmentsMembershipLineItem.php
@@ -292,11 +292,27 @@ class CRM_MembershipExtras_Form_RecurringContribution_AddNoInstalmentsMembership
   }
 
   private function showErrorNotification(Exception $e) {
+    $errorMessage = $e->getMessage();
+    $this->replaceExceptionMessagesWithHumanReadableContent($errorMessage);
     CRM_Core_Session::setStatus(
-      ts('The membership could not be added to the payment plan. Error reason:') . $e->getMessage(),
+      ts('The membership could not be added to the payment plan. Error reason: ') . $errorMessage,
       ts('Error Adding') . $this->membershipType->name,
       'error'
     );
+  }
+
+  /**
+   * Replaces some of the exception messages thrown
+   * when submitting this form with more readable
+   * content.
+   *
+   * @param string $errorMessage
+   * @return void
+   */
+  private function replaceExceptionMessagesWithHumanReadableContent(&$errorMessage) {
+    if (strpos($errorMessage, 'The membership cannot be saved because the status cannot be calculated') !== FALSE) {
+      $errorMessage = 'There is no valid membership status available for the given membership dates.';
+    }
   }
 
 }


### PR DESCRIPTION
## Before

When the statuses "Current Renewed" and "Future Start" are disabled, if you try to add a membership line item with future date the following error will appear:

![2023-09-28 11_49_12-sasda dsadsa _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/0b6b6bc0-6c7a-4813-aa26-8bf3c1dfc600)

Which as you can see is not that great and shows the dates in not very readable format.

## After


The error message that appear after trying to add a membership line with future date is improved:

![2023-09-28 11_52_08-sasda dsadsa _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/7fca5e2f-7db9-4d6f-8658-b3c70ec9b663)



## Technical details

In the manage instalment screen we catch exceptions that comes from Civi core and show it in the error notification as is, which is fine most of the time given most of the messages are readable, but given it is not the case with the status calculation message, I here search the exception message to check if it is really the status calculation message, and if so I replace its content with the improved wording.
