### PR TITLE
FOSFA-474: Refresh Group Cache In Renewal Process

### DIFF
--- a/CRM/MembershipExtras/Service/AutoUpgradableMembershipChecker.php
+++ b/CRM/MembershipExtras/Service/AutoUpgradableMembershipChecker.php
@@ -14,8 +14,16 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipChecker {
 
   private $membershipUpgradeRules;
 
+  /**
+   * In-memory snapshot of contacts belonging to each filter group.
+   *
+   * @var array
+   */
+  private array $filterGroupMembers = [];
+
   public function __construct() {
     $this->membershipUpgradeRules = $this->getMembershipUpgradeRulesSortedByWeightAsc();
+    $this->preloadFilterGroupMembers();
   }
 
   private function getMembershipUpgradeRulesSortedByWeightAsc() {
@@ -30,6 +38,63 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipChecker {
     }
 
     return $membershipUpgradeRulesList;
+  }
+
+  /**
+   * Builds an in-memory snapshot of the contacts that belong to each filter group.
+   *
+   * We have to use raw sql query here instead of api4 as Civi\Api4\GroupContact::get()
+   * only covers regular groups and not smart groups.
+   */
+  private function preloadFilterGroupMembers(): void {
+    $filterGroupIds = [];
+    foreach ($this->membershipUpgradeRules as $rule) {
+      if (!empty($rule['filter_group'])) {
+        $filterGroupIds[(int) $rule['filter_group']] = TRUE;
+      }
+    }
+    $filterGroupIds = array_keys($filterGroupIds);
+
+    if (empty($filterGroupIds)) {
+      return;
+    }
+
+    foreach ($filterGroupIds as $filterGroupId) {
+      $this->filterGroupMembers[$filterGroupId] = [];
+
+      $group = new CRM_Contact_DAO_Group();
+      $group->id = $filterGroupId;
+      if (!$group->find(TRUE)) {
+        continue;
+      }
+
+      if (!empty($group->saved_search_id) || !empty($group->children)) {
+        try {
+          CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($filterGroupId);
+          CRM_Contact_BAO_GroupContactCache::load($group);
+        }
+        catch (\Throwable $e) {
+          // If the rebuild fails (e.g. another process holds the lock) we fall through and read whatever rows
+          // are currently in the cache table. That preserves the previous behaviour rather than aborting the
+          // whole renewal process.
+          Civi::log()->error('Group cache reload failed for group id ' . $filterGroupId . ' with error: ' . $e->getMessage());
+        }
+      }
+
+      $query = "
+        SELECT contact_id FROM civicrm_group_contact
+         WHERE group_id = %1 AND status = 'Added'
+        UNION
+        SELECT contact_id FROM civicrm_group_contact_cache
+         WHERE group_id = %1
+      ";
+      $result = CRM_Core_DAO::executeQuery($query, [
+        1 => [$filterGroupId, 'Integer'],
+      ]);
+      while ($result->fetch()) {
+        $this->filterGroupMembers[$filterGroupId][(int) $result->contact_id] = TRUE;
+      }
+    }
   }
 
   /**
@@ -87,7 +152,7 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipChecker {
       }
 
       if (!empty($membershipUpgradeRule['filter_group'])) {
-        $isInFilterGroup = $this->checkIfMemberInFilterGroup($membership['contact_id'], $membershipUpgradeRule['filter_group']);
+        $isInFilterGroup = $this->checkIfMemberInFilterGroup((int) $membership['contact_id'], (int) $membershipUpgradeRule['filter_group']);
         if (!$isInFilterGroup) {
           continue;
         }
@@ -109,21 +174,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipChecker {
    *
    * @return bool
    */
-  private function checkIfMemberInFilterGroup($contactId, $filterGroupId) {
-    // smart group contacts are stored in civicrm_group_contact_cache table
-    // which has no API, so we are forced to use an SQL query here.
-    $query = "SELECT id FROM civicrm_group_contact WHERE contact_id = %1 AND group_id = %2 UNION 
-                  SELECT id FROM civicrm_group_contact_cache WHERE contact_id = %1 AND group_id = %2";
-    $result = CRM_Core_DAO::executeQuery($query, [
-      1 => [$contactId, 'Integer'],
-      2 => [$filterGroupId, 'Integer'],
-    ]);
-
-    if (!$result->fetch()) {
-      return FALSE;
-    }
-
-    return TRUE;
+  private function checkIfMemberInFilterGroup(int $contactId, int $filterGroupId): bool {
+    return isset($this->filterGroupMembers[$filterGroupId][$contactId]);
   }
 
 }

--- a/tests/phpunit/CRM/MembershipExtras/Service/AutoUpgradableMembershipCheckerTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/AutoUpgradableMembershipCheckerTest.php
@@ -85,8 +85,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'start_date' => date('Y-m-d', strtotime('-1 year')),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertEquals($this->testYearlyToMembershipType['id'], $upgradeMembershipTypeId);
   }
 
@@ -107,8 +107,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'start_date' => date('Y-m-d', strtotime('-1 month')),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertEquals($this->testMonthlyToMembershipType['id'], $upgradeMembershipTypeId);
   }
 
@@ -136,8 +136,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'start_date' => date('Y-m-d', strtotime('-1 year')),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertEquals($this->testYearlyToMembershipType['id'], $upgradeMembershipTypeId);
   }
 
@@ -161,8 +161,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'start_date' => date('Y-m-d', strtotime('-1 year')),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertNull($upgradeMembershipTypeId);
   }
 
@@ -183,8 +183,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'start_date' => date('Y-m-d', strtotime('-1 year')),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertNull($upgradeMembershipTypeId);
   }
 
@@ -206,8 +206,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'end_date' => date('Y-m-d'),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertNull($upgradeMembershipTypeId);
   }
 
@@ -229,8 +229,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'end_date' => date('Y-m-d'),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertNull($upgradeMembershipTypeId);
   }
 
@@ -252,8 +252,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'end_date' => date('Y-m-d'),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertNull($upgradeMembershipTypeId);
   }
 
@@ -275,8 +275,8 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'end_date' => date('Y-m-d'),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertNull($upgradeMembershipTypeId);
   }
 
@@ -306,8 +306,263 @@ class CRM_MembershipExtras_Service_AutoUpgradableMembershipCheckerTest extends B
       'start_date' => date('Y-m-d', strtotime('-1 year')),
     ]);
 
-    $AutoUpgradeService = new AutoUpgradeService();
-    $upgradeMembershipTypeId = $AutoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $this->assertEquals($this->testYearlyToMembershipType['id'], $upgradeMembershipTypeId);
+  }
+
+  public function testThatRemovedContactFromRegularFilterGroupIsExcluded() {
+    $filterGroup = GroupFabricator::fabricate();
+
+    civicrm_api3('GroupContact', 'create', [
+      'group_id' => $filterGroup['id'],
+      'contact_id' => $this->testContactId,
+    ]);
+    civicrm_api3('GroupContact', 'create', [
+      'group_id' => $filterGroup['id'],
+      'contact_id' => $this->testContactId,
+      'status' => 'Removed',
+    ]);
+
+    AutoMembershipUpgradeRuleFabricator::fabricate([
+      'label' => 'removed status test',
+      'from_membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'to_membership_type_id' => $this->testYearlyToMembershipType['id'],
+      'upgrade_trigger_date_type' => TriggerDateType::MEMBER_START,
+      'period_length' => 1,
+      'period_length_unit' => PeriodUnit::YEARS,
+      'filter_group' => $filterGroup['id'],
+    ]);
+
+    $testMembership = MembershipFabricator::fabricate([
+      'contact_id' => $this->testContactId,
+      'membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'join_date' => date('Y-m-d', strtotime('-1 year')),
+      'start_date' => date('Y-m-d', strtotime('-1 year')),
+    ]);
+
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $this->assertNull($upgradeMembershipTypeId);
+  }
+
+  public function testThatFilterGroupSnapshotIsTakenAtConstructionTime() {
+    $filterGroup = GroupFabricator::fabricate();
+
+    civicrm_api3('GroupContact', 'create', [
+      'group_id' => $filterGroup['id'],
+      'contact_id' => $this->testContactId,
+    ]);
+
+    AutoMembershipUpgradeRuleFabricator::fabricate([
+      'label' => 'snapshot test',
+      'from_membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'to_membership_type_id' => $this->testYearlyToMembershipType['id'],
+      'upgrade_trigger_date_type' => TriggerDateType::MEMBER_START,
+      'period_length' => 1,
+      'period_length_unit' => PeriodUnit::YEARS,
+      'filter_group' => $filterGroup['id'],
+    ]);
+
+    $testMembership = MembershipFabricator::fabricate([
+      'contact_id' => $this->testContactId,
+      'membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'join_date' => date('Y-m-d', strtotime('-1 year')),
+      'start_date' => date('Y-m-d', strtotime('-1 year')),
+    ]);
+
+    $autoUpgradeService = new AutoUpgradeService();
+
+    civicrm_api3('GroupContact', 'create', [
+      'group_id' => $filterGroup['id'],
+      'contact_id' => $this->testContactId,
+      'status' => 'Removed',
+    ]);
+
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $this->assertEquals($this->testYearlyToMembershipType['id'], $upgradeMembershipTypeId);
+  }
+
+  public function testThatDeletedFilterGroupDoesNotCauseFailure() {
+    $filterGroup = GroupFabricator::fabricate();
+    $orphanedGroupId = $filterGroup['id'];
+
+    $rule = AutoMembershipUpgradeRuleFabricator::fabricate([
+      'label' => 'deleted group test',
+      'from_membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'to_membership_type_id' => $this->testYearlyToMembershipType['id'],
+      'upgrade_trigger_date_type' => TriggerDateType::MEMBER_START,
+      'period_length' => 1,
+      'period_length_unit' => PeriodUnit::YEARS,
+      'filter_group' => $orphanedGroupId,
+    ]);
+
+    civicrm_api3('Group', 'delete', ['id' => $orphanedGroupId]);
+
+    try {
+      CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 0');
+      CRM_Core_DAO::executeQuery(
+        'UPDATE membershipextras_auto_membership_upgrade_rule
+            SET filter_group = %1
+          WHERE id = %2',
+        [
+          1 => [$orphanedGroupId, 'Integer'],
+          2 => [$rule['id'], 'Integer'],
+        ]
+      );
+    }
+    finally {
+      CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 1');
+    }
+
+    $testMembership = MembershipFabricator::fabricate([
+      'contact_id' => $this->testContactId,
+      'membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'join_date' => date('Y-m-d', strtotime('-1 year')),
+      'start_date' => date('Y-m-d', strtotime('-1 year')),
+    ]);
+
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $this->assertNull($upgradeMembershipTypeId);
+  }
+
+  public function testThatMultipleDistinctFilterGroupsAreAllPreloaded() {
+    $filterGroupA = GroupFabricator::fabricate(['title' => 'Filter Group A']);
+    $filterGroupB = GroupFabricator::fabricate(['title' => 'Filter Group B']);
+
+    civicrm_api3('GroupContact', 'create', [
+      'group_id' => $filterGroupB['id'],
+      'contact_id' => $this->testContactId,
+    ]);
+
+    AutoMembershipUpgradeRuleFabricator::fabricate([
+      'label' => 'group A rule',
+      'from_membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'to_membership_type_id' => $this->testMonthlyToMembershipType['id'],
+      'upgrade_trigger_date_type' => TriggerDateType::MEMBER_START,
+      'period_length' => 1,
+      'period_length_unit' => PeriodUnit::YEARS,
+      'filter_group' => $filterGroupA['id'],
+      'weight' => 1,
+    ]);
+
+    AutoMembershipUpgradeRuleFabricator::fabricate([
+      'label' => 'group B rule',
+      'from_membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'to_membership_type_id' => $this->testYearlyToMembershipType['id'],
+      'upgrade_trigger_date_type' => TriggerDateType::MEMBER_START,
+      'period_length' => 1,
+      'period_length_unit' => PeriodUnit::YEARS,
+      'filter_group' => $filterGroupB['id'],
+      'weight' => 2,
+    ]);
+
+    $testMembership = MembershipFabricator::fabricate([
+      'contact_id' => $this->testContactId,
+      'membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'join_date' => date('Y-m-d', strtotime('-1 year')),
+      'start_date' => date('Y-m-d', strtotime('-1 year')),
+    ]);
+
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $this->assertEquals($this->testYearlyToMembershipType['id'], $upgradeMembershipTypeId);
+  }
+
+  public function testThatRulesWithoutFilterGroupStillUpgrade() {
+    AutoMembershipUpgradeRuleFabricator::fabricate([
+      'label' => 'no filter group',
+      'from_membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'to_membership_type_id' => $this->testYearlyToMembershipType['id'],
+      'upgrade_trigger_date_type' => TriggerDateType::MEMBER_START,
+      'period_length' => 1,
+      'period_length_unit' => PeriodUnit::YEARS,
+    ]);
+
+    $testMembership = MembershipFabricator::fabricate([
+      'contact_id' => $this->testContactId,
+      'membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'join_date' => date('Y-m-d', strtotime('-1 year')),
+      'start_date' => date('Y-m-d', strtotime('-1 year')),
+    ]);
+
+    $autoUpgradeService = new AutoUpgradeService();
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
+    $this->assertEquals($this->testYearlyToMembershipType['id'], $upgradeMembershipTypeId);
+  }
+
+  public function testThatSmartGroupCacheIsRebuiltDuringPreload() {
+    $uniqueSource = 'autoupgrade_test_' . uniqid();
+    civicrm_api3('Contact', 'create', [
+      'id' => $this->testContactId,
+      'source' => $uniqueSource,
+    ]);
+
+    $savedSearch = civicrm_api3('SavedSearch', 'create', [
+      'form_values' => [
+        ['contact_type', '=', 'Individual', 0, 0],
+        ['sort_name', 'LIKE', '%', 0, 1],
+        ['source', '=', $uniqueSource, 0, 0],
+      ],
+    ]);
+
+    $smartGroup = civicrm_api3('Group', 'create', [
+      'title' => 'Smart Filter Group ' . $uniqueSource,
+      'saved_search_id' => $savedSearch['id'],
+      'is_active' => 1,
+    ]);
+    $smartGroupId = $smartGroup['id'];
+
+    CRM_Core_DAO::executeQuery(
+      "DELETE FROM civicrm_group_contact_cache WHERE group_id = %1",
+      [1 => [$smartGroupId, 'Integer']]
+    );
+    CRM_Core_DAO::executeQuery(
+      "UPDATE civicrm_group SET cache_date = NULL WHERE id = %1",
+      [1 => [$smartGroupId, 'Integer']]
+    );
+
+    // Sanity check: the cache really is empty before construction.
+    $rowsBefore = CRM_Core_DAO::singleValueQuery(
+      "SELECT COUNT(*) FROM civicrm_group_contact_cache WHERE group_id = %1",
+      [1 => [$smartGroupId, 'Integer']]
+    );
+    $this->assertEquals(0, (int) $rowsBefore);
+
+    AutoMembershipUpgradeRuleFabricator::fabricate([
+      'label' => 'smart group rebuild test',
+      'from_membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'to_membership_type_id' => $this->testYearlyToMembershipType['id'],
+      'upgrade_trigger_date_type' => TriggerDateType::MEMBER_START,
+      'period_length' => 1,
+      'period_length_unit' => PeriodUnit::YEARS,
+      'filter_group' => $smartGroupId,
+    ]);
+
+    $testMembership = MembershipFabricator::fabricate([
+      'contact_id' => $this->testContactId,
+      'membership_type_id' => $this->testYearlyFromMembershipType['id'],
+      'join_date' => date('Y-m-d', strtotime('-1 year')),
+      'start_date' => date('Y-m-d', strtotime('-1 year')),
+    ]);
+
+    $autoUpgradeService = new AutoUpgradeService();
+
+    $rowsAfter = CRM_Core_DAO::singleValueQuery(
+      "SELECT COUNT(*) FROM civicrm_group_contact_cache WHERE group_id = %1 AND contact_id = %2",
+      [
+        1 => [$smartGroupId, 'Integer'],
+        2 => [$this->testContactId, 'Integer'],
+      ]
+    );
+    $this->assertGreaterThan(
+      0,
+      (int) $rowsAfter,
+      'Smart group cache should be rebuilt for the test contact during checker construction.'
+    );
+
+    $upgradeMembershipTypeId = $autoUpgradeService->calculateMembershipTypeToUpgradeTo($testMembership['id']);
     $this->assertEquals($this->testYearlyToMembershipType['id'], $upgradeMembershipTypeId);
   }
 


### PR DESCRIPTION
## Overview

The offline auto-renewal job was silently skipping the membership-type switch for some contacts, even when an active `AutoMembershipUpgradeRule` should have applied. The root cause was that `AutoUpgradableMembershipChecker` read directly from `civicrm_group_contact_cache` without ensuring the cache was populated, making correctness dependent on CiviCRM's smart-group cache hygiene (the `Job.group_rebuild` / `Job.group_cache_flush` schedule, `smartGroupCacheTimeout`, `smart_group_cache_refresh_mode`, recent DB restores, etc.).

This PR makes the checker self-sufficient by snapshotting filter-group membership in PHP memory once per renewal run, after force-refreshing each smart group's cache. The renewal logic is no longer at the mercy of unrelated scheduled jobs or operational events.

## Before

`checkIfMemberInFilterGroup()` ran a raw SQL UNION against `civicrm_group_contact` and `civicrm_group_contact_cache` for every contact, every rule:

- It assumed the smart group cache was already current. On the live site (deterministic refresh mode, 60-min `smartGroupCacheTimeout`, daily `Job.group_rebuild`, missing `Job.group_cache_flush`, recent DB restore from backup), the cache was empty or stale at the moment the renewal job ran. Contacts the saved search now matches were not in the cache yet → filter check returned FALSE → upgrade silently skipped.
- It did not filter `civicrm_group_contact.status`, so contacts who had been explicitly removed from a regular group (rows with `status = 'Removed'`) were still counted as members — a separate correctness bug in the opposite direction.
- It re-issued the UNION query for every (contact, filter group) pair across the renewal loop, with no guarantee of cache freshness.

## After

- Filter-group membership is captured once, at the start of the renewal run, into an in-memory map: `[filterGroupId => [contactId => TRUE]]`.
- For each smart group referenced by an active rule, the cache is **invalidated and force-rebuilt** immediately before being read, so the snapshot always reflects the current state of the underlying saved search.
- Regular-group reads are filtered by `status = 'Added'`, correctly excluding contacts who were removed.
- `checkIfMemberInFilterGroup()` is now an O(1) `isset()` lookup against the snapshot — no SQL per check, no dependency on the live state of `civicrm_group_contact_cache` during the renewal loop.
- Filter groups that have been deleted (rule still references the orphaned id) no longer crash the renewal — they are treated as empty so the rule is effectively skipped for everyone.
- The cost is bounded by the number of **distinct** filter groups across active rules — typically a handful — and the rebuild happens once per checker instance, not once per contact.

## Technical Details

### Files changed

- `CRM/MembershipExtras/Service/AutoUpgradableMembershipChecker.php`
- `tests/phpunit/CRM/MembershipExtras/Service/AutoUpgradableMembershipCheckerTest.php`

A new private property `$filterGroupMembers` holds the snapshot. A new private method `preloadFilterGroupMembers()` is invoked from the constructor, immediately after the rules are loaded:

1. Collect distinct, non-empty `filter_group` ids from the active rules.
2. For each filter group:
   - Load the `CRM_Contact_DAO_Group`. If `find(TRUE)` returns FALSE (deleted group), record an empty entry and continue.
   - If the group has a `saved_search_id` or `children`, call `CRM_Contact_BAO_GroupContactCache::invalidateGroupContactCache($groupId)` then `::load($group)` to force a fresh rebuild. Wrapped in try/catch so a transient lock or rebuild error does not abort the entire renewal.
   - Store contact ids into `$filterGroupMembers[$groupId]` as a hash.

`checkIfMemberInFilterGroup($contactId, $filterGroupId)` is reduced to:

```php
return isset($this->filterGroupMembers[(int) $filterGroupId][(int) $contactId]);
```