### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -12,7 +12,7 @@
   <version>6.9.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.51</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>
     Supported CiviCRM versions  :

--- a/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
+++ b/templates/CRM/MembershipExtras/Page/EditContributionRecurLineItems.tpl
@@ -30,13 +30,13 @@
 
   <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
     <li id="tab_current" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
-      <a href="#current-subtab" title="{ts}Contributions{/ts}" class="clickable">
+      <a href="#current-subtab" title="{ts escape='htmlattribute'}Contributions{/ts}" class="clickable">
         {ts}Current Period{/ts}
       </a>
     </li>
     {if $showNextPeriodTab}
     <li id="tab_next" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
-      <a href="#next-subtab" title="{ts}Recurring Contributions{/ts}" class="clickable">
+      <a href="#next-subtab" title="{ts escape='htmlattribute'}Recurring Contributions{/ts}" class="clickable">
         {ts}Next Period (Forecast){/ts}
       </a>
     </li>

--- a/templates/CRM/MembershipExtras/Page/PaymentScheme.tpl
+++ b/templates/CRM/MembershipExtras/Page/PaymentScheme.tpl
@@ -35,7 +35,7 @@
                 <td class="crm-admin-member-payment-scheme-permission">{$permissionLabels[$row.permission]}</td>
                 <td class="crm-admin-member-payment-scheme-permission-enabled" id="row_{$row.id}_status">{if $row.enabled eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>
-                  <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=update&reset=1"}" class="action-item crm-hover-button" title="{ts}View and Edit Payment Scheme{/ts}">{ts}Edit{/ts}</a>
+                  <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=update&reset=1"}" class="action-item crm-hover-button" title="{ts escape='htmlattribute'}View and Edit Payment Scheme{/ts}">{ts}Edit{/ts}</a>
                   <a href="{crmURL p="civicrm/member/admin/payment-scheme" q="id=`$row.id`&action=delete&reset=1"}" class="action-item crm-hover-button small-popup" title="Delete Payment Scheme">Delete</a>
                 </td>
               </tr>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.