### PR TITLE
CIWEMB-491: Replace the membership status calculation error with more readable content when switching membership type

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.php
@@ -117,8 +117,10 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
       );
     }
     catch (Exception $e) {
+      $errorMessage = $e->getMessage();
+      $this->replaceExceptionMessagesWithHumanReadableContent($errorMessage);
       CRM_Core_Session::setStatus(
-        ts('The membership type could not be changed: ') . $e->getMessage(),
+        ts('The membership type could not be changed. Error reason: ') . $errorMessage,
         ts('Changing Membership Type'),
         'error'
       );
@@ -138,6 +140,20 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
       'financial_type_id' => $submittedValues['switchmembership_financial_type_id'],
       'send_confirmation_email' => $sendConfirmation,
     ];
+  }
+
+  /**
+   * Replaces some of the exception messages thrown
+   * when submitting this form with more readable
+   * content.
+   *
+   * @param string $errorMessage
+   * @return void
+   */
+  private function replaceExceptionMessagesWithHumanReadableContent(&$errorMessage) {
+    if (strpos($errorMessage, 'The membership cannot be saved because the status cannot be calculated') !== FALSE) {
+      $errorMessage = 'There is no valid membership status available for the given membership dates.';
+    }
   }
 
 }


### PR DESCRIPTION
## Overview

A follow up for this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/502 where I also update the membership status calculation error with something more readable when switching the membership from one type to another.

## Before

https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/382fa5dd-55fc-45e4-af0d-f4456093ba70

![bef](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/6abc1c7f-074c-491f-9f4f-8240a38ba3fd)



## After


https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/6a4c1531-14d1-4c89-9f8b-c5abde0451aa


![2023-11-04 13_29_32-dada dsadas _ compuclient22sspv3](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/935a8b2e-4bce-4dca-b4cf-d7dda1475ba0)