### PR TITLE
CIVIMM-293: Fix permission label

### DIFF
--- a/membershipextras.php
+++ b/membershipextras.php
@@ -405,8 +405,8 @@ function membershipextras_civicrm_alterMailParams(&$params, $context) {
 function membershipextras_civicrm_permission(&$permissions) {
   $permissions += [
     'administer MembershipExtras' => [
-      E::ts('MembershipExtras: administer Membership Extras'),
-      E::ts('Perform all Membership Extras administration tasks in CiviCRM'),
+      'label' => E::ts('MembershipExtras: administer Membership Extras'),
+      'description' => E::ts('Perform all Membership Extras administration tasks in CiviCRM'),
     ],
   ];
 }


### PR DESCRIPTION
## Overview

This PR fixes the permission label warning

> permission 'administer MembershipExtras' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions at /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/CRM/Core/Error.php:1132