### PR TITLE
IESSPRT-293: Fix membership end date not updating for multiple payments in one webhook

### DIFF
--- a/CRM/MembershipExtras/Hook/Config/APIWrapper/ContributionCompleteTransactionAPI.php
+++ b/CRM/MembershipExtras/Hook/Config/APIWrapper/ContributionCompleteTransactionAPI.php
@@ -1,0 +1,25 @@
+<?php
+
+use CRM_MembershipExtras_ExtensionUtil as ExtensionUti;
+
+class CRM_MembershipExtras_Hook_Config_APIWrapper_ContributionCompleteTransactionAPI {
+
+  /**
+   * Callback precedes Contribution.completetransaction API call.
+   *
+   * Sets `completeTransactionCalled` flag so that the Membership Pre Edit
+   * hook can detect we're in a payment completion context (e.g. GoCardless
+   * webhook) and prevent per-installment membership date extensions.
+   *
+   * This follows the same pattern as PaymentAPI wrapper.
+   */
+  public static function preApiCall($event) {
+    $apiRequestSig = $event->getApiRequestSig();
+    if ($apiRequestSig !== '3.contribution.completetransaction') {
+      return;
+    }
+
+    Civi::$statics[ExtensionUti::LONG_NAME]['completeTransactionCalled'] = TRUE;
+  }
+
+}

--- a/CRM/MembershipExtras/Hook/Config/APIWrapper/ContributionCompleteTransactionAPI.php
+++ b/CRM/MembershipExtras/Hook/Config/APIWrapper/ContributionCompleteTransactionAPI.php
@@ -7,11 +7,12 @@ class CRM_MembershipExtras_Hook_Config_APIWrapper_ContributionCompleteTransactio
   /**
    * Callback precedes Contribution.completetransaction API call.
    *
-   * Sets `completeTransactionCalled` flag so that the Membership Pre Edit
-   * hook can detect we're in a payment completion context (e.g. GoCardless
-   * webhook) and prevent per-installment membership date extensions.
-   *
-   * This follows the same pattern as PaymentAPI wrapper.
+   * Sets `resetContributionID` flag so that the static $contributionID
+   * in membershipextras_civicrm_pre() is reset to NULL before each
+   * completeTransaction's Membership edit hook fires. This prevents
+   * stale contribution IDs from a previous completeTransaction call
+   * (e.g. multi-event GoCardless webhook) from incorrectly triggering
+   * prevention of membership date extension.
    */
   public static function preApiCall($event) {
     $apiRequestSig = $event->getApiRequestSig();
@@ -19,7 +20,7 @@ class CRM_MembershipExtras_Hook_Config_APIWrapper_ContributionCompleteTransactio
       return;
     }
 
-    Civi::$statics[ExtensionUti::LONG_NAME]['completeTransactionCalled'] = TRUE;
+    Civi::$statics[ExtensionUti::LONG_NAME]['resetContributionID'] = TRUE;
   }
 
 }

--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -73,8 +73,7 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
         $this->paymentContributionID ||
         $this->isRecordingPayment() ||
         $this->isBulkStatusUpdate() ||
-        $this->editedFromPaymentAPIContext() ||
-        $this->editedFromCompleteTransactionContext()
+        $this->editedFromPaymentAPIContext()
       ) && $this->isSupportedPaymentPlanMembership();
 
     $null = NULL;
@@ -178,25 +177,6 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    */
   private function editedFromPaymentAPIContext() {
     if (!empty(Civi::$statics[ExtensionUti::LONG_NAME]['paymentApiCalled'])) {
-      return TRUE;
-    }
-
-    return FALSE;
-  }
-
-  /**
-   * Is this membership being edited from
-   * Contribution.completetransaction API context?
-   *
-   * This detects when a payment is being completed via webhook
-   * (e.g. GoCardless) and prevents per-installment membership
-   * date extensions. Follows the same pattern as
-   * editedFromPaymentAPIContext().
-   *
-   * @return bool
-   */
-  private function editedFromCompleteTransactionContext() {
-    if (!empty(Civi::$statics[ExtensionUti::LONG_NAME]['completeTransactionCalled'])) {
       return TRUE;
     }
 

--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -73,7 +73,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
         $this->paymentContributionID ||
         $this->isRecordingPayment() ||
         $this->isBulkStatusUpdate() ||
-        $this->editedFromPaymentAPIContext()
+        $this->editedFromPaymentAPIContext() ||
+        $this->editedFromCompleteTransactionContext()
       ) && $this->isSupportedPaymentPlanMembership();
 
     $null = NULL;
@@ -177,6 +178,25 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
    */
   private function editedFromPaymentAPIContext() {
     if (!empty(Civi::$statics[ExtensionUti::LONG_NAME]['paymentApiCalled'])) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Is this membership being edited from
+   * Contribution.completetransaction API context?
+   *
+   * This detects when a payment is being completed via webhook
+   * (e.g. GoCardless) and prevents per-installment membership
+   * date extensions. Follows the same pattern as
+   * editedFromPaymentAPIContext().
+   *
+   * @return bool
+   */
+  private function editedFromCompleteTransactionContext() {
+    if (!empty(Civi::$statics[ExtensionUti::LONG_NAME]['completeTransactionCalled'])) {
       return TRUE;
     }
 

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -13,6 +13,7 @@ function membershipextras_civicrm_config(&$config) {
   _membershipextras_civix_civicrm_config($config);
 
   Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_MembershipExtras_Hook_Config_APIWrapper_PaymentAPI', 'preApiCall']);
+  Civi::dispatcher()->addListener('civi.api.prepare', ['CRM_MembershipExtras_Hook_Config_APIWrapper_ContributionCompleteTransactionAPI', 'preApiCall']);
 }
 
 /**

--- a/membershipextras.php
+++ b/membershipextras.php
@@ -93,6 +93,11 @@ function membershipextras_civicrm_pre($op, $objectName, $id, &$params) {
   }
 
   if ($objectName === 'Membership' && $op == 'edit') {
+    if (!empty(Civi::$statics[E::LONG_NAME]['resetContributionID'])) {
+      $contributionID = NULL;
+      unset(Civi::$statics[E::LONG_NAME]['resetContributionID']);
+    }
+
     $paymentType = Civi::$statics[E::LONG_NAME]['paymentType'] ?? '';
     $membershipPreHook = new CRM_MembershipExtras_Hook_Pre_MembershipEdit($id, $params, $contributionID, $paymentType);
     $membershipPreHook->preProcess();

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
@@ -69,6 +69,30 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
   }
 
   /**
+   * Creates a payment plan with Pending contributions for integration testing.
+   */
+  private function createPendingPaymentPlan($membershipType) {
+    $paymentPlanMembershipOrder = new PaymentPlanMembershipOrder();
+    $paymentPlanMembershipOrder->membershipStartDate = date('Y-m-d', strtotime('-1 year -1 month'));
+    $paymentPlanMembershipOrder->paymentPlanFrequency = 'Monthly';
+    $paymentPlanMembershipOrder->paymentPlanStatus = 'Pending';
+    $paymentPlanMembershipOrder->lineItems[] = [
+      'entity_table' => 'civicrm_membership',
+      'price_field_id' => $membershipType->priceFieldValue['price_field_id'],
+      'price_field_value_id' => $membershipType->priceFieldValue['id'],
+      'label' => $membershipType->membershipType['name'],
+      'qty' => 1,
+      'unit_price' => $membershipType->priceFieldValue['amount'],
+      'line_total' => $membershipType->priceFieldValue['amount'],
+      'financial_type_id' => 'Member Dues',
+      'non_deductible_amount' => 0,
+      'auto_renew' => 1,
+    ];
+
+    return PaymentPlanOrderFabricator::fabricate($paymentPlanMembershipOrder);
+  }
+
+  /**
    * Obtains memberships set to auto-renew for payment plan.
    *
    * @param int $paymentPlanID
@@ -293,6 +317,112 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
       date('Y-m-d', strtotime($membershipParams['end_date']))
     );
     CRM_Utils_GlobalStack::singleton()->pop();
+  }
+
+  public function testEndDateNotUnsetWhenContributionIdIsNull() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlan = $this->createPaymentPlan($mainMembershipType);
+    $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
+    $membershipParams = array_shift($memberships);
+
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, NULL, '');
+    $hook->preProcess();
+
+    $this->assertArrayHasKey('end_date', $membershipParams, 'end_date should not be unset when contributionID is NULL');
+  }
+
+  public function testEndDateUnsetWhenContributionIdIsSet() {
+    $mainMembershipType = $this->createMembershipType([
+      'name' => 'Main Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlan = $this->createPaymentPlan($mainMembershipType);
+    $contributions = $this->getPaymentPlanContributions($paymentPlan['id']);
+    $memberships = $this->getPaymentPlanRenewableMemberships($paymentPlan['id']);
+    $membershipParams = array_shift($memberships);
+    $membershipParams['end_date'] = date('Y-m-d', strtotime('+1 year'));
+
+    $hook = new MembershipEditHook($membershipParams['id'], $membershipParams, $contributions[0]['id'], '');
+    $hook->preProcess();
+
+    $this->assertArrayNotHasKey('end_date', $membershipParams, 'end_date should be unset when contributionID is set for a payment plan membership');
+  }
+
+  /**
+   * Integration test: simulates the real webhook scenario with two
+   * completeTransaction calls in the same PHP request.
+   * The second call should not have its membership end_date reset
+   * by a stale static $contributionID from the first call.
+   */
+  public function testSecondCompleteTransactionDoesNotResetMembershipEndDate() {
+    $membershipTypeA = $this->createMembershipType([
+      'name' => 'Membership Type A',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+    $membershipTypeB = $this->createMembershipType([
+      'name' => 'Membership Type B',
+      'period_type' => 'rolling',
+      'minimum_fee' => 60,
+      'duration_interval' => 12,
+      'duration_unit' => 'month',
+    ]);
+
+    $paymentPlanA = $this->createPendingPaymentPlan($membershipTypeA);
+    $paymentPlanB = $this->createPendingPaymentPlan($membershipTypeB);
+
+    $contributionsA = $this->getPaymentPlanContributions($paymentPlanA['id']);
+    $contributionsB = $this->getPaymentPlanContributions($paymentPlanB['id']);
+
+    $membershipB = civicrm_api3('Membership', 'get', [
+      'sequential' => 1,
+      'contribution_recur_id' => $paymentPlanB['id'],
+    ])['values'][0];
+
+    $endDateBeforeB = $membershipB['end_date'];
+
+    // Payment 1: complete contribution A (simulates first event in webhook)
+    civicrm_api3('Contribution', 'completetransaction', [
+      'id' => $contributionsA[0]['id'],
+      'trxn_id' => 'GC_TEST_PM001',
+      'is_transactional' => FALSE,
+    ]);
+
+    // Payment 2: complete contribution B (simulates second event in same webhook)
+    civicrm_api3('Contribution', 'completetransaction', [
+      'id' => $contributionsB[0]['id'],
+      'trxn_id' => 'GC_TEST_PM002',
+      'is_transactional' => FALSE,
+    ]);
+
+    // Refresh membership B from DB
+    $membershipBAfter = civicrm_api3('Membership', 'getsingle', ['id' => $membershipB['id']]);
+
+    // Membership B's end_date should be preserved — not nulled by stale
+    // $contributionID, and not extended per-installment. The
+    // completeTransactionCalled flag ensures prevention fires correctly.
+    $this->assertNotEmpty(
+      $membershipBAfter['end_date'],
+      'Second completeTransaction in same request should not null membership B end_date'
+    );
+    $this->assertEquals(
+      $endDateBeforeB,
+      $membershipBAfter['end_date'],
+      'Second completeTransaction should preserve membership B end_date (not extend per-installment)'
+    );
   }
 
   public function testExtendPendingPlanWithFixedMembershipAndOneInstalment() {

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
@@ -362,8 +362,8 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
   /**
    * Integration test: simulates the real webhook scenario with two
    * completeTransaction calls in the same PHP request.
-   * The second call should not have its membership end_date reset
-   * by a stale static $contributionID from the first call.
+   * The resetContributionID flag ensures each call starts with a
+   * clean $contributionID, preventing stale state from interfering.
    */
   public function testSecondCompleteTransactionDoesNotResetMembershipEndDate() {
     $membershipTypeA = $this->createMembershipType([
@@ -387,13 +387,6 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $contributionsA = $this->getPaymentPlanContributions($paymentPlanA['id']);
     $contributionsB = $this->getPaymentPlanContributions($paymentPlanB['id']);
 
-    $membershipB = civicrm_api3('Membership', 'get', [
-      'sequential' => 1,
-      'contribution_recur_id' => $paymentPlanB['id'],
-    ])['values'][0];
-
-    $endDateBeforeB = $membershipB['end_date'];
-
     // Payment 1: complete contribution A (simulates first event in webhook)
     civicrm_api3('Contribution', 'completetransaction', [
       'id' => $contributionsA[0]['id'],
@@ -408,20 +401,23 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
       'is_transactional' => FALSE,
     ]);
 
-    // Refresh membership B from DB
-    $membershipBAfter = civicrm_api3('Membership', 'getsingle', ['id' => $membershipB['id']]);
+    // Refresh both memberships from DB
+    $membershipAAfter = civicrm_api3('Membership', 'getsingle', [
+      'contribution_recur_id' => $paymentPlanA['id'],
+    ]);
+    $membershipBAfter = civicrm_api3('Membership', 'getsingle', [
+      'contribution_recur_id' => $paymentPlanB['id'],
+    ]);
 
-    // Membership B's end_date should be preserved — not nulled by stale
-    // $contributionID, and not extended per-installment. The
-    // completeTransactionCalled flag ensures prevention fires correctly.
+    // Both memberships should have valid end_dates — neither should be
+    // nulled or corrupted by stale static $contributionID state.
+    $this->assertNotEmpty(
+      $membershipAAfter['end_date'],
+      'First completeTransaction should not null membership A end_date'
+    );
     $this->assertNotEmpty(
       $membershipBAfter['end_date'],
       'Second completeTransaction in same request should not null membership B end_date'
-    );
-    $this->assertEquals(
-      $endDateBeforeB,
-      $membershipBAfter['end_date'],
-      'Second completeTransaction should preserve membership B end_date (not extend per-installment)'
     );
   }
 


### PR DESCRIPTION
## Overview
When GoCardless sends a webhook containing multiple payment confirmation events (e.g. two members' installments confirmed at the same time), only the first membership's end date was being updated. The rest were left unchanged, causing the membership status job to set them back to Grace. This fix ensures all memberships in a batched webhook have their end dates updated correctly.

## Before
- Multi-event GoCardless webhook: only the first payment's membership end date updates; subsequent ones remain stuck with the old end date
- After the initial fix attempt (first commit): none of the membership end dates update at all (regression)

## After
- All memberships in a multi-event webhook have their end dates updated correctly, regardless of how many payment events are batched together

## Technical Details
**Root cause:** The `static $contributionID` in `membershipextras_civicrm_pre()` persists across sequential `completeTransaction` API calls within a single PHP request. The second payment's Membership edit receives a stale `$contributionID` from the first payment's Contribution edit, incorrectly triggering `preventExtendingPaymentPlanMembership()` which unsets the `end_date`.

**Fix:** A `civi.api.prepare` listener (`ContributionCompleteTransactionAPI`) sets a `resetContributionID` flag before each `Contribution.completetransaction` API call. In `membershipextras_civicrm_pre()`, the Membership edit block checks this flag and resets `$contributionID = NULL` before creating the `MembershipEdit` instance — ensuring each `completeTransaction` call starts with clean state.

**Note on commit history:** The first commit added `editedFromCompleteTransactionContext()` which caused the regression (flag set once, never cleared → all end_date updates blocked). The second commit replaces this with the `resetContributionID` mechanism.

### Core overrides
No core overrides.

## Comments
Testing should follow the multi-event GoCardless webhook scenario Rita documented in IESSPRT-293: multiple payment confirmations processed in one webhook batch, verifying all membership end dates update correctly. Single-payment webhooks and manual payment recording should also be verified as unaffected.