### PR TITLE
ESEB-137: Fix 'Next Contribution Date' for webform fixed memberships

### DIFF
--- a/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
+++ b/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php
@@ -25,7 +25,7 @@ class CRM_MembershipExtras_Service_PaymentPlanNextContributionDate {
       'options' => ['limit' => 1],
     ])['values'][0];
 
-    $this->operation = $operation;
+    $this->operation = strtolower($operation);
   }
 
   /**

--- a/CRM/MembershipExtras/WebformAPI/PaymentPlanNextContributionDateUpdater.php
+++ b/CRM/MembershipExtras/WebformAPI/PaymentPlanNextContributionDateUpdater.php
@@ -7,7 +7,7 @@ class CRM_MembershipExtras_WebformAPI_PaymentPlanNextContributionDateUpdater {
 
   public static function update($contributionRecurId) {
     // For offline payment plans memberships, we only offer create new ones through webforms, manual renewal is not supported.
-    $operation = 'Creation';
+    $operation = 'creation';
     $nextContributionDateService = new CRM_MembershipExtras_Service_PaymentPlanNextContributionDate($contributionRecurId, $operation);
     $nextContributionDateService->calculateAndUpdate();
   }


### PR DESCRIPTION
## Before

If you configure a webform with a payment plan and a fixed 1 year membership that starts at 1st of January and ends at 31th of December:

![2024-01-27 00_46_25-](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/9bee0f02-880a-4d3e-8c7b-061ca7690e60)

then the created recurring contribution "Next Scheduled Contribution Date" will be:

- The first instalment receive date + 1 year (in case of single instalment payment plans)

Or

- The last instalment receive date + 1 month (in case of monthly payment plan).

![2024-01-27 00_46_04-ksaadka@ad com ksaadka@ad com _ Site-Install](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/660fa6f9-7545-4b4a-9044-1983d03b7f65)

![2024-01-27 00_46_41-ksaadka@ad com ksaadka@ad com _ Site-Install](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/b2755295-828e-43ee-883c-248e907ae558)


This shouldn't be the case, and instead the "Next Scheduled Contribution Date"  should be:

- The membership end date + 1 day

## After


The "Next Scheduled Contribution Date" is :  The membership end date + 1 day


![2024-01-27 00_47_11-Settings](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/abf91ad3-c446-45f7-b332-570e2208d3ee)


## Technical Details

The `PaymentPlanNextContributionDateUpdater` Webform API passes the word "Creation" as 2nd argument to the `PaymentPlanNextContributionDate` Service that is responsible for calculating the  "Next Scheduled Contribution Date" 
 instead of "creation" (all letters should be lower case), so this part of the code that is responsible for calculating the date for fixed memberships did not run:
https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/feaf57503db0fd556998a6361a9893ee7980c086/CRM/MembershipExtras/Service/PaymentPlanNextContributionDate.php#L74-L82

So I fixed this by passing the right operation name which is "creation" instead of "Creation", and as fail-safe I also change the `$operation` parameter letters to be lower case before using it.