### PR TITLE
CIWEMB-535: Hide fields that are unnecessary for payment plans linked to payment schemes

### DIFF
--- a/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/BuildForm/UpdateSubscription.php
@@ -40,10 +40,11 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
    */
   private function setRecurringContribution() {
     $recurringContributionID = CRM_Utils_Request::retrieve('crid', 'Integer', $this->form, TRUE);
-    $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
-      'sequential' => 1,
-      'id' => $recurringContributionID,
-    ])['values'][0];
+    $this->recurringContribution = \Civi\Api4\ContributionRecur::get(FALSE)
+      ->addSelect('payment_processor_id', 'frequency_unit', 'auto_renew', 'payment_instrument_id', 'cycle_day', 'next_sched_contribution_date', 'payment_plan_extra_attributes.payment_scheme_id')
+      ->addWhere('id', '=', $recurringContributionID)
+      ->execute()
+      ->getArrayCopy()[0];
   }
 
   /**
@@ -78,13 +79,17 @@ class CRM_MembershipExtras_Hook_BuildForm_UpdateSubscription {
     $this->form->setDefaults(['payment_instrument_id' => $this->recurringContribution['payment_instrument_id']]);
     $this->form->assign('isBackOffice', 1);
 
-    $this->form->add('text', 'cycle_day', ts('Cycle Day'), [], TRUE);
-    $this->form->setDefaults(['cycle_day' => $this->recurringContribution['cycle_day']]);
+    $this->form->assign('isPaymentSchemePlan', TRUE);
+    if (empty($this->recurringContribution['payment_plan_extra_attributes.payment_scheme_id'])) {
+      $this->form->assign('isPaymentSchemePlan', FALSE);
+      $this->form->add('text', 'cycle_day', ts('Cycle Day'), [], TRUE);
+      $this->form->setDefaults(['cycle_day' => $this->recurringContribution['cycle_day']]);
 
-    $this->form->add('datepicker', 'next_sched_contribution_date', ts('Next Scheduled Contribution Date'), [], FALSE, ['time' => FALSE]);
-    $nextScheduledDate = CRM_Utils_Array::value('next_sched_contribution_date', $this->recurringContribution);
-    if (!empty($nextScheduledDate)) {
-      $this->form->setDefaults(['next_sched_contribution_date' => $this->recurringContribution['next_sched_contribution_date']]);
+      $this->form->add('datepicker', 'next_sched_contribution_date', ts('Next Scheduled Contribution Date'), [], FALSE, ['time' => FALSE]);
+      $nextScheduledDate = CRM_Utils_Array::value('next_sched_contribution_date', $this->recurringContribution);
+      if (!empty($nextScheduledDate)) {
+        $this->form->setDefaults(['next_sched_contribution_date' => $this->recurringContribution['next_sched_contribution_date']]);
+      }
     }
 
     $this->form->addButtons([

--- a/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
+++ b/CRM/MembershipExtras/Hook/ValidateForm/UpdateSubscription.php
@@ -58,8 +58,10 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
       return;
     }
 
-    $this->validateCycleDay();
-    $this->validateNextContributionDate();
+    if (empty($this->recurringContribution['payment_plan_extra_attributes.payment_scheme_id'])) {
+      $this->validateCycleDay();
+      $this->validateNextContributionDate();
+    }
   }
 
   public function validateCycleDay() {
@@ -102,10 +104,11 @@ class CRM_MembershipExtras_Hook_ValidateForm_UpdateSubscription {
   private function setRecurringContribution() {
     $recurringContributionID = $this->form->getVar('contributionRecurID');
 
-    $this->recurringContribution = civicrm_api3('ContributionRecur', 'get', [
-      'sequential' => 1,
-      'id' => $recurringContributionID,
-    ])['values'][0];
+    $this->recurringContribution = \Civi\Api4\ContributionRecur::get(FALSE)
+      ->addSelect('frequency_unit', 'payment_plan_extra_attributes.payment_scheme_id')
+      ->addWhere('id', '=', $recurringContributionID)
+      ->execute()
+      ->getArrayCopy()[0];
   }
 
 }

--- a/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
+++ b/templates/CRM/Member/Form/UpdateSubscriptionModifications.tpl
@@ -57,7 +57,7 @@
 </table>
 <div id="confirmInstallmentsUpdate" style="display: none;">
   <div class="messages status no-popup">
-    {if $paymentPlanFrequency == 'month'}
+    {if $paymentPlanFrequency == 'month' && !$isPaymentSchemePlan}
       <i aria-hidden="true" class="crm-i fa-info-circle"></i>{ts}Do you want to update any outstanding instalment
       contribution with the new Payment Method or Cycle Day? Hence that updating the cycle day will also update the next
       scheduled contribution date.{/ts}
@@ -67,3 +67,18 @@
     {/if}
   </div>
 </div>
+
+<script type="text/javascript">
+{literal}
+CRM.$(function($) {
+{/literal}
+  {if $isPaymentSchemePlan}
+   {literal}
+    CRM.$('#installments').closest('tr').css('display', 'none');
+    CRM.$('#amount')[0].nextSibling.remove();
+  {/literal}
+  {/if}
+  {literal}
+});
+{/literal}
+</script>


### PR DESCRIPTION
## Overview

In this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/473
we hid several fields from the recurring contribution view page if it is linked to a payment scheme,  here we are doing the same on the recurring contribution edit form.

## Before

The recurring contribution "edit" form shows the following fields:

![2024-01-31 23_40_36-aokacs acsas _ Site-Install](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/93639986-07f1-49f8-ac51-8b7cf2f174da)

and when trying to submit the form it shows the following message:

![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/a4c8fcfa-58c6-4b1f-b6a2-23a2b6e2e9e8)


## After

These fields are now hidden:

- Frequency
- Instalments
- Cycle Day
- Next Scheduled instalment

![2024-01-31 23_36_49-aokacs acsas _ Site-Install](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/48cb9c43-a528-49e8-85f1-8ab76bf4d5f6)

and when trying to submit the form, it no longer mentions the "Cycle day", but rather it shows the same message that appear to "annual" payment plans:

![2024-01-31 23_38_10-aokacs acsas _ Site-Install](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/049b6b1c-44e4-4227-ad48-3ced0cfd9634)

where recurring contributions that are not linked to a payment scheme still work as they used to where all these fields are visible:

![2024-01-31 23_37_29-kadsa@ad com kadsa@ad com _ Site-Install](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/58bad0ba-a503-48a7-821a-0b1b3148d33a)


## Technical Details

The "Cycle day" and "Next Scheduled Contribution Date" do not exist on the original CiviCRM recurring contribution form, and they were rather added by us inside the buildForm hook, so hiding both of them was a matter of adding an if condition so they are only added if the edited recurring contribution is linked to a payment scheme.

But because we also have some validations inside the form validation hook related to these two fields and some other stuff we do in the postProcess hook, I also had to also to update these two hooks to ignore these operations in case of payment schemes.


For the "instalments" and the "frequency" fields, and given they are added to the form by CiviCRM core, I had to use Javascript/JQuery to hide them.
