### PR TITLE
CIWEMB-373: Correct field labels for error display

### DIFF
--- a/CRM/MembershipExtras/Form/PaymentScheme.php
+++ b/CRM/MembershipExtras/Form/PaymentScheme.php
@@ -78,6 +78,7 @@ class CRM_MembershipExtras_Form_PaymentScheme extends CRM_Core_Form {
       [
         'type' => 'submit',
         'name' => ts('Submit'),
+        'js' => ['onclick' => "document.querySelectorAll('label.crm-inline-error').forEach(function(item) { item.innerHTML = '';})"],
         'isDefault' => TRUE,
       ],
       [


### PR DESCRIPTION
## Overview
This pr corrects the labels for fields to display the error message correctly.

## Before
![image-20230621-130805](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/147053234/bf5b6cab-bc3a-445c-bdc7-b978c4773f5c)

## After
<img width="1792" alt="Screenshot 2024-01-01 at 10 21 12 PM" src="https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/147053234/f7e57627-e04e-470a-b7ce-2c0d20560879">