### PR TITLE
MAE-1178: Fix Pro Rata Calculation For Membership

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -183,7 +183,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
 
     $instalments['sub_total'] = $this->instalmentCalculator->getInstalmentsSubTotalAmount($instalments['instalments']);
     $instalments['tax_amount'] = $this->instalmentCalculator->getInstalmentsTaxAmount($instalments['instalments']);
-    $instalments['total_amount'] = $this->instalmentCalculator->getInstalmentsTotalAmount($instalments['instalments']);
+    $instalments['total_amount'] = number_format($this->instalmentCalculator->getInstalmentsTotalAmount($instalments['instalments']), 2);
 
     $instalments['membership_start_date'] = $this->startDate->format('Y-m-d');
     $instalments['membership_end_date'] = $this->endDate->format('Y-m-d');


### PR DESCRIPTION
## Overview
Currently when user is creating a membership on a contact. The “member since” field is pre-populated to today’s date and the price in the contribution tab is populated to the full price for the membership, if the user adjusts the date (in the example to future date the membership), the price remains at the full price for the year and if the user then submits with no other changes, the pro-rating of the membership price has effectively not occurred. So this pr fixes the issue now whenever user selects a membership or price set or adjusts the mebership start date the total amount adjusts automatically to pro rata amount.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/aae08537-e6a5-4882-ad99-619132db3db0)


## After
![screen_recording_after](https://github.com/user-attachments/assets/418cfcdb-9ba4-4e05-ac29-85a36d0281df)

