### PR TITLE
ESESPRT-77: Show View Option For Memberships

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -384,7 +384,9 @@ function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$
   if (in_array($op, ['membership.tab.row', 'membership.selector.row']) && $objectName == 'Membership') {
     $cancelAutorenewalActionName = ts('Cancel Auto-renewal');
     $cancelAutoRenewActionIndex = array_search($cancelAutorenewalActionName, array_column($links, 'name'));
-    unset($links[$cancelAutoRenewActionIndex]);
+    if ($cancelAutoRenewActionIndex !== FALSE) {
+      unset($links[$cancelAutoRenewActionIndex]);
+    }
   }
 }
 


### PR DESCRIPTION
## Overview
This pr makes 'view' option visible for memberships on contact view page.

## Before
<img width="1327" alt="Screenshot 2024-03-05 at 3 29 30 PM" src="https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/147053234/7998cdec-7433-4505-9781-c220e7d31260">


## After
<img width="1792" alt="Screenshot 2024-03-26 at 2 29 53 PM" src="https://github.com/compucorp/uk.co.compucorp.membershipextras/assets/147053234/1ebcf0e2-d224-42c0-b867-8c22620da10a">

## Technical Details
The issue was introduced in this [pr](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/474) where we wanted to hide 'Cancel Auto-Renewal' option for memberships linked to a recurring contribution, but if this option is not available for any membership then array_search [here](https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/master/membershipextras.php#L386) returns false and as a result [this](https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/master/membershipextras.php#L387) line unsets the first item in links array.
