### PR TITLE
LCCSPRT-108: Add hook to declare custom fields excluded from auto-renew copying

### DIFF
--- a/CRM/MembershipExtras/Hook/CustomDispatch/AutoRenewExcludedCustomFields.php
+++ b/CRM/MembershipExtras/Hook/CustomDispatch/AutoRenewExcludedCustomFields.php
@@ -1,0 +1,38 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Class CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields
+ *
+ * Lets other extensions declare custom field IDs that must never be copied
+ * from the previous contribution onto the renewed contribution during offline
+ * auto-renewal. Listeners append their field IDs to $event->customFieldIds.
+ */
+class CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields {
+
+  const NAME = 'me.autorenew.excluded_custom_fields';
+
+  /**
+   * Custom field IDs to exclude from auto-renew copying.
+   *
+   * @var array
+   */
+  private array $customFieldIds;
+
+  /**
+   * @param array $customFieldIds
+   */
+  public function __construct(array &$customFieldIds) {
+    $this->customFieldIds =& $customFieldIds;
+  }
+
+  /**
+   * Dispatches the event.
+   */
+  public function dispatch() {
+    $event = GenericHookEvent::create(['customFieldIds' => &$this->customFieldIds]);
+    Civi::dispatcher()->dispatch(self::NAME, $event);
+  }
+
+}

--- a/CRM/MembershipExtras/SettingsManager.php
+++ b/CRM/MembershipExtras/SettingsManager.php
@@ -39,27 +39,22 @@ class CRM_MembershipExtras_SettingsManager {
   }
 
   public static function getCustomFieldsIdsToExcludeForAutoRenew() {
-    $customGroupsIdsToExcludeForAutoRenew = self::getSettingValue('membershipextras_customgroups_to_exclude_for_autorenew');
-    if (empty($customGroupsIdsToExcludeForAutoRenew)) {
-      return [];
-    }
-
-    $customFieldsToExcludeForAutoRenew = civicrm_api3('CustomField', 'get', [
-      'return' => ['id'],
-      'sequential' => 1,
-      'custom_group_id' => ['IN' => $customGroupsIdsToExcludeForAutoRenew],
-      'options' => ['limit' => 0],
-    ]);
-    if (empty($customFieldsToExcludeForAutoRenew['values'])) {
-      return [];
-    }
-
     $customFieldsIdsToExcludeForAutoRenew = [];
-    foreach ($customFieldsToExcludeForAutoRenew['values'] as $customField) {
-      $customFieldsIdsToExcludeForAutoRenew[] = $customField['id'];
+
+    $customGroupsIdsToExcludeForAutoRenew = self::getSettingValue('membershipextras_customgroups_to_exclude_for_autorenew');
+    if (!empty($customGroupsIdsToExcludeForAutoRenew)) {
+      $customFieldsToExcludeForAutoRenew = \Civi\Api4\CustomField::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('custom_group_id', 'IN', (array) $customGroupsIdsToExcludeForAutoRenew)
+        ->execute();
+      foreach ($customFieldsToExcludeForAutoRenew as $customField) {
+        $customFieldsIdsToExcludeForAutoRenew[] = (int) $customField['id'];
+      }
     }
 
-    return $customFieldsIdsToExcludeForAutoRenew;
+    (new CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields($customFieldsIdsToExcludeForAutoRenew))->dispatch();
+
+    return array_values(array_unique(array_map('intval', $customFieldsIdsToExcludeForAutoRenew)));
   }
 
   /**

--- a/tests/phpunit/CRM/MembershipExtras/Hook/CustomDispatch/AutoRenewExcludedCustomFieldsTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/CustomDispatch/AutoRenewExcludedCustomFieldsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Tests CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew()
+ * for both the existing setting-based exclusion and the new hook-based exclusion.
+ *
+ * @group headless
+ */
+class CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFieldsTest extends BaseHeadlessTest {
+
+  const SETTING_NAME = 'membershipextras_customgroups_to_exclude_for_autorenew';
+
+  private function createCustomGroupWithField($groupName, $fieldName) {
+    $group = \Civi\Api4\CustomGroup::create(FALSE)
+      ->addValue('name', $groupName)
+      ->addValue('title', $groupName)
+      ->addValue('extends', 'Contribution')
+      ->execute()
+      ->first();
+
+    $field = \Civi\Api4\CustomField::create(FALSE)
+      ->addValue('custom_group_id', $group['id'])
+      ->addValue('name', $fieldName)
+      ->addValue('label', $fieldName)
+      ->addValue('html_type', 'Text')
+      ->addValue('data_type', 'String')
+      ->execute()
+      ->first();
+
+    return [(int) $group['id'], (int) $field['id']];
+  }
+
+  public function testReturnsEmptyWhenNothingExcluded() {
+    Civi::settings()->set(self::SETTING_NAME, []);
+
+    $this->assertSame([], CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew());
+  }
+
+  public function testSettingBasedExclusionReturnsGroupFields() {
+    [$groupId, $fieldId] = $this->createCustomGroupWithField('test_exclude_group', 'test_excluded_field');
+    Civi::settings()->set(self::SETTING_NAME, [(string) $groupId]);
+
+    $excluded = array_map('intval', CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew());
+
+    $this->assertContains($fieldId, $excluded);
+  }
+
+  public function testListenersCanAddExcludedCustomFields() {
+    Civi::settings()->set(self::SETTING_NAME, []);
+    $listener = function (GenericHookEvent $event) {
+      $customFieldIds =& $event->customFieldIds;
+      $customFieldIds[] = 99999;
+    };
+    Civi::dispatcher()->addListener(
+      CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME,
+      $listener
+    );
+
+    try {
+      $excluded = CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew();
+    }
+    finally {
+      Civi::dispatcher()->removeListener(
+        CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME,
+        $listener
+      );
+    }
+
+    $this->assertContains(99999, $excluded);
+  }
+
+  public function testSettingAndHookExclusionsAreCombinedAndDeduped() {
+    [$groupId, $fieldId] = $this->createCustomGroupWithField('test_exclude_group2', 'test_excluded_field2');
+    Civi::settings()->set(self::SETTING_NAME, [(string) $groupId]);
+
+    // Listener adds the same field plus a new one.
+    $listener = function (GenericHookEvent $event) use ($fieldId) {
+      $customFieldIds =& $event->customFieldIds;
+      $customFieldIds[] = $fieldId;
+      $customFieldIds[] = 88888;
+    };
+    Civi::dispatcher()->addListener(
+      CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME,
+      $listener
+    );
+
+    try {
+      $excluded = array_map('intval', CRM_MembershipExtras_SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew());
+    }
+    finally {
+      Civi::dispatcher()->removeListener(
+        CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME,
+        $listener
+      );
+    }
+
+    $this->assertContains($fieldId, $excluded);
+    $this->assertContains(88888, $excluded);
+    // The field declared by both the setting and the listener appears once.
+    $this->assertCount(1, array_keys($excluded, $fieldId));
+  }
+
+}

--- a/tests/phpunit/CRM/MembershipExtras/Service/CustomFieldsCopierTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Service/CustomFieldsCopierTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @group headless
+ */
+class CRM_MembershipExtras_Service_CustomFieldsCopierTest extends BaseHeadlessTest {
+
+  public function testExcludedFieldIsNotCopiedWhileOthersAre() {
+    $contactId = civicrm_api3('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Copier',
+      'last_name' => 'Test',
+    ])['id'];
+
+    $groupId = civicrm_api3('CustomGroup', 'create', [
+      'title' => 'Copier Test Group',
+      'extends' => 'Contribution',
+    ])['id'];
+
+    $excludedFieldId = civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => $groupId,
+      'label' => 'Excluded Field',
+      'html_type' => 'Text',
+      'data_type' => 'String',
+    ])['id'];
+
+    $copiedFieldId = civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => $groupId,
+      'label' => 'Copied Field',
+      'html_type' => 'Text',
+      'data_type' => 'String',
+    ])['id'];
+
+    $sourceId = civicrm_api3('Contribution', 'create', [
+      'contact_id' => $contactId,
+      'financial_type_id' => 1,
+      'total_amount' => 10,
+      'contribution_status_id' => 'Completed',
+      'custom_' . $excludedFieldId => 'should-not-copy',
+      'custom_' . $copiedFieldId => 'should-copy',
+    ])['id'];
+
+    $destinationId = civicrm_api3('Contribution', 'create', [
+      'contact_id' => $contactId,
+      'financial_type_id' => 1,
+      'total_amount' => 10,
+      'contribution_status_id' => 'Completed',
+    ])['id'];
+
+    // Exclude only the "excluded" field, via the hook.
+    $listener = function (GenericHookEvent $event) use ($excludedFieldId) {
+      $customFieldIds =& $event->customFieldIds;
+      $customFieldIds[] = (int) $excludedFieldId;
+    };
+    Civi::dispatcher()->addListener(
+      CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME,
+      $listener
+    );
+
+    try {
+      CRM_MembershipExtras_Service_CustomFieldsCopier::copy($sourceId, $destinationId, 'Contribution');
+    }
+    finally {
+      Civi::dispatcher()->removeListener(
+        CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields::NAME,
+        $listener
+      );
+    }
+
+    $destination = civicrm_api3('Contribution', 'getsingle', [
+      'id' => $destinationId,
+      'return' => ['custom_' . $excludedFieldId, 'custom_' . $copiedFieldId],
+    ]);
+
+    $this->assertEmpty(
+      $destination['custom_' . $excludedFieldId] ?? '',
+      'Excluded field must not be copied to the destination contribution'
+    );
+    $this->assertEquals(
+      'should-copy',
+      $destination['custom_' . $copiedFieldId] ?? '',
+      'Non-excluded field should be copied to the destination contribution'
+    );
+  }
+
+}


### PR DESCRIPTION
## Overview

Lets other extensions declare custom fields that must never be carried over to the renewed contribution during membership auto-renewal. Until now this could only be set per-site via an admin setting.

## Before

During offline auto-renewal, MembershipExtras copies the previous contribution's custom field values onto the new contribution. The only way to stop a field being copied was the "custom groups to exclude for auto-renew" admin setting, configured by hand on each site. An extension that owns a transient field (e.g. a "payment in progress" flag) had no way to declare "never copy this", so each site had to be remembered and configured manually.

_No UI change — screenshots N/A._

## After

`SettingsManager::getCustomFieldsIdsToExcludeForAutoRenew()` now also dispatches an event that lets any extension add custom field IDs to the exclusion list. The admin setting still works exactly as before; code-declared exclusions are merged in and de-duplicated.

_No UI change — screenshots N/A._

## Technical Details

- New dispatched event `me.autorenew.excluded_custom_fields` via `CRM_MembershipExtras_Hook_CustomDispatch_AutoRenewExcludedCustomFields`, following the existing `Hook/CustomDispatch` + `GenericHookEvent` pattern (as used by `CalculateMembershipMinimumFee`). Listeners append to `$event->customFieldIds`.
- `getCustomFieldsIdsToExcludeForAutoRenew()` always dispatches the event (even when the admin setting is empty) and returns the merged, de-duplicated list. Previous setting-based behaviour is unchanged.
- No DB migration — resolved at runtime.

Example listener:

```php
Civi::dispatcher()->addListener('me.autorenew.excluded_custom_fields', function ($event) {
  $ids =& $event->customFieldIds;
  $ids[] = 123;
});
```

Tests:
- `AutoRenewExcludedCustomFieldsTest`: empty case, setting-based exclusion (regression on the refactored method), listener-based exclusion, and combined setting + listener with de-duplication.
- `CustomFieldsCopierTest`: end-to-end — an excluded custom field is not copied onto the destination contribution, while a non-excluded field is.

### Core overrides

None.

## Comments

First consumer of this hook (companion PR): compucorp/io.compuco.automateddirectdebit#34, which excludes the External DD Payment Information fields. Context: LCCSPRT-108.
