### PR TITLE
COMCL-410: Hide unnecessary fields for non active payment plans that are linked to a payment scheme 

### DIFF
--- a/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
@@ -13,6 +13,7 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
 
   private function modifyPageElements() {
     $contributionData = $this->page->get_template_vars('recur');
+    $isActiveRecurringContribution = $this->isActivePaymentPlan($contributionData['id']);
     $paymentSchemeSchedule = $this->getFuturePaymentSchemeScheduleIfExist($contributionData['id']);
 
     CRM_Core_Resources::singleton()->addScriptFile(
@@ -24,17 +25,22 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
       CRM_MembershipExtras_ExtensionUtil::SHORT_NAME,
       [
         'recur_contribution' => $contributionData,
+        'is_active_recurring_contribution' => $isActiveRecurringContribution,
         'payment_scheme_schedule' => $paymentSchemeSchedule,
       ]
     );
   }
 
+  private function isActivePaymentPlan($recurId) {
+    return \Civi\Api4\ContributionRecur::get(FALSE)
+      ->addSelect('payment_plan_extra_attributes.is_active')
+      ->addWhere('id', '=', $recurId)
+      ->execute()
+      ->column('payment_plan_extra_attributes.is_active')[0];
+  }
+
   private function getFuturePaymentSchemeScheduleIfExist($recurId) {
     try {
-      if (!$this->isActivePaymentPlan($recurId)) {
-        return NULL;
-      }
-
       $paymentPlanScheduleGenerator = new CRM_MembershipExtras_Service_PaymentScheme_PaymentPlanScheduleGenerator($recurId);
       $paymentsSchedule = $paymentPlanScheduleGenerator->generateSchedule();
       array_walk($paymentsSchedule['instalments'], function (&$value) {
@@ -46,14 +52,6 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
     catch (CRM_Extension_Exception $e) {
       return NULL;
     }
-  }
-
-  private function isActivePaymentPlan($recurId) {
-    return \Civi\Api4\ContributionRecur::get(FALSE)
-      ->addSelect('payment_plan_extra_attributes.is_active')
-      ->addWhere('id', '=', $recurId)
-      ->execute()
-      ->column('payment_plan_extra_attributes.is_active')[0];
   }
 
 }

--- a/js/modifyRecurringContributionPage.js
+++ b/js/modifyRecurringContributionPage.js
@@ -1,4 +1,5 @@
 CRM.$(function () {
+  const isActiveRecurringContribution = CRM.vars.membershipextras.is_active_recurring_contribution;
   const paymentSchemeSchedule = CRM.vars.membershipextras.payment_scheme_schedule;
   hideUnnecessaryPaymentPlanFields();
   addFuturePaymentSchemeSchedule();
@@ -25,6 +26,11 @@ CRM.$(function () {
 
   function addFuturePaymentSchemeSchedule() {
     if (paymentSchemeSchedule === null) {
+      return;
+    }
+
+    // no point in showing future instalments for inactive payment plans
+    if (!isActiveRecurringContribution) {
       return;
     }
 


### PR DESCRIPTION
## Overview

In this PR: https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/473 we hide various fields that are irrelevant for payment plans that are linked to payment schemes, but this was only done for active payment plans, so it would be better if we also hide them for non active payment plans as well.


## Before

The following fields appear on inactive payment plans that are linked to payment schemes:

- Frequency
- Installments
- Cycle Day
- Next Scheduled Contribution Date

https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/2e2f3f49-4edc-473a-91a8-14794b17e4a2



## After

The mentioned fields no longer appear on inactive payment plans that are linked to payment schemes:

https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/7736fd4d-fe9c-426b-981a-5543666a70b8

But there is still a difference, the "Future payment scheme" table is hidden on inactive payment plans: 
![image](https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/6275540/f7bb090c-2624-4692-9d69-c1bbb34a8937)

given inactive payment plans won't renewal, so there are no future instalments and so there is no point in showing this table.
