### PR TITLE
 CIWEMB-492: Prevent switching to the same membership type

### DIFF
--- a/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.php
+++ b/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.php
@@ -43,6 +43,12 @@ class CRM_MembershipExtras_Form_RecurringContribution_SwitchMembershipType exten
       'entity' => 'membership_type',
       'placeholder' => ts('- Select Membership Type -'),
       'select' => ['minimumInputLength' => 0],
+      'api' => [
+        'params' => [
+          'is_active' => TRUE,
+          'id' => ['!=' => $currentMembershipType['id']],
+        ],
+      ],
     ], TRUE);
 
     $this->add('datepicker', 'switch_date', ts('Switch Date'), [], TRUE, ['time' => FALSE]);


### PR DESCRIPTION
## Before

When trying to switch a membership from one type to another, the current membership type still appears in the list of membership types that you can switch to:

https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/1ed45c12-0164-440f-a1e3-44434d5bf81c


## After

The current membership type no longer appears in the list of membership types that you can switch to:

https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/1e614a7b-5cb1-4cfa-9f83-e7d6dbbbdff9


## Technical details

The "New membership type" field is an a civicrm entity reference field which is added by calling `$this->addEntityRef()` in the buildForm method (see: https://docs.civicrm.org/dev/en/latest/framework/quickform/entityref/) ,  so all I need is to add an API parameter to `$this->addEntityRef()` to exclude the current membership type, also added another parameter to only search for active membership types.

## About failing tests

The failing test is non relevant to this PR and is already fixed inside this branch:  https://github.com/compucorp/uk.co.compucorp.membershipextras/tree/ESEB-53-workstream 

which will be part of Membershipextras version 6.1.0
