### PR TITLE
add weights to links

### DIFF
--- a/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
+++ b/CRM/MembershipExtras/Hook/Links/RecurringContribution.php
@@ -90,6 +90,7 @@ class CRM_MembershipExtras_Hook_Links_RecurringContribution {
         'url' => 'civicrm/recurring-contribution/edit-lineitems',
         'qs' => 'reset=1&crid=%%crid%%&cid=%%cid%%&context=contribution',
         'title' => 'View/Modify Future Instalments',
+        'weight' => 0,
       ];
     }
   }

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -356,6 +356,7 @@ function membershipextras_civicrm_links($op, $objectName, $objectId, &$links, &$
         'url' => 'civicrm/contribution/duplicate-contribution',
         'qs' => 'reset=1&crid=%%id%%',
         'title' => 'Duplicate As New Pending Contribution',
+        'weight' => 0,
       ];
     }
   }


### PR DESCRIPTION
## Overview
The links added by this extension don't have a defined weight, which leads to PHP warnings when viewing activities.

## Before
```
Warning: Undefined array key "weight" in CRM_Core_Action::{closure}() (line 318 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/Action.php).
```

## After
No warnings.

## Technical Details
The closure here is sorting the links by weight, and in PHP8, creates a warning when a weight element doesn't exist.