### PR TITLE
COMCL-823: Fix Status Calculation

### DIFF
--- a/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
+++ b/CRM/MembershipExtras/Hook/Post/MembershipPayment.php
@@ -69,7 +69,7 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
     $this->membership = civicrm_api3('Membership', 'get', [
       'sequential' => 1,
       'id' => $this->membershipPayment->membership_id,
-      'return' => ['membership_type_id', 'is_override', 'status_override_end_date'],
+      'return' => ['membership_type_id', 'is_override', 'status_override_end_date', 'status_id.name'],
     ])['values'][0];
   }
 
@@ -103,7 +103,8 @@ class CRM_MembershipExtras_Hook_Post_MembershipPayment {
       'membership_id' => $this->membershipPayment->membership_id,
     ]);
 
-    if (!empty($newMembershipStatus['id'])) {
+    if (!empty($newMembershipStatus['id']) &&
+      (stripos($newMembershipStatus['name'], 'arrears') !== FALSE || stripos((string) CRM_Utils_Array::value('status_id.name', $this->membership), 'arrears') !== FALSE)) {
       $mem = new CRM_Member_DAO_Membership();
       $mem->id = $this->membershipPayment->membership_id;
       $mem->find(TRUE);


### PR DESCRIPTION
## Overview
In [this](https://github.com/compucorp/uk.co.compucorp.membershipextras/pull/223) PR we added the code for status calculation after membership payment record has been created, however that change was just intended to be for arrears related statuses but no relevant check to restrict this logic to arrears statuses was added to the code which resulted in this logic being executed for each membership status whenever a membership payment is created that is related to a recurring contribution and as a result on membership payment creation the membership status is derived forward if it matches the next status rule. This PR fixes the issue by adding relevant checks to run the logic added in mentioned PR for only arrears related membership statuses.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/5c779ef9-1129-4109-9613-804e971f7851)


## After
![screen_recording_after](https://github.com/user-attachments/assets/fb0f6cae-bb5c-4e9c-85f8-3f8f52bfe16b)
