### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionRecurViewPage.php
@@ -14,7 +14,7 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
   }
 
   private function modifyPageElements() {
-    $contributionData = $this->page->get_template_vars('recur');
+    $contributionData = $this->page->getTemplateVars('recur');
     $isActiveRecurringContribution = $this->isActivePaymentPlan($contributionData['id']);
     $paymentSchemeSchedule = $this->getFuturePaymentSchemeScheduleIfExist($contributionData['id']);
 
@@ -59,7 +59,7 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionRecurViewPage implements CRM
   }
 
   private function setPaymentSchemeTitle() {
-    $customData = $this->page->get_template_vars('viewCustomData');
+    $customData = $this->page->getTemplateVars('viewCustomData');
     $paymentSchemeGroup = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
       'name' => self::PAYMENT_PLAN_EXTRA_ATTRIBUTES_CUSTOM_GROUP_NAME,

--- a/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
+++ b/CRM/MembershipExtras/Hook/PageRun/ContributionTab.php
@@ -30,7 +30,7 @@ class CRM_MembershipExtras_Hook_PageRun_ContributionTab implements CRM_Membershi
     foreach ($rowTypes as $rowType) {
       $tplVarName = $rowType . 'PaymentSchemeField';
 
-      $recurRows = $this->page->get_template_vars($rowType);
+      $recurRows = $this->page->getTemplateVars($rowType);
       $recurIds = [];
       foreach ($recurRows as $recurRow) {
         $recurIds[] = $recurRow['id'];

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageDashboardColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageDashboardColourUpdate.php
@@ -34,7 +34,7 @@ class CRM_MembershipExtras_Hook_PageRun_MemberPageDashboardColourUpdate implemen
    * @param CRM_Core_Page $page
    */
   private function setMembershipTypeColourStyle($page) {
-    $rows = $page->get_template_vars('rows');
+    $rows = $page->getTemplateVars('rows');
 
     if (empty($rows)) {
       return;

--- a/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
+++ b/CRM/MembershipExtras/Hook/PageRun/MemberPageTabColourUpdate.php
@@ -36,8 +36,8 @@ class CRM_MembershipExtras_Hook_PageRun_MemberPageTabColourUpdate implements CRM
    * @param CRM_Core_Page $page
    */
   private function setMembershipTypeColourStyle($page) {
-    $inactiveMembers = $page->get_template_vars('inActiveMembers') ?? [];
-    $activeMembers = $page->get_template_vars('activeMembers') ?? [];
+    $inactiveMembers = $page->getTemplateVars('inActiveMembers') ?? [];
+    $activeMembers = $page->getTemplateVars('activeMembers') ?? [];
     $allMemberships = array_merge($inactiveMembers, $activeMembers);
     $css = '';
     $membershipTypeColourSettings = Civi::settings()->get(MembershipTypeSettings::COLOUR_SETTINGS_KEY);

--- a/tests/phpunit/CRM/MembershipExtras/Page/InstalmentScheduleTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Page/InstalmentScheduleTest.php
@@ -26,8 +26,8 @@ class CRM_MembershipExtras_Page_InstalmentScheduleTest extends BaseHeadlessTest 
     $this->disableReturnResult($page);
     $page->run();
     $this->assertPageRun($page);
-    $this->assertNull($page->get_template_vars('prorated_number'));
-    $this->assertNull($page->get_template_vars('prorated_unit'));
+    $this->assertNull($page->getTemplateVars('prorated_number'));
+    $this->assertNull($page->getTemplateVars('prorated_unit'));
   }
 
   public function testRunFixedMembershipType() {
@@ -42,8 +42,8 @@ class CRM_MembershipExtras_Page_InstalmentScheduleTest extends BaseHeadlessTest 
     $this->disableReturnResult($page);
     $page->run();
     $this->assertPageRun($page);
-    $this->assertNotNull($page->get_template_vars('prorated_number'));
-    $this->assertNotNull($page->get_template_vars('prorated_unit'));
+    $this->assertNotNull($page->getTemplateVars('prorated_number'));
+    $this->assertNotNull($page->getTemplateVars('prorated_unit'));
   }
 
   public function tearDown(): void {
@@ -56,12 +56,12 @@ class CRM_MembershipExtras_Page_InstalmentScheduleTest extends BaseHeadlessTest 
   }
 
   private function assertPageRun($page) {
-    $this->assertNotNull($page->get_template_vars('instalments'));
-    $this->assertNotNull($page->get_template_vars('sub_total'));
-    $this->assertNotNull($page->get_template_vars('tax_amount'));
-    $this->assertNotNull($page->get_template_vars('total_amount'));
-    $this->assertNotNull($page->get_template_vars('membership_start_date'));
-    $this->assertNotNull($page->get_template_vars('membership_end_date'));
+    $this->assertNotNull($page->getTemplateVars('instalments'));
+    $this->assertNotNull($page->getTemplateVars('sub_total'));
+    $this->assertNotNull($page->getTemplateVars('tax_amount'));
+    $this->assertNotNull($page->getTemplateVars('total_amount'));
+    $this->assertNotNull($page->getTemplateVars('membership_start_date'));
+    $this->assertNotNull($page->getTemplateVars('membership_end_date'));
   }
 
   private function disableReturnResult($page) {


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.