### PR TITLE
CIWEMB-490: Make the 'days to renew in advance' field accepts integers only

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentPlanSettings.php
+++ b/CRM/MembershipExtras/Form/PaymentPlanSettings.php
@@ -115,11 +115,12 @@ class CRM_MembershipExtras_Form_PaymentPlanSettings extends CRM_Core_Form {
    * @param array $field
    */
   private function addSettingField($field) {
+    $attributes = $field['attributes'] ?? '';
     $this->add(
       $field['html_type'],
       $field['name'],
       ts($field['title']),
-      '',
+      $attributes,
       $field['is_required']
     );
   }

--- a/settings/PaymentPlan.setting.php
+++ b/settings/PaymentPlan.setting.php
@@ -39,7 +39,7 @@ return [
     'quick_form_type' => 'Element',
     'add' => '4.7',
     'title' => 'Days to renew in advance',
-    'html_type' => 'text',
+    'html_type' => 'number',
     'is_required' => FALSE,
     'description' => 'Number of days in advance of membership end date should an offline auto-renew membership get renewed.',
     'help_text' => 'Number of days in advance of membership end date should an offline auto-renew membership get renewed.',


### PR DESCRIPTION
## Before

The "days to renew in advance" field is a text field that accepts any alphanumeric string where it should only accepts integers: 
![before](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/658cab50-9019-425f-9024-1129481a14a8)


## After

The "days to renew in advance" field only accepts integers:
![after](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/5e4edffe-8f93-4434-b33f-f8b485793293)


## Technical details

The 2nd commit in this PR allow adding extra attributes to setting fields, which is needed for this: https://github.com/compucorp/io.compuco.automateddirectdebit/pull/14 to work.
