### PR TITLE
COMCL-939: Avoid reformatting total amount in the template

### DIFF
--- a/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
+++ b/templates/CRM/MembershipExtras/Page/InstalmentSchedule.tpl
@@ -84,7 +84,7 @@
     <td colspan="3"></td>
     <td class="instalment-amount-text">{ts}Total Amount{/ts}</td>
     <td colspan="2">
-      <span>{$currency_symbol}&nbsp;<span id="instalment-total-amount">{$total_amount|crmNumberFormat:2}</span>
+      <span>{$currency_symbol}&nbsp;<span id="instalment-total-amount">{$total_amount}</span>
       {if isset($prorated_number) && isset($prorated_unit)}
         <span class="instalment-prorated-text">({ts}Prorated for {/ts} {$prorated_number} {$prorated_unit})</span>
       {/if}


### PR DESCRIPTION
## Overview
Avoid reformatting total amount in the template, this regression was introduced in this PR https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/539, where we formatted the total amount from the Backend to a string, while the frontend view also attempts to format the same total amount with the expectation that the value is float.


## Before
The total amount value is empty
<img width="814" alt="Screenshot 2024-11-21 at 05 55 48" src="https://github.com/user-attachments/assets/3c7a3ccd-3fab-4cb5-80a5-5220c0936895">

## After
The total amount value is no longer empty

<img width="844" alt="Screenshot 2024-11-21 at 05 53 28" src="https://github.com/user-attachments/assets/862bcc03-14f7-4c37-998a-fca4b392dae7">
