### PR TITLE
BTHAB-293: Allow extension to update membership minimum

### DIFF
--- a/CRM/MembershipExtras/API/PaymentSchedule/Base.php
+++ b/CRM/MembershipExtras/API/PaymentSchedule/Base.php
@@ -41,7 +41,8 @@ abstract class CRM_MembershipExtras_API_PaymentSchedule_Base {
     $endDate = !empty($this->params['end_date']) ? new DateTime($this->params['end_date']) : NULL;
     $membershipInstalmentsSchedule = new CRM_MembershipExtras_Service_MembershipInstalmentsSchedule(
       $membershipTypes,
-      $this->params['schedule']
+      $this->params['schedule'],
+      $this->params['contact_id'] ?? NULL
     );
 
     if (!empty($nonMembershipPriceFieldValues)) {

--- a/CRM/MembershipExtras/API/PaymentSchedule/PriceValues.php
+++ b/CRM/MembershipExtras/API/PaymentSchedule/PriceValues.php
@@ -72,8 +72,8 @@ class CRM_MembershipExtras_API_PaymentSchedule_PriceValues extends CRM_Membershi
       $this->membershipTypes[] = $membershipType;
     }
 
-    if (empty($membershipTypes)) {
-      new API_Exception(ts('At least one price field items must be of type membership'));
+    if (empty($this->membershipTypes)) {
+      throw  new API_Exception(ts('At least one price field items must be of type membership'));
     }
   }
 

--- a/CRM/MembershipExtras/Hook/CustomDispatch/CalculateMembershipMinimumFee.php
+++ b/CRM/MembershipExtras/Hook/CustomDispatch/CalculateMembershipMinimumFee.php
@@ -1,0 +1,45 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class CRM_MembershipExtras_Hook_CustomDispatch_CalculateMembershipMinimumFee
+ */
+class CRM_MembershipExtras_Hook_CustomDispatch_CalculateMembershipMinimumFee {
+
+  const NAME = 'me.membership.calculate_minimum_fee';
+
+  /**
+   * Membership Types.
+   *
+   * @var array
+   */
+  private array $membershipTypes;
+
+  /**
+   * Contact ID.
+   *
+   * @var int
+   */
+  private $contactID;
+
+  /**
+   * CRM_MembershipExtras_Hook_CustomDispatch_CalculateMembershipMinimumFee constructor.
+   *
+   * @param array $membershipTypes
+   * @param int $contactID
+   */
+  public function __construct(&$membershipTypes, $contactID) {
+    $this->membershipTypes =& $membershipTypes;
+    $this->contactID = $contactID;
+  }
+
+  /**
+   * Dispatches event.
+   */
+  public function dispatch() {
+    $event = GenericHookEvent::create(['contactID' => $this->contactID, 'membershipTypes' => &$this->membershipTypes]);
+    Civi::dispatcher()->dispatch(self::NAME, $event);
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
@@ -5,6 +5,7 @@ use CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculator 
 use CRM_MembershipExtras_Service_MembershipInstalmentAmountCalculator as InstalmentAmountCalculator;
 use CRM_MembershipExtras_Service_MembershipTypeDurationCalculator as MembershipTypeDurationCalculator;
 use CRM_MembershipExtras_Service_MembershipTypeDatesCalculator as MembershipTypeDatesCalculator;
+use CRM_MembershipExtras_Hook_CustomDispatch_CalculateMembershipMinimumFee as CalculateMembershipMinimumFeeHook;
 use CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalculator as RollingPeriodTypeCalculator;
 
 class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProcessor {
@@ -86,6 +87,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProce
   }
 
   protected function getInstalmentAmountCalculator(array $membershipTypes, $periodType = 'rolling') {
+    (new CalculateMembershipMinimumFeeHook($membershipTypes, $this->params['contact_id']))->dispatch();
     if ($periodType == 'fixed') {
       $calculator = new FixedPeriodTypeCalculator($membershipTypes);
       $calculator->setStartDate(new DateTime($this->getMembership()['start_date']));

--- a/CRM/MembershipExtras/Page/InstalmentSchedule.php
+++ b/CRM/MembershipExtras/Page/InstalmentSchedule.php
@@ -28,6 +28,7 @@ class CRM_MembershipExtras_Page_InstalmentSchedule extends CRM_Core_Page {
     $params['payment_method'] = CRM_Utils_Request::retrieve('payment_method', 'Int');
     $params['start_date'] = CRM_Utils_Request::retrieve('start_date', 'String');
     $params['join_date'] = CRM_Utils_Request::retrieve('join_date', 'String');
+    $params['contact_id'] = CRM_Utils_Request::retrieve('contact_id', 'Int');
 
     try {
       $result = civicrm_api3('PaymentSchedule', $action, $params);

--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -14,6 +14,9 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
       preventPaymentTabLinkAction();
       toggleNumOfTermsField();
       preventMultiFormSubmission();
+      window.isPaymentPlanTabActive = isPaymentPlanTabActive;
+      window.isPriceSetSelected = isPriceSetSelected;
+      window.getSelectedPriceFieldValues = getSelectedPriceFieldValues;
     });
 
     /**
@@ -108,7 +111,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
         assignFirstContributionReceiveDate();
       });
 
-      $('#payment_plan_schedule, #payment_instrument_id, #start_date, #end_date').change(() => {
+      $('#payment_plan_schedule, #payment_instrument_id, #start_date, #end_date, #contact_id').change(() => {
         if (!isPaymentPlanTabActive()) {
           return;
         }
@@ -172,11 +175,14 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
      */
     function generateInstalmentSchedule(isPriceSet, startDate) {
       let schedule = $('#payment_plan_schedule').val();
+      const searchParams = new URLSearchParams(window.location.search);
+      const cid = $('#contact_id').val() ?? searchParams.get('cid');
       let params = {
         schedule: schedule,
         start_date: startDate,
         join_date: $('#join_date').val(),
         payment_method: $('#payment_instrument_id').val(),
+        contact_id: cid,
       };
       if (isPriceSet) {
         let selectedPriceFieldValues = getSelectedPriceFieldValues();

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
@@ -183,6 +183,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest 
       'contribution_id' => $contribution['id'],
       'entity_table' => 'civicrm_membership',
       'entity_id' => $this->membership['id'],
+      'contact_id' => $contact['id'],
     ];
   }
 


### PR DESCRIPTION
## Overview
This pull request introduces a hook/event, `me.membership.calculate_minimum_fee`, enabling third-party extensions to modify the minimum fee associated with a membership type during the following operations:
- Instalment table generation
- Computation of membership contribution instalment amounts
- Membership offline auto-renewal job execution

Additionally, an exception is now appropriately thrown when attempting to generate an instalment table for a Price field lacking a membership type.