### PR TITLE
CIWEMB-389: Fix payment scheme UI support for non admin users

### DIFF
--- a/CRM/MembershipExtras/BAO/PaymentScheme.php
+++ b/CRM/MembershipExtras/BAO/PaymentScheme.php
@@ -49,7 +49,7 @@ class CRM_MembershipExtras_BAO_PaymentScheme extends CRM_MembershipExtras_DAO_Pa
    *   is linked to any recurring contribution.
    */
   public static function deleteByID($id) {
-    $contributionRecursCount = \Civi\Api4\ContributionRecur::get()
+    $contributionRecursCount = \Civi\Api4\ContributionRecur::get(FALSE)
       ->selectRowCount()
       ->addWhere('payment_plan_extra_attributes.payment_scheme_id', '=', $id)
       ->execute()->count();

--- a/CRM/MembershipExtras/Form/RecurringContribution/Cancel.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/Cancel.php
@@ -42,7 +42,7 @@ class CRM_MembershipExtras_Form_RecurringContribution_Cancel extends CRM_Core_Fo
     $this->id = CRM_Utils_Request::retrieve('crid', 'Positive', $this);
     $this->contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
-    $this->recurContribution = \Civi\Api4\ContributionRecur::get()
+    $this->recurContribution = \Civi\Api4\ContributionRecur::get(FALSE)
       ->addSelect('payment_processor_id', 'payment_processor_id:name', 'custom.*')
       ->addWhere('id', '=', $this->id)
       ->addOrderBy('id', 'DESC')

--- a/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
@@ -49,7 +49,7 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
   }
 
   private function isActivePaymentPlan($recurId) {
-    return \Civi\Api4\ContributionRecur::get()
+    return \Civi\Api4\ContributionRecur::get(FALSE)
       ->addSelect('payment_plan_extra_attributes.is_active')
       ->addWhere('id', '=', $recurId)
       ->execute()

--- a/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
@@ -47,7 +47,7 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionTab implements CRM_Membershi
   }
 
   private function getRecurringContributionsPaymentSchemeFieldInSameInputOrder($recurIds) {
-    $paymentSchemeValues = \Civi\Api4\ContributionRecur::get()
+    $paymentSchemeValues = \Civi\Api4\ContributionRecur::get(FALSE)
       ->addSelect('payment_plan_extra_attributes.payment_scheme_id')
       ->addWhere('id', 'IN', $recurIds)
       ->execute()

--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentSchemePlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/PaymentSchemePlan.php
@@ -344,7 +344,7 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_PaymentSchemePlan extends CRM_
   }
 
   private function getPaymentPlanContributionsForPaymentSchemeHook() {
-    return \Civi\Api4\Contribution::get()
+    return \Civi\Api4\Contribution::get(FALSE)
       ->addSelect('id', 'receive_date', 'total_amount', 'currency')
       ->addWhere('contribution_recur_id', '=', $this->newRecurringContributionID)
       ->execute()


### PR DESCRIPTION
## Before 

In  these PRs:

- https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/473
- https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/496

I did updates to the Recurring contribution view page and tab, where it now indicates if the recurring contribution is linked to a payment scheme and hide any unnecessary information.

But we found out that the work above does not work for users with only 'CiviCRM User' role, or users in general with limited permissions.


## After

The work done in the above PRs work fine for users with 'CiviCRM User' role or users who have enough permission to access the recurring contribution tab in general:

![2023-10-27 13_23_15-adsdas dsaads _ Site-Install](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/3a6bb250-cd4b-4758-b28b-bbdc7611f389)


## Technical Details

Some of the API calls in the backend code are using API v4, which by default enforce permission checks, but most of the time API calls that are done from the backend do not need a permission check, given most of the time other permissions are enforced at higher level so these API calls are already being executed from safe contexts.

So here I just add the "FALSE" parameter to all the backend API v4 "get" calls, so not unnecessary permission checks are performed.

