### PR TITLE
COMCL-765: Fix Styling For Membership View Page

### DIFF
--- a/css/membershipView.css
+++ b/css/membershipView.css
@@ -1,0 +1,4 @@
+.crm-container .CRM_Member_Form_MembershipView .crm-contact-contribute-contributions>table.selector{
+  margin: 0 !important;
+  width: 100% !important;
+}

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -319,6 +319,14 @@ function membershipextras_civicrm_pageRun($page) {
     );
   }
 
+  if (get_class($page) === 'CRM_Member_Page_Tab' && CRM_Utils_System::currentPath() === 'civicrm/contact/view/membership') {
+    CRM_Core_Resources::singleton()->addStyleFile(
+      CRM_MembershipExtras_ExtensionUtil::LONG_NAME,
+      'css/membershipView.css',
+      1
+    );
+  }
+
   if ($page instanceof CRM_Contribute_Page_ContributionRecur) {
     $recurViewPage = new CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage();
     $recurViewPage->handle($page);


### PR DESCRIPTION
## Overview
This pr fixes the styling for membership view screen as currently 'Related Contributions and Recurring Contributions' section is not visible properly.

## Before
<img width="1792" alt="Screenshot 2024-08-19 at 5 40 45 PM" src="https://github.com/user-attachments/assets/324147d3-8e19-4e40-af90-64edb8940687">


## After
<img width="1792" alt="Screenshot 2024-08-19 at 5 51 59 PM" src="https://github.com/user-attachments/assets/e787bcc8-307a-4882-b6cc-08c9ca99ddea">
