### PR TITLE
FOSFASPRT-9: Fix pro rata calculation for membership payment plan

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/AbstractProcessor.php
@@ -99,7 +99,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_AbstractProce
     }
 
     $instalmentAmountCalculator = new InstalmentAmountCalculator($calculator);
-    $instalmentAmountCalculator->getCalculator()->calculate();
+    $isNotQuickConfig = $this->getLineItemCount() > 1;
+    $instalmentAmountCalculator->getCalculator()->calculate(!$this->isUsingPriceSet() || $isNotQuickConfig);
 
     return $instalmentAmountCalculator;
   }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/Contribution.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/Contribution.php
@@ -319,4 +319,10 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_Contribution 
     }
   }
 
+  protected function getLineItemCount(): int {
+    $lineItems = CRM_Utils_Array::value('line_item', $this->params, []);
+
+    return !empty($lineItems) ? count(array_values($lineItems)[0]) : 1;
+  }
+
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
@@ -69,4 +69,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem exte
     }
   }
 
+  protected function getLineItemCount(): int {
+    return CRM_Utils_Array::value('lineItemCount', $this->params, 1);
+  }
+
 }

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php
@@ -66,14 +66,15 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_FixedPeriodTypeCalculato
   /**
    * @throws Exception
    */
-  public function calculate() {
+  public function calculate(bool $calculateProRated = TRUE) {
     foreach ($this->membershipTypes as $membershipType) {
       $settings = CRM_MembershipExtras_SettingsManager::getMembershipTypeSettings($membershipType->id);
       $membershipAmount = $membershipType->minimum_fee;
       $taxAmount = $this->instalmentTaxAmountCalculator->calculateByMembershipType($membershipType, $membershipAmount);
 
       $skipProRataUntilSetting = $settings[SettingField::ANNUAL_PRORATA_SKIP_ELEMENT] ?? NULL;
-      if (!empty($skipProRataUntilSetting) && !empty($skipProRataUntilSetting['M']) && $this->isWithinMembershipTypeProRataSkipPeriod($skipProRataUntilSetting)) {
+      if ((!empty($skipProRataUntilSetting) && !empty($skipProRataUntilSetting['M']) && $this->isWithinMembershipTypeProRataSkipPeriod($skipProRataUntilSetting))
+      || !$calculateProRated) {
         $amount = $membershipAmount;
       }
       else {

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/PeriodTypeCalculatorInterface.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/PeriodTypeCalculatorInterface.php
@@ -3,7 +3,7 @@
 
 interface CRM_MembershipExtras_Service_MembershipPeriodType_PeriodTypeCalculatorInterface {
 
-  public function calculate();
+  public function calculate(bool $calculateProRated = TRUE);
 
   public function getAmount();
 

--- a/CRM/MembershipExtras/Service/MembershipPeriodType/RollingPeriodTypeCalculator.php
+++ b/CRM/MembershipExtras/Service/MembershipPeriodType/RollingPeriodTypeCalculator.php
@@ -21,7 +21,7 @@ class CRM_MembershipExtras_Service_MembershipPeriodType_RollingPeriodTypeCalcula
    *
    * @throws Exception
    */
-  public function calculate() {
+  public function calculate(bool $calculateProRated = TRUE) {
     foreach ($this->membershipTypes as $membershipType) {
       $amount = $membershipType->minimum_fee;
       $taxAmount = $this->instalmentTaxAmountCalculator->calculateByMembershipType($membershipType, $membershipType->minimum_fee);

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItemTest.php
@@ -34,18 +34,14 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest 
    *
    * @throws Exception
    */
-  public function testProRatedPriceSetContributionLineItemOnCalculationByMonthFixedMembershipType() {
+  public function testProRatedPriceSetContributionLineItemOnCalculationWithModifiedMembershipFee() {
     $params = $this->mockParams('fixed', 'year', FixedPeriodCalculator::BY_MONTHS);
     //Since we test price set, line item amount can be different
     //from membership type that attached to price field value
     //the line total is changed here to test if the hook
     //is working correct with different price.
     $params['line_total'] = 240;
-
-    $memTypeObj = CRM_Member_BAO_MembershipType::findById($params['membership_type_id']);
-    $membershipTypeDurationCalculator = new MembershipTypeDurationCalculator($memTypeObj, new MembershipTypeDatesCalculator());
-    $diffInMonths = $membershipTypeDurationCalculator->calculateMonthsBasedOnDates(new DateTime($this->membership['start_date']));
-    $expectedLineToTal = MoneyUtilities::roundToPrecision($params['line_total'] / 12 * $diffInMonths, 2);
+    $expectedLineToTal = $params['line_total'];
     $expectedTaxAmount = MoneyUtilities::roundToPrecision(($params['tax_rate'] / 100) * $expectedLineToTal, 2);
 
     $_REQUEST['price_set_id'] = $this->priceSet['id'];
@@ -64,11 +60,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItemTest 
    */
   public function testProRatedPriceSetContributionLineItemOnCalculationByDaysFixedMembershipType() {
     $params = $this->mockParams('fixed', 'year', FixedPeriodCalculator::BY_DAYS);
-    $memTypeObj = CRM_Member_BAO_MembershipType::findById($params['membership_type_id']);
-    $membershipTypeDurationCalculator = new MembershipTypeDurationCalculator($memTypeObj, new MembershipTypeDatesCalculator());
-    $membershipTypeDurationInDays = $membershipTypeDurationCalculator->calculateOriginalInDays();
-    $diffInDays = $membershipTypeDurationCalculator->calculateDaysBasedOnDates(new DateTime($this->membership['start_date']));
-    $expectedLineToTal = MoneyUtilities::roundToPrecision(($params['line_total'] / $membershipTypeDurationInDays) * $diffInDays, 2);
+    $expectedLineToTal = $params['line_total'];
     $expectedTaxAmount = MoneyUtilities::roundToPrecision(($params['tax_rate'] / 100) * $expectedLineToTal, 2);
 
     $_REQUEST['price_set_id'] = $this->priceSet['id'];


### PR DESCRIPTION
## Overview
This pr fixes an issue with pro rata calculation of membership payment plan that caused pro rata to be applied twice to the same amount resulting in significant less amount being charged for membership.

## Technical Details
When quick config price set was used for creating a membership pro rata calculation was applied [here](https://github.com/compucorp/uk.co.compucorp.membershipextras/blob/6b1bdadaa43ce727f44932f65e49529620bd2c88/CRM/MembershipExtras/Service/MembershipPeriodType/FixedPeriodTypeCalculator.php#L83) to already prorated amount so this pr fixes this issue.
