### PR TITLE
MAE-1114: Fix The Extension Installation on some sites

### DIFF
--- a/CRM/MembershipExtras/Setup/Manage/ManualPaymentProcessor.php
+++ b/CRM/MembershipExtras/Setup/Manage/ManualPaymentProcessor.php
@@ -24,7 +24,7 @@ class CRM_MembershipExtras_Setup_Manage_ManualPaymentProcessor extends AbstractM
       'is_default' => '0',
       'class_name' => 'Payment_Manual',
       'is_recur' => '1',
-      'payment_instrument_id' => 'EFT',
+      'payment_instrument_id' => (new CRM_MembershipExtras_Setup_Manage_OfflineRecurringPaymentMethod)->getPaymentMethod(),
     ];
 
     // creates the live version of the payment processor.

--- a/CRM/MembershipExtras/Setup/Manage/ManualPaymentProcessorType.php
+++ b/CRM/MembershipExtras/Setup/Manage/ManualPaymentProcessorType.php
@@ -30,7 +30,7 @@ class CRM_MembershipExtras_Setup_Manage_ManualPaymentProcessorType extends Abstr
       'billing_mode' => CRM_Core_Payment::BILLING_MODE_NOTIFY,
       'is_recur' => '1',
       'payment_type' => CRM_Core_Payment::PAYMENT_TYPE_DIRECT_DEBIT,
-      'payment_instrument_id' => 'EFT',
+      'payment_instrument_id' => (new CRM_MembershipExtras_Setup_Manage_OfflineRecurringPaymentMethod)->getPaymentMethod(),
       'user_name_label' => 'User Name',
     ]);
   }

--- a/CRM/MembershipExtras/Setup/Manage/OfflineRecurringPaymentMethod.php
+++ b/CRM/MembershipExtras/Setup/Manage/OfflineRecurringPaymentMethod.php
@@ -1,0 +1,101 @@
+<?php
+
+use Civi\Api4\EntityFinancialAccount;
+
+class CRM_MembershipExtras_Setup_Manage_OfflineRecurringPaymentMethod {
+
+  private const NAME = 'Offline Automated Recurring';
+
+  /**
+   * Ensure that payment method is there and return it.
+   *
+   * @return string
+   */
+  public function getPaymentMethod(): string {
+    $this->ensurePaymentMethod();
+
+    return self::NAME;
+  }
+
+  /**
+   * Create offline automated recurring payment method if
+   * it does not exist already.
+   *
+   * @return void
+   */
+  private function ensurePaymentMethod(): void {
+    if ($this->PaymentMethodExists()) {
+      return;
+    }
+
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => 'payment_instrument',
+      'name' => self::NAME,
+      'label' => self::NAME,
+      'description' => 'A payment method used by Membership Extras extension manual payment processor. This is created as the payment method is a required field on installing a payment processor and can be changed on the payment processor if not needed.',
+      'is_active' => 1,
+      'is_default' => 0,
+      'is_reserved' => 0,
+      'weight' => 1,
+    ]);
+
+    $paymentMethodId = $result['id'];
+    $financialAccountId = $this->getFinancialAccountForPaymentMethod();
+    if ($financialAccountId === 0) {
+      throw new Exception('Could not find a financial account to use with payment method for manual payment processor.');
+    }
+
+    EntityFinancialAccount::create(FALSE)
+      ->addValue('entity_table', 'civicrm_option_value')
+      ->addValue('entity_id', $paymentMethodId)
+      ->addValue('financial_account_id', $financialAccountId)
+      ->addValue('account_relationship:name', 'Asset Account is')
+      ->execute();
+  }
+
+  /**
+   * Checks if offline automated recurring payment method exists.
+   *
+   * @return bool
+   */
+  private function PaymentMethodExists(): bool {
+    $paymentMethod = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'payment_instrument',
+      'name' => self::NAME,
+      'sequential' => 1,
+    ]);
+
+    return !empty($paymentMethod['id']);
+  }
+
+  /**
+   * Returns the financial account id to be used with offline automated recurring payment method.
+   *
+   * @return int
+   */
+  private function getFinancialAccountForPaymentMethod(): int {
+    $financialAccountId = 0;
+    $assetAccountType = CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name = 'Asset' ");
+    if (empty($assetAccountType)) {
+      return $financialAccountId;
+    }
+
+    $financialAccounts = civicrm_api3('FinancialAccount', 'get', [
+      'sequential' => 1,
+      'financial_account_type_id' => key($assetAccountType),
+    ]);
+    if (empty($financialAccounts['values'])) {
+      return $financialAccountId;
+    }
+
+    foreach ($financialAccounts['values'] as $financialAccount) {
+      if ((int) $financialAccount['is_default'] === 1) {
+        $financialAccountId = $financialAccount['id'];
+        break;
+      }
+    }
+
+    return (int) ($financialAccountId > 0 ? $financialAccountId : $financialAccounts['values'][0]['id']);
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR fixes the extension installation on some sites.

## Before
Previously the extension installation was failing if the **EFT** payment method was not there as the creation of manual payment processor was dependent on **EFT** payment method.

## After

This PR changes the flow to first create a new payment by the name of **Offline Automated Recurring** method that manual payment processor will use instead of **EFT**

## Technical Overview
We create a new payment method attached to default financial account of type **Asset** or the first financial account of type **Asset** if default financial account of type **Asset** is not present 
