### PR TITLE
ESEB-115: Fix pro-rata calculation during leap years

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipLineProRataCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipLineProRataCalculator.php
@@ -35,7 +35,7 @@ class CRM_MembershipExtras_Service_MembershipLineProRataCalculator {
     $membershipEndDate = new DateTime($toDate);
     $prorataDaysCount = $membershipDurationCalculator->calculateDaysBasedOnDates($membershipStartDate, $membershipEndDate);
 
-    $membershipTypeDurationInDays = $membershipDurationCalculator->calculateOriginalInDays();
+    $membershipTypeDurationInDays = $membershipDurationCalculator->calculateOriginalInDays($membershipStartDate, $membershipEndDate);
     $proratedAmount = ($membershipType->minimum_fee / $membershipTypeDurationInDays) * $prorataDaysCount;
     $proratedAmount = CRM_MembershipExtras_Service_MoneyUtilities::roundToPrecision($proratedAmount, 2);
 

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/AbstractPeriodTypeCalculator.php
@@ -70,10 +70,13 @@ abstract class CRM_MembershipExtras_Service_MembershipPeriodType_AbstractPeriodT
   protected function generateLineItem(int $financialTypeId, float $amount, float $taxAmount) {
     $roundedAmount = MoneyUtils::roundToPrecision($amount, 2);
     $roundedTaxAmount = MoneyUtils::roundToPrecision($taxAmount, 2);
-
-    $subTotal = $roundedAmount * $this->quantity;
-    $totalAmount = $subTotal + $roundedTaxAmount;
     $taxRate = $this->instalmentTaxAmountCalculator->getTaxRateByFinancialTypeId($financialTypeId);
+
+    $unroundedSubTotal = $amount * $this->quantity;
+    $unroundedTotalAmount = $unroundedSubTotal + $taxAmount;
+    $subTotal = MoneyUtils::roundToPrecision($unroundedSubTotal, 2);
+    $totalAmount = MoneyUtils::roundToPrecision($unroundedTotalAmount, 2);
+
     $scheduleInstalmentLineItem = new CRM_MembershipExtras_DTO_ScheduleInstalmentLineItem();
     $scheduleInstalmentLineItem->setFinancialTypeId($financialTypeId);
     $scheduleInstalmentLineItem->setQuantity($this->quantity);

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
@@ -131,10 +131,11 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
     }
     else {
       $this->proRatedUnit = self::BY_DAYS;
-      $duration = $membershipTypeDurationCalculator->calculateOriginalInDays();
+      $duration = $membershipTypeDurationCalculator->calculateOriginalInDays($this->startDate, $this->endDate);
       $this->proRatedNumber = $membershipTypeDurationCalculator->calculateDaysBasedOnDates($this->startDate, $this->endDate, $this->joinDate);
       if ($this->isDurationWithInOneYearPeriod($duration, $this->proRatedNumber) && !empty($this->endDate)) {
         $this->reCalculateEndDate();
+        $duration = $membershipTypeDurationCalculator->calculateOriginalInDays($this->startDate, $this->endDate);
         $this->proRatedNumber = $membershipTypeDurationCalculator->calculateDaysBasedOnDates($this->startDate, $this->endDate, $this->joinDate);
       }
     }

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
@@ -90,20 +90,51 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
   }
 
   private function isWithinMembershipTypeProRataSkipPeriod($skipProRataUntilSetting) {
-    $membershipStartDate = $this->startDate->format('Y-m-d');
+    $nearestSkipProRataDate = $this->getNearestSkipProRataDate($skipProRataUntilSetting);
+    $membershipStartDate = $this->startDate->format('Ymd');
 
-    $skipMonth = $skipProRataUntilSetting['M'];
-    $skipDay = $skipProRataUntilSetting['d'];
-    $currentYear = date('Y');
-    $skipDateString = $currentYear . '-' . $skipMonth . '-' . $skipDay;
-    $skipUntilDate = DateTime::createFromFormat('Y-n-j', $skipDateString);
-    $skipUntilDate = $skipUntilDate->format('Y-m-d');
+    if (empty($nearestSkipProRataDate)) {
+      return FALSE;
+    }
 
-    if ($membershipStartDate <= $skipUntilDate) {
+    if ($membershipStartDate <= $nearestSkipProRataDate) {
       return TRUE;
     }
 
     return FALSE;
+  }
+
+  /**
+   * Returns first "skip pro-rata" date that falls
+   * between the membership start and end dates, if any.
+   */
+  private function getNearestSkipProRataDate($skipProRataUntilSetting) {
+    $membershipStartYear = $this->startDate->format('Y');
+    $membershipEndYear = $this->endDate->format('Y');
+
+    $skipDateStringBasedOnStartYear = $membershipStartYear . '-' . $skipProRataUntilSetting['M'] . '-' . $skipProRataUntilSetting['d'];
+    $skipUntilDateBasedOnStartYear  = DateTime::createFromFormat('Y-n-j', $skipDateStringBasedOnStartYear);
+    $skipUntilDateBasedOnStartYear = $skipUntilDateBasedOnStartYear->format('Ymd');
+
+    $skipDateStringBasedOnEndYear = $membershipEndYear . '-' . $skipProRataUntilSetting['M'] . '-' . $skipProRataUntilSetting['d'];
+    $skipUntilDateBasedOnEndYear = DateTime::createFromFormat('Y-n-j', $skipDateStringBasedOnEndYear);
+    $skipUntilDateBasedOnEndYear = $skipUntilDateBasedOnEndYear->format('Ymd');
+
+    if ($skipUntilDateBasedOnStartYear >= $this->startDate->format('Ymd')
+      && $skipUntilDateBasedOnStartYear <= $this->endDate->format('Ymd')) {
+      return $skipUntilDateBasedOnStartYear;
+    }
+
+    if ($skipUntilDateBasedOnStartYear == $skipUntilDateBasedOnEndYear) {
+      return NULL;
+    }
+
+    if ($skipUntilDateBasedOnEndYear >= $this->startDate->format('Ymd')
+      && $skipUntilDateBasedOnEndYear <= $this->endDate->format('Ymd')) {
+      return $skipUntilDateBasedOnEndYear;
+    }
+
+    return NULL;
   }
 
   /**

--- a/CRM/MembershipExtras/Service/MembershipTypeDurationCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipTypeDurationCalculator.php
@@ -31,12 +31,86 @@ class CRM_MembershipExtras_Service_MembershipTypeDurationCalculator {
 
   /**
    * Calculates the membership type period in days based on the membership type period unit
-   * and interval.
+   * ,interval and the dates in which the membership will be created within.
+   *
+   * @params \DateTime|NULL $membershipStartDate
+   * @params \DateTime|NULL $membershipEndDate
    *
    * @return int
    */
-  public function calculateOriginalInDays() {
-    return $this->getDurationInDays();
+  public function calculateOriginalInDays($membershipStartDate = NULL, $membershipEndDate = NULL) {
+    $membershipType = CRM_Member_BAO_MembershipType::findById($this->membershipType->id);
+    if ($membershipType->duration_unit == 'year' && !empty($membershipStartDate) && !empty($membershipEndDate)) {
+      return $this->calculateDurationForOneYearMemberships($membershipType, $membershipStartDate, $membershipEndDate);
+    }
+
+    $membershipDates = $this->membershipTypeDatesCalculator->getDatesForMembershipType($this->membershipType->id);
+    $startDate = new DateTime($membershipDates['start_date']);
+    $endDate = new DateTime($membershipDates['end_date']);
+    $interval = $endDate->diff($startDate);
+
+    return (int) $interval->format("%a") + 1;
+  }
+
+  /**
+   * This handles calculating during for membership types with "year" duration unit.
+   * In general, we only support "1 year" fixed memberships, where the fixed period
+   * start day can only be the 1st day of the month, so this simplifies calculating
+   * the pro-rata amount, but there are some cases that are handled here such as:
+   *
+   * 1- Creating a membership with dates that fall within a leap year during
+   * a non leap year (e.g the membership starts and ends within 2024 but it was created
+   * druing 2023).
+   *
+   * 2- Creating a membership with dates that fall within a non leap year during
+   * a leap year.
+   *
+   * 3- Creating a membership that start during a non leap year but ends within
+   * a leap year, or the other way around.
+   */
+  private function calculateDurationForOneYearMemberships($membershipType, $membershipStartDate, $membershipEndDate) {
+    $isStartDateYearLeapYear = $this->isLeapYear($membershipStartDate->format('Y'));
+    $isEndDateYearLeapYear = $this->isLeapYear($membershipEndDate->format('Y'));
+    $termStartMonth = substr($membershipType->fixed_period_start_day, 0, strlen($membershipType->fixed_period_start_day) - 2);
+    $termEndMonth = substr($membershipType->fixed_period_rollover_day, 0, strlen($membershipType->fixed_period_rollover_day) - 2);
+
+    if (!$isStartDateYearLeapYear && !$isEndDateYearLeapYear) {
+      return 365;
+    }
+
+    if ($isStartDateYearLeapYear && $isEndDateYearLeapYear) {
+      return 366;
+    }
+
+    if ($isStartDateYearLeapYear && !$isEndDateYearLeapYear) {
+      // If the fixed membership type is configured to start on or after March, and a membership
+      // of such type is created with start date that is also on or after March, then the
+      // leap day (which is february the 29th) shouldn't be included.
+      if ($termStartMonth >= 3) {
+        return 365;
+      }
+      return 366;
+    }
+
+    if (!$isStartDateYearLeapYear && $isEndDateYearLeapYear) {
+      // If the fixed membership type is configured to end on or after March, and a membership
+      // of such type is created with end date that is also on or after March, then the
+      // leap day (which is february the 29th) should be included.
+      if ($termEndMonth >= 3) {
+        return 366;
+      }
+      return 365;
+    }
+
+    return 365;
+  }
+
+  private function isLeapYear($year) {
+    if (date('L', strtotime("$year-01-01"))) {
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
   /**
@@ -100,21 +174,6 @@ class CRM_MembershipExtras_Service_MembershipTypeDurationCalculator {
     $membershipEndDate = new DateTime($endDate);
 
     return $membershipEndDate->diff($membershipStartDate);
-  }
-
-  /**
-   * Returns the number of days for a membership type period duration.
-   *
-   * @return float|int
-   * @throws Exception
-   */
-  private function getDurationInDays() {
-    $membershipDates = $this->membershipTypeDatesCalculator->getDatesForMembershipType($this->membershipType->id);
-    $startDate = new DateTime($membershipDates['start_date']);
-    $endDate = new DateTime($membershipDates['end_date']);
-    $interval = $endDate->diff($startDate);
-
-    return (int) $interval->format("%a") + 1;
   }
 
 }

--- a/CRM/MembershipExtras/Service/MembershipTypeSwitcher.php
+++ b/CRM/MembershipExtras/Service/MembershipTypeSwitcher.php
@@ -261,7 +261,7 @@ class CRM_MembershipExtras_Service_MembershipTypeSwitcher {
     $membershipDurationCalculator = new CRM_MembershipExtras_Service_MembershipTypeDurationCalculator($this->newMembershipType, $membershipTypeDatesCalculator);
     $prorataDaysCount = $membershipDurationCalculator->calculateDaysBasedOnDates($newMembershipStartDate, $newMembershipEndDate, $newMembershipStartDate);
 
-    $membershipTypeDurationInDays = $membershipDurationCalculator->calculateOriginalInDays();
+    $membershipTypeDurationInDays = $membershipDurationCalculator->calculateOriginalInDays($newMembershipStartDate, $newMembershipEndDate);
     $proratedAmount = ($this->newMembershipType->minimum_fee / $membershipTypeDurationInDays) * $prorataDaysCount;
     $proratedAmountExcTax = CRM_MembershipExtras_Service_MoneyUtilities::roundToPrecision($proratedAmount, 2);
 

--- a/tests/phpunit/CRM/MembershipExtras/Service/MembershipTypeSwitcherTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/MembershipTypeSwitcherTest.php
@@ -156,10 +156,10 @@ class CRM_MembershipExtras_Service_MembershipTypeSwitcherTest extends BaseHeadle
     $contributionsNumber = 1;
     foreach ($contributions as $contribution) {
       if ($contributionsNumber <= 6) {
-        $this->assertNotEquals(8.38, $contribution['total_amount']);
+        $this->assertNotEquals(8.40, $contribution['total_amount']);
       }
       else {
-        $this->assertEquals(8.38, $contribution['total_amount']);
+        $this->assertEquals(8.40, $contribution['total_amount']);
       }
 
       $contributionsNumber++;

--- a/tests/phpunit/api/v3/PaymentSchedule/GetPaymentScheduleTest.php
+++ b/tests/phpunit/api/v3/PaymentSchedule/GetPaymentScheduleTest.php
@@ -95,7 +95,7 @@ class api_v3_PaymentSchedule_GetPaymentScheduleTest extends BaseHeadlessTest {
     $membershipTypeObj = CRM_Member_BAO_MembershipType::findById($membershipType['id']);
     $membershipTypeDates = new CRM_MembershipExtras_Service_MembershipTypeDatesCalculator();
     $durationCalculator = new CRM_MembershipExtras_Service_MembershipTypeDurationCalculator($membershipTypeObj, $membershipTypeDates);
-    $membershipDuration = $durationCalculator->calculateOriginalInDays();
+    $membershipDuration = $durationCalculator->calculateOriginalInDays($startDate, $endDate);
 
     $expectedAmount = round(((120 / $membershipDuration) * $durationInDays) / 9, 2);
     $expectedTaxAmount = 0;


### PR DESCRIPTION
## Before

If you have a fixed membership with:

- Fixed Period Start Day = 1st of Jan
- Fixed Period Rollover Day = 31th of Dec
- Annual Pro-rata Calculation = By Days

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/29251237-6af6-4a66-bfe6-01f152c90db3)


And you are trying to create a fixed membership with payment plan in non leap year (such as 2023), but with future dates that fall within a leap year (such as 2024-01-01 to 2024-12-31), then the membership form will keep not allow you to set the end date to "2024-12-31", and instead will keep changing the end date into  "2023-12-31" which is the fixed period rollover day during the current year (instead of the using the future year that you are trying to create the membership in), This will also result in showing wrong pro-rata membership fees:


https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/4b77faef-ffca-461e-a4c6-a8a72bd6539f


## After

The membership end date is no longer being set based on current year, and instead it is now more aligned with the selected membership dates, and because of that the membership fees are now calculated correctly: 


https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/1798f7d8-9d43-48d4-a179-d4c4be03ac02


I also found out that other scenarios around leap years that were not handled correctly before but they now do, such as:

-   Having a fixed membership type that is configured to start on or after March, and a membership of such type is created with start date that is also on or after March. In this case the leap day (which is February the 29th) shouldn't be included, so to calculate the price of one day of the membership, the membership fee should be divided by 365 instead of 366
-   Having a fixed membership type that is configured to end on or after March, and a membership of such type is created with end date that is also on or after March. In this case the price of one day of the membership should be the membership fee divided  bye 366 (given the leap day 29th of February is within the membership period).


In addition to that, I found that the "skip pro-rata" setting was not always utilized correctly, given it was always relying on the "Current Year" to check if the membership pro-rata should be skipped or not, instead of relying on the input start membership and end dates, so cases where the membership starts during one year (such as 2024) and ends in another (e.g 2025), or the membership is created in the future (e.g we are in 2024 and  trying to create a membership that starts and ends in 2025).


