### PR TITLE
BTHA-194: Ensure membeership rate total can be calculated for line item

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipPaymentPlanProcessor/LineItem.php
@@ -8,6 +8,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem exte
 
   public function __construct(&$params) {
     $this->params = &$params;
+    $this->setContactID();
     $this->assignInstalmentDetails();
   }
 
@@ -71,6 +72,19 @@ class CRM_MembershipExtras_Hook_Pre_MembershipPaymentPlanProcessor_LineItem exte
 
   protected function getLineItemCount(): int {
     return CRM_Utils_Array::value('lineItemCount', $this->params, 1);
+  }
+
+  private function setContactID() {
+    if (!empty($this->params['contact_id']) || empty($this->params['contribution_id'])) {
+      return;
+    }
+
+    $this->params['contact_id'] = \Civi\Api4\Contribution::get()
+      ->addSelect('contact_id')
+      ->addWhere('id', '=', $this->params['contribution_id'])
+      ->setLimit(1)
+      ->execute()
+      ->first()['contact_id'] ?? NULL;
   }
 
 }


### PR DESCRIPTION
## Overview
Before this PR we had an issue where when a user ‘record’ a payment against a membership contribution with total computed from [membersjhiprate](https://github.com/compucorp/io.compuco.membershiprates) extension, the amount due is shown as the amount attached to the original membership type ‘minimum fee’ (ie, pre calculation from the membership fee calculator).

The event we added here https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/508, requires that contactID be sent, but in the line item create hook, the contact ID was null.

In this PR we have retrieved the set the contact ID from the line item contribution.


## Before
The amount due is shown as the amount attached to the original membership type ‘minimum fee.
![@@@11111111qqq22222222](https://github.com/user-attachments/assets/5446f06f-63ba-481a-82ae-6add3935a3ad)


## After
The amount due is shown as the amount calculated by the membership fee calculator.
![@@11111111qqq22222222](https://github.com/user-attachments/assets/8e3622f6-b99c-4638-a6e8-adc000df0d44)