### PR TITLE
CSTMM-118: Refresh Membership Count Upon Updating Relationships

### DIFF
--- a/js/RefreshMembershipCount.js
+++ b/js/RefreshMembershipCount.js
@@ -1,0 +1,31 @@
+CRM.$(function ($) {
+
+  $(function () {
+    refreshRelatedTabsOnRelationshipUpdate();
+  });
+
+  function refreshRelatedTabsOnRelationshipUpdate() {
+    waitForElement($, '#contact-rel',
+      function(element) {
+        if (isRelationshipTabActive() && $('#tab_contribute').length && $('#tab_member').length) {
+          $('#contact-rel').off('crmPopupFormSuccess').on('crmPopupFormSuccess', function() {
+            CRM.tabHeader.resetTab('#tab_contribute');
+            CRM.tabHeader.resetTab('#tab_member', true);
+          });
+        }
+      }
+    );
+  }
+
+  function waitForElement($, elementPath, callBack) {
+    (new MutationObserver(function(mutations) {
+      callBack($(elementPath));
+    })).observe(document.querySelector(elementPath), {
+      attributes: true
+    });
+  }
+
+  function isRelationshipTabActive() {
+    return $('#contact-rel').length && $('#contact-rel').is(":visible");
+  }
+});

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -300,6 +300,15 @@ function membershipextras_civicrm_pageRun($page) {
     $hook = new CRM_MembershipExtras_Hook_PageRun_ContributionTab();
     $hook->handle($page);
   }
+
+  if ($page instanceof CRM_Contact_Page_View_Summary) {
+    CRM_Core_Resources::singleton()->addScriptFile(
+      CRM_MembershipExtras_ExtensionUtil::LONG_NAME,
+      'js/RefreshMembershipCount.js',
+      1,
+      'page-header'
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview
Currently when user updates or enable/disable any relationship the membership count does not get updated and it only gets updated when user clicks on membership tab

## Before
![screen_recording_before](https://github.com/user-attachments/assets/21d81114-99f7-4e6a-8e53-f4ef83e01781)


## After
The membership count gets updated as soon as the user updates any relationship
![screen_recording_after](https://github.com/user-attachments/assets/f4f397df-1b4a-43ae-8148-20c910ae5762)

