### PR TITLE
COMCL-1345: Fix Price Set Amount Display

### DIFF
--- a/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
+++ b/CRM/MembershipExtras/Service/MembershipInstalmentsSchedule.php
@@ -183,7 +183,7 @@ class CRM_MembershipExtras_Service_MembershipInstalmentsSchedule {
 
     $instalments['sub_total'] = $this->instalmentCalculator->getInstalmentsSubTotalAmount($instalments['instalments']);
     $instalments['tax_amount'] = $this->instalmentCalculator->getInstalmentsTaxAmount($instalments['instalments']);
-    $instalments['total_amount'] = number_format($this->instalmentCalculator->getInstalmentsTotalAmount($instalments['instalments']), 2);
+    $instalments['total_amount'] = CRM_Utils_Money::format($this->instalmentCalculator->getInstalmentsTotalAmount($instalments['instalments']), NULL, NULL, TRUE);
 
     $instalments['membership_start_date'] = $this->startDate->format('Y-m-d');
     $instalments['membership_end_date'] = $this->endDate->format('Y-m-d');

--- a/js/paymentPlanToggler.js
+++ b/js/paymentPlanToggler.js
@@ -280,7 +280,7 @@ function paymentPlanToggler(togglerValue, currencySymbol) {
     function updateTotalAmount(totalAmount, isPriceSet) {
       $('#total_amount').val(totalAmount);
       if (isPriceSet) {
-        $('#pricevalue').html(currencySymbol + ' ' + CRM.formatMoney(totalAmount, true));
+        $('#pricevalue').html(currencySymbol + ' ' + totalAmount);
       }
     }
 


### PR DESCRIPTION
## Overview
This PR fixes the display of price set amount on new membership back office form which currently displays NAN when the amount is in thousands.

## Before
![screen_recording_before](https://github.com/user-attachments/assets/c349c143-4580-43d8-bff9-71b3114d62b9)


## After
![screen_recording_after](https://github.com/user-attachments/assets/4de333b2-bde3-4d2e-9629-b94ce5ad2f4d)


## Technical Details
This issue was caused by due to the fact that we were formatting the total amount twice, once in backend then in frontend as well which caused NAN as the total amount was already formatted and contained a comma in it. This PR fixes the issue by using the correct format method only in backend.
