### PR TITLE
Update membershipextras.php to fix error

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -438,13 +438,12 @@ function membershipextras_civicrm_alterMailParams(&$params, $context) {
  *
  */
 function membershipextras_civicrm_permission(&$permissions) {
-  $permissions += [
-    'administer MembershipExtras' => [
-      E::ts('MembershipExtras: administer Membership Extras'),
-      E::ts('Perform all Membership Extras administration tasks in CiviCRM'),
-    ],
+  $permissions['administer membershipextras'] = [
+    'label' => E::ts('MembershipExtras: administer Membership Extras'),
+    'description' => E::ts('Perform all Membership Extras administration tasks in CiviCRM'),
   ];
 }
+
 
 /**
  * Implements hook_civicrm_alterAPIPermissions().


### PR DESCRIPTION
Error being caused, this fixes said error.
[warning] Permission 'administer MembershipExtras' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions
