### PR TITLE
COMCL-887: Support renewal of paid contribution

### DIFF
--- a/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
+++ b/CRM/MembershipExtras/Job/OfflineAutoRenewal/SingleInstalmentPlan.php
@@ -76,7 +76,6 @@ class CRM_MembershipExtras_Job_OfflineAutoRenewal_SingleInstalmentPlan extends C
    LEFT JOIN civicrm_membership cm ON (cm.id = cli.entity_id AND cli.entity_table = 'civicrm_membership')
    LEFT JOIN civicrm_value_payment_plan_extra_attributes ppea ON ppea.entity_id = ccr.id
        WHERE (ccr.payment_processor_id IS NULL OR ccr.payment_processor_id IN ({$supportedPaymentProcessorsIDs}))
-         AND ccr.end_date IS NULL
          AND (
           ccr.installments <= 1
           OR ccr.installments IS NULL


### PR DESCRIPTION
## Overview
Before this PR membership with paid contributions did not get renewed, this is because of a recurring contribution condition that filters out recurring contributions with non-empty end date

## Before
Membership did not get renewed, and no new contribution was created after running the renewal job
<img width="1068" alt="Screenshot 2024-10-24 at 14 02 59" src="https://github.com/user-attachments/assets/22f6171f-5a4a-478f-b6ce-57ab696d67dd">


## After
Running the renewal job now renews the membership with a completed contribution and creates a new pending contribution
<img width="1119" alt="Screenshot 2024-10-24 at 13 59 46" src="https://github.com/user-attachments/assets/4e2475f0-774f-46f7-9ea4-bb80a24a9644">

## Technical Details
This issue didn't happen in the previous CiviCRM version because completing a contribution does not change the end date of the recurring contribution.


