### PR TITLE
CIVIPLMMSR-731: Block webform end-date extension of memberships with unpaid renewal payment

### DIFF
--- a/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
+++ b/CRM/MembershipExtras/Hook/Pre/MembershipEdit.php
@@ -89,6 +89,10 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
       $this->preventExtendingPaymentPlanMembership();
     }
 
+    if (!$preventMembershipDateExtension && $this->isUnpaidWebformRenewal()) {
+      $this->preventExtendingUnpaidMembership();
+    }
+
     if (!in_array($this->id, self::$extendedMemberships)) {
       $isPaymentPlan = $this->isPaymentPlanBeingRecordedOnForm();
       $isMembershipRenewal = CRM_Utils_Request::retrieve('action', 'String') & CRM_Core_Action::RENEW;
@@ -198,6 +202,115 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEdit {
   public function preventExtendingPaymentPlanMembership() {
     unset($this->params['end_date']);
     $this->preventCreatingRenewalActivity();
+  }
+
+  /**
+   * Prevents extending a membership whose renewal payment is incomplete.
+   *
+   * A webform renewal against an offsite payment processor can save the
+   * membership with a new end date before the payment has completed, and
+   * each duplicate submission extends it by another term. This blocks the
+   * extension while the latest payment linked to the membership is not
+   * Completed.
+   */
+  public function preventExtendingUnpaidMembership() {
+    unset($this->params['end_date']);
+    $this->preventCreatingRenewalActivity();
+  }
+
+  /**
+   * Determines if this edit is a webform-submitted renewal of a one-off
+   * (non payment plan) membership whose payment has not been completed.
+   *
+   * @return bool
+   */
+  private function isUnpaidWebformRenewal() {
+    if (empty($this->id) || empty($this->params['end_date'])) {
+      return FALSE;
+    }
+
+    if (!$this->isWebformSubmissionRequest()) {
+      return FALSE;
+    }
+
+    // Contexts where a payment is being received are allowed to extend.
+    $isPaymentContext = $this->paymentContributionID
+      || $this->isRecordingPayment()
+      || $this->editedFromPaymentAPIContext()
+      || CRM_Utils_Array::value('membership_activity_status', $this->params) === 'Completed';
+    if ($isPaymentContext) {
+      return FALSE;
+    }
+
+    // Payment plan memberships are handled by preventExtendingPaymentPlanMembership.
+    if ($this->getMembershipRecurringContributionID() !== NULL) {
+      return FALSE;
+    }
+
+    if (!$this->isExtendingEndDate()) {
+      return FALSE;
+    }
+
+    return $this->latestLinkedContributionIsUnpaid();
+  }
+
+  /**
+   * Checks if the current request is a Drupal webform submission.
+   *
+   * @return bool
+   */
+  private function isWebformSubmissionRequest() {
+    $formId = CRM_Utils_Array::value('form_id', $_POST, '');
+
+    return is_string($formId)
+      && (strpos($formId, 'webform_client_form') === 0 || strpos($formId, 'webform_submission') === 0);
+  }
+
+  /**
+   * Checks if the parameters move the membership end date forward.
+   *
+   * @return bool
+   */
+  private function isExtendingEndDate() {
+    try {
+      $currentEndDate = civicrm_api3('Membership', 'getvalue', [
+        'return' => 'end_date',
+        'id' => $this->id,
+      ]);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      return FALSE;
+    }
+
+    if (empty($currentEndDate)) {
+      return FALSE;
+    }
+
+    return strtotime($this->params['end_date']) > strtotime($currentEndDate);
+  }
+
+  /**
+   * Checks if the latest contribution linked to the membership is unpaid.
+   *
+   * @return bool
+   */
+  private function latestLinkedContributionIsUnpaid() {
+    $statusId = CRM_Core_DAO::singleValueQuery('
+      SELECT c.contribution_status_id
+      FROM civicrm_membership_payment mp
+      INNER JOIN civicrm_contribution c ON c.id = mp.contribution_id
+      WHERE mp.membership_id = %1
+      ORDER BY mp.contribution_id DESC
+      LIMIT 1
+    ', [1 => [$this->id, 'Integer']]);
+
+    if (empty($statusId)) {
+      return FALSE;
+    }
+
+    $completedStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+
+    return (int) $statusId !== (int) $completedStatusId;
   }
 
   /**

--- a/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
+++ b/tests/phpunit/CRM/MembershipExtras/Hook/Pre/MembershipEditTest.php
@@ -546,4 +546,105 @@ class CRM_MembershipExtras_Hook_Pre_MembershipEditTest extends BaseHeadlessTest 
     $this->assertEquals($originalStartDate, $membershipParams['start_date']);
   }
 
+  /**
+   * Creates a one-off (non payment plan) membership with a linked
+   * contribution in the given status.
+   *
+   * @param string $contributionStatus
+   *
+   * @return array
+   *   The membership record.
+   */
+  private function createOneOffMembershipWithLinkedContribution($contributionStatus) {
+    $membershipType = $this->createMembershipType([
+      'name' => 'One-off Rolling Membership',
+      'period_type' => 'rolling',
+      'minimum_fee' => 50,
+      'duration_interval' => 1,
+      'duration_unit' => 'year',
+    ]);
+
+    $contact = ContactFabricator::fabricate();
+    $membership = MembershipFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'membership_type_id' => $membershipType->membershipType['id'],
+      'join_date' => date('Y-m-d', strtotime('-1 year')),
+      'start_date' => date('Y-m-d', strtotime('-1 year')),
+      'end_date' => date('Y-m-d', strtotime('-1 day')),
+    ]);
+
+    $contribution = ContributionFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'financial_type_id' => 'Member Dues',
+      'total_amount' => 50,
+      'contribution_status_id' => $contributionStatus,
+      'receive_date' => date('Y-m-d'),
+    ]);
+
+    civicrm_api3('MembershipPayment', 'create', [
+      'membership_id' => $membership['id'],
+      'contribution_id' => $contribution['id'],
+    ]);
+
+    return $membership;
+  }
+
+  private function pushWebformSubmissionRequest() {
+    $tmpGlobals = [];
+    $tmpGlobals['_POST']['form_id'] = 'webform_client_form_25';
+    CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
+  }
+
+  public function testWebformRenewalExtensionIsBlockedWhenLatestLinkedContributionIsUnpaid() {
+    $membership = $this->createOneOffMembershipWithLinkedContribution('Pending');
+    $params = ['end_date' => date('Y-m-d', strtotime('+1 year'))];
+
+    $this->pushWebformSubmissionRequest();
+    $hook = new MembershipEditHook($membership['id'], $params, NULL, '');
+    $hook->preProcess();
+    CRM_Utils_GlobalStack::singleton()->pop();
+
+    $this->assertArrayNotHasKey('end_date', $params);
+  }
+
+  public function testWebformRenewalExtensionIsAllowedWhenLatestLinkedContributionIsCompleted() {
+    $membership = $this->createOneOffMembershipWithLinkedContribution('Completed');
+    $newEndDate = date('Y-m-d', strtotime('+1 year'));
+    $params = ['end_date' => $newEndDate];
+
+    $this->pushWebformSubmissionRequest();
+    $hook = new MembershipEditHook($membership['id'], $params, NULL, '');
+    $hook->preProcess();
+    CRM_Utils_GlobalStack::singleton()->pop();
+
+    $this->assertEquals($newEndDate, $params['end_date']);
+  }
+
+  public function testExtensionOutsideWebformRequestIsAllowed() {
+    $membership = $this->createOneOffMembershipWithLinkedContribution('Pending');
+    $newEndDate = date('Y-m-d', strtotime('+1 year'));
+    $params = ['end_date' => $newEndDate];
+
+    $hook = new MembershipEditHook($membership['id'], $params, NULL, '');
+    $hook->preProcess();
+
+    $this->assertEquals($newEndDate, $params['end_date']);
+  }
+
+  public function testWebformExtensionInPaymentCompletionContextIsAllowed() {
+    $membership = $this->createOneOffMembershipWithLinkedContribution('Pending');
+    $newEndDate = date('Y-m-d', strtotime('+1 year'));
+    $params = [
+      'end_date' => $newEndDate,
+      'membership_activity_status' => 'Completed',
+    ];
+
+    $this->pushWebformSubmissionRequest();
+    $hook = new MembershipEditHook($membership['id'], $params, NULL, '');
+    $hook->preProcess();
+    CRM_Utils_GlobalStack::singleton()->pop();
+
+    $this->assertEquals($newEndDate, $params['end_date']);
+  }
+
 }


### PR DESCRIPTION
## Overview
Safety net for CIVIPLMMSR-731: online membership renewals submitted through a webform with an offsite payment processor (Stripe, GoCardless) extend the membership end date before any payment completes, and every duplicate submission adds another unpaid term. This change blocks the end-date extension at the `hook_civicrm_pre` level while the membership's renewal payment is incomplete, protecting all sites immediately while the webform_civicrm fix rides the release cycle.

## Before
A webform renewal submission against an unpaid contribution moves the membership end date forward one term per submission (confirmed 6 years from one £43 payment on woodcraft — see CIVIPLMMSR-731). The existing `preventExtendingPaymentPlanMembership()` guard covers exactly this scenario, but only for payment-plan memberships: `isSupportedPaymentPlanMembership()` returns FALSE when there is no recurring contribution, so one-off webform renewals are never protected.

## After
On a Membership edit, the end-date change is stripped (same mechanism as the payment-plan guard) when **all** of the following hold:

* the request is a Drupal webform submission (`form_id` = `webform_client_form_*` / `webform_submission*`);
* it is not a payment-receiving context (Payment API, record payment, or core's payment-completion path via the `membership_activity_status = Completed` marker);
* the membership is **not** on a payment plan (those keep the existing guard);
* the parameters move the end date forward;
* the membership's latest linked contribution is not Completed.

Legitimate flows are unaffected: payment completions via IPN/webhook arrive in separate requests with no webform `form_id`; same-request completions are exempted by the payment-context checks; staff edits from CiviCRM admin forms are not webform submissions.

## Technical Details
* `CRM/MembershipExtras/Hook/Pre/MembershipEdit.php`: new `isUnpaidWebformRenewal()` decision (called from `preProcess()` when the payment-plan guard did not already fire) plus `preventExtendingUnpaidMembership()`, which reuses the established strip mechanism (`unset end_date` + suppress the renewal activity).
* "Unpaid" is determined from the latest contribution linked via `civicrm_membership_payment`. Note core's `completeOrder` updates the membership **before** saving the contribution as Completed, which is why completion contexts must be exempted explicitly rather than relying on the stored contribution status.
* Four headless tests cover: blocked when the latest linked payment is Pending; allowed when Completed; allowed outside webform requests; allowed in the payment-completion context.

### Core overrides
None.

## Comments
* This is a mitigation/backstop, not the root-cause fix: it cannot block the very first unpaid grant (no linked contribution exists yet at that point). The root-cause fix is in webform_civicrm (https://github.com/compucorp/webform_civicrm/pull/96); together they make the whole class of bug unreachable.
* Full analysis and production evidence on [CIVIPLMMSR-731](https://compucorp.atlassian.net/browse/CIVIPLMMSR-731).
