### PR TITLE
CIWEMB-509: Make Current and New Membership Sections Closer

### DIFF
--- a/templates/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.tpl
+++ b/templates/CRM/MembershipExtras/Form/RecurringContribution/SwitchMembershipType.tpl
@@ -95,8 +95,8 @@
   <table id="switch_membership_form_container" class="form-layout-compressed">
     <tbody>
     <tr>
-      <td>{ts}Current Membership Type{/ts}</td>
-      <td></td>
+      <td style="width: 50%;">{ts}Current Membership Type{/ts}</td>
+      <td style="width: 20%;"></td>
       <td style="font-weight: 600;color: #464354;">{$form.new_membership_type.label}</td>
     </tr>
     <tr>


### PR DESCRIPTION
## Overview
This pr improves the ui of "change membership type" screen by bringing the current and new membership sections closer to each other.

## Before
<img width="1792" alt="Screenshot 2024-03-25 at 4 07 42 PM" src="https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/147053234/e8f3cf4b-aa0a-4c87-8d53-8da3b57af073">


## After
<img width="1792" alt="Screenshot 2024-03-25 at 4 26 41 PM" src="https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/147053234/b404b0a4-ce51-43a7-9f1f-3dce1b6a9087">
